### PR TITLE
build(gradle): generate shaded flavours from a single source tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,12 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build
         run: ./gradlew :sample:assemble
+      - name: Build shaded flavours
+        run: ./gradlew :compose-shaded:assemble :compose-shaded-compose:assemble
       - name: Test
         run: ./gradlew desktopTest
+      - name: Test shaded flavours
+        run: ./gradlew :compose-shaded:jvmTest :compose-shaded-compose:jvmTest
       - name: Deploy to Sonatype
         if: startsWith(github.ref, 'refs/tags/')
         run: ./gradlew publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,20 @@ Make sure you have
  - JDK 17  
  - A Mac if you're developing Compose for iOS/macOS
 
+### Project layout
+
+`:compose` is the only module with sources — edit them there. The two shaded flavours,
+`:compose-shaded` and `:compose-shaded-compose`, own no `src/` at all: their sources are generated
+from `:compose` at build time by rewriting package names, so a change to `:compose` reaches every
+published flavour on its own. The generation and the shared Kotlin Multiplatform configuration live
+in the `build-logic` convention plugin; what makes each flavour different is the `constraintlayout.*`
+properties in its own `gradle.properties`.
+
+To inspect what a flavour will actually compile:
+
+```shell
+./gradlew :compose-shaded:relocateCommonMain
+```
+
 ### Code guidelines
 To check the code style, run `./gradlew spotlessCheck` and fix the errors before you submit any PR.  

--- a/README.md
+++ b/README.md
@@ -73,13 +73,38 @@ val commonMain by getting {
     dependencies {
         /// Compose 1.11.0+
         implementation("tech.annexflow.compose:constraintlayout-compose-multiplatform:0.8.0")
-        /// Compose 1.11.0+ with different tech.annexflow.constraintlayout.core package
-        implementation("tech.annexflow.compose:constraintlayout-compose-multiplatform:0.8.0-shaded-core")
-        /// Compose 1.11.0+ with different tech.annexflow.constraintlayout package
-        implementation("tech.annexflow.compose:constraintlayout-compose-multiplatform:0.8.0-shaded")
     }
 }
 ```
+
+### Shaded flavours
+
+If the `androidx.constraintlayout` package names clash with something else on your classpath — most
+often the real `androidx.constraintlayout:constraintlayout-compose` on Android — pick a relocated
+flavour instead. All three are built from the same sources and released under the same version.
+
+| Artifact | Packages it ships |
+|---|---|
+| `constraintlayout-compose-multiplatform` | `androidx.constraintlayout.compose` + `androidx.constraintlayout.core` |
+| `constraintlayout-compose-multiplatform-shaded` | `tech.annexflow.constraintlayout.compose` + `tech.annexflow.constraintlayout.core` |
+| `constraintlayout-compose-multiplatform-shaded-compose` | `tech.annexflow.constraintlayout.compose` + `androidx.constraintlayout.core` |
+
+```kotlin
+/// Everything relocated — the flavour to reach for when you hit a clash
+implementation("tech.annexflow.compose:constraintlayout-compose-multiplatform-shaded:0.8.0")
+```
+
+Two caveats:
+
+- `-shaded-compose` relocates only the Compose layer and still ships the solver as
+  `androidx.constraintlayout.core`, so it does **not** resolve a clash with
+  `androidx.constraintlayout:constraintlayout-core`. Use `-shaded` for that.
+- The flavours declare overlapping package names, so exactly one of them belongs on a classpath.
+
+Before 0.8.0 the flavours were published as version suffixes on a single artifact. They are separate
+artifacts now, because a shared artifact id let Gradle's version-conflict resolution silently swap
+one flavour for another: `0.8.0-shaded` becomes `-shaded:0.8.0`, and `0.8.0-shaded-core` — which
+despite its name relocated the Compose layer, not the solver — becomes `-shaded-compose:0.8.0`.
 
 ## Credits
 Thanks to Chris Banes for the initial structure of the project.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,25 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    `kotlin-dsl`
+}
+
+// The plugins are `compileOnly` here and put on the build classpath by the root project, which
+// declares all of them with `apply false`.
+dependencies {
+    compileOnly(libs.gradlePlugin.android)
+    compileOnly(libs.gradlePlugin.compose)
+    compileOnly(libs.gradlePlugin.composeCompiler)
+    compileOnly(libs.gradlePlugin.kotlin)
+    compileOnly(libs.gradlePlugin.mavenPublish)
+}
+
+gradlePlugin {
+    plugins {
+        register("constraintlayoutLibrary") {
+            id = "tech.annexflow.constraintlayout-library"
+            implementationClass = "tech.annexflow.buildlogic.ConstraintLayoutLibraryPlugin"
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,18 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+rootProject.name = "build-logic"
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
@@ -1,0 +1,129 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.buildlogic
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+private const val ANDROID_COMPILE_SDK = 37
+private const val ANDROID_MIN_SDK = 21
+
+/**
+ * Configures one flavour of the ConstraintLayout Compose Multiplatform library. Every published
+ * flavour shares this single definition of targets, source-set hierarchy and dependencies; they
+ * differ only in the [LibraryFlavour] read from the module's own `gradle.properties`.
+ */
+@OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalWasmDsl::class)
+class ConstraintLayoutLibraryPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            listOf(
+                "org.jetbrains.kotlin.multiplatform",
+                "com.android.kotlin.multiplatform.library",
+                "org.jetbrains.compose",
+                "org.jetbrains.kotlin.plugin.compose",
+                "com.vanniktech.maven.publish",
+            ).forEach(pluginManager::apply)
+
+            val flavour = LibraryFlavour.of(this)
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val jvmTarget = JvmTarget.fromTarget(rootProject.extensions.extraProperties.get("jvmTarget") as String)
+
+            extensions.configure<KotlinMultiplatformExtension> {
+                applyDefaultHierarchyTemplate()
+
+                android {
+                    namespace = flavour.androidNamespace
+                    compileSdk = ANDROID_COMPILE_SDK
+                    minSdk = ANDROID_MIN_SDK
+                    compilerOptions { this.jvmTarget.set(jvmTarget) }
+                    withHostTest {}
+                }
+
+                jvm { compilerOptions { this.jvmTarget.set(jvmTarget) } }
+                js { browser() }
+                wasmJs { browser() }
+                macosArm64()
+
+                listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+                    iosTarget.binaries.framework {
+                        baseName = flavour.frameworkBaseName
+                        isStatic = true
+                    }
+                }
+
+                targets.configureEach {
+                    compilations.configureEach {
+                        compileTaskProvider.configure {
+                            compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+                        }
+                    }
+                }
+
+                configureSourceSets(libs)
+
+                if (flavour.shadeRules.isNotEmpty()) {
+                    registerShadedSources(this, flavour.shadeRules)
+                }
+            }
+        }
+    }
+
+    private fun KotlinMultiplatformExtension.configureSourceSets(libs: VersionCatalog) = with(sourceSets) {
+        configureEach {
+            languageSettings { optIn("kotlin.experimental.ExperimentalNativeApi") }
+        }
+
+        val commonMain = getByName("commonMain")
+        commonMain.dependencies {
+            implementation(libs.library("compose-ui"))
+            implementation(libs.library("compose-ui-util"))
+            implementation(libs.library("compose-foundation"))
+            implementation(libs.library("compose-runtime"))
+            implementation(libs.library("annotation"))
+            implementation(libs.library("collection"))
+            implementation("org.jetbrains.kotlin:kotlin-reflect:${libs.version("kotlin")}")
+        }
+
+        // Two extra source sets on top of the default hierarchy: everything that is not Android
+        // (`nonAndroid`) and everything that runs on a JVM, Android included (`jvmCommonMain`).
+        val nonAndroid = create("nonAndroid").apply { dependsOn(commonMain) }
+        val jvmCommonMain = create("jvmCommonMain").apply { dependsOn(commonMain) }
+
+        getByName("jvmMain").apply {
+            dependsOn(jvmCommonMain)
+            dependsOn(nonAndroid)
+        }
+        getByName("androidMain").dependsOn(jvmCommonMain)
+        getByName("nativeMain").dependsOn(nonAndroid)
+        getByName("wasmJsMain").dependsOn(nonAndroid)
+        getByName("jsMain").dependsOn(nonAndroid)
+
+        getByName("commonTest").dependencies {
+            implementation("org.jetbrains.kotlin:kotlin-test:${libs.version("kotlin")}")
+        }
+    }
+}
+
+/**
+ * The `android { }` block of a Kotlin Multiplatform library. Build scripts reach it through a
+ * generated accessor, which does not exist inside a binary plugin; AGP registers the target as an
+ * extension of the Kotlin extension, so look it up by type instead.
+ */
+private fun KotlinMultiplatformExtension.android(configure: KotlinMultiplatformAndroidLibraryTarget.() -> Unit) =
+    (this as ExtensionAware).extensions.configure(configure)
+
+private fun VersionCatalog.library(alias: String) = findLibrary(alias).orElseThrow().get()
+
+private fun VersionCatalog.version(alias: String) = findVersion(alias).orElseThrow().requiredVersion

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/LibraryFlavour.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/LibraryFlavour.kt
@@ -1,0 +1,50 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.buildlogic
+
+import org.gradle.api.Project
+
+/**
+ * One publishable flavour of the ConstraintLayout Compose Multiplatform library, described by the
+ * `constraintlayout.*` properties in the module's own `gradle.properties` — the same place the
+ * `POM_*` properties already live.
+ *
+ * A flavour with empty [shadeRules] compiles its own `src/` tree; that is `:compose`, the single
+ * place where sources are edited. A flavour with non-empty [shadeRules] owns no sources at all: its
+ * whole source tree is generated from `:compose` by rewriting package names, so every published
+ * flavour stays in lockstep with `:compose` without a long-lived branch to merge.
+ */
+internal data class LibraryFlavour(
+    /** Android namespace. Must be unique across every module of the build. */
+    val androidNamespace: String,
+    /** `baseName` of the produced iOS framework. Must be unique across every module of the build. */
+    val frameworkBaseName: String,
+    /** Package prefixes to rewrite while generating sources, e.g. `androidx.foo` -> `tech.annexflow.foo`. */
+    val shadeRules: Map<String, String>,
+) {
+    companion object {
+        fun of(project: Project): LibraryFlavour =
+            LibraryFlavour(
+                androidNamespace = project.requiredProperty("constraintlayout.androidNamespace"),
+                frameworkBaseName = project.requiredProperty("constraintlayout.frameworkBaseName"),
+                shadeRules = parseShadeRules(project.findProperty("constraintlayout.shadeRules") as String?),
+            )
+
+        /** Parses `from=to,from=to`; blank or absent means "not a shaded flavour". */
+        private fun parseShadeRules(raw: String?): Map<String, String> =
+            raw.orEmpty()
+                .split(',')
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .associate { rule ->
+                    val (from, to) = rule.split('=', limit = 2).also {
+                        require(it.size == 2) { "Malformed constraintlayout.shadeRules entry: '$rule', expected 'from=to'" }
+                    }
+                    from.trim() to to.trim()
+                }
+    }
+}
+
+private fun Project.requiredProperty(name: String): String =
+    requireNotNull(findProperty(name) as String?) { "$path is missing the '$name' property in its gradle.properties" }

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ShadedSources.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ShadedSources.kt
@@ -1,0 +1,67 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.buildlogic
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Sync
+import org.gradle.kotlin.dsl.register
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/** Every source set of `:compose` that holds hand-written sources. */
+internal val SHADED_SOURCE_SETS =
+    listOf(
+        "commonMain",
+        "commonTest",
+        "androidMain",
+        "jvmCommonMain",
+        "jvmMain",
+        "nonAndroid",
+        "nativeMain",
+        "jsMain",
+        "wasmJsMain",
+    )
+
+/** Directory the shaded flavours are generated from, relative to the root project. */
+private const val ORIGIN_SOURCE_DIR = "compose/src"
+
+/**
+ * Registers one `relocate<SourceSet>` task per source set, each copying `:compose` sources while
+ * rewriting [rules] both in file contents and in directory names, and wires the generated trees
+ * into [kotlin] as source directories.
+ */
+internal fun Project.registerShadedSources(
+    kotlin: KotlinMultiplatformExtension,
+    rules: Map<String, String>,
+) {
+    val originSrc = rootProject.layout.projectDirectory.dir(ORIGIN_SOURCE_DIR)
+    val generatedRoot = layout.buildDirectory.dir("generated/shaded")
+    val pathRules = rules.map { (from, to) -> from.replace('.', '/') to to.replace('.', '/') }
+
+    SHADED_SOURCE_SETS.forEach { sourceSet ->
+        val relocate =
+            tasks.register<Sync>("relocate${sourceSet.replaceFirstChar(Char::uppercaseChar)}") {
+                group = "shading"
+                description = "Generates the $sourceSet sources by rewriting :compose package names."
+                // The rules only reach Gradle through the closures below, so declare them
+                // explicitly — otherwise a changed rule would not invalidate the generated output.
+                inputs.property("shadeRules", rules)
+
+                from(originSrc.dir("$sourceSet/kotlin")) {
+                    filteringCharset = Charsets.UTF_8.name()
+                    filter { line: String ->
+                        rules.entries.fold(line) { acc, (from, to) -> acc.replace(from, to) }
+                    }
+                    eachFile {
+                        path = pathRules.fold(path) { acc, (from, to) -> acc.replace(from, to) }
+                    }
+                }
+                into(generatedRoot.map { it.dir("$sourceSet/kotlin") })
+                // `eachFile` only renames files; without this the emptied `androidx/**` directories
+                // would survive next to the rewritten ones.
+                includeEmptyDirs = false
+            }
+
+        kotlin.sourceSets.getByName(sourceSet).kotlin.srcDir(relocate)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.multiplatform).apply(false)
     alias(libs.plugins.compose).apply(false)
+    alias(libs.plugins.compose.compiler).apply(false)
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.android.kotlin.library).apply(false)
     alias(libs.plugins.maven.publish)

--- a/compose-shaded-compose/build.gradle.kts
+++ b/compose-shaded-compose/build.gradle.kts
@@ -1,8 +1,8 @@
 // Copyright 2023, Sergei Gagarin and the project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// The only module with sources. The shaded flavours in `:compose-shaded` and
-// `:compose-shaded-compose` generate theirs from this one — see `build-logic`.
+// Sources are generated from `:compose`; this module has no `src/` of its own.
+// Its flavour is described by `constraintlayout.*` in gradle.properties.
 plugins {
     id("tech.annexflow.constraintlayout-library")
 }

--- a/compose-shaded-compose/gradle.properties
+++ b/compose-shaded-compose/gradle.properties
@@ -1,0 +1,7 @@
+POM_ARTIFACT_ID=constraintlayout-compose-multiplatform-shaded-compose
+POM_NAME=Compose ConstraintLayout (compose layer shaded)
+POM_DESCRIPTION=Compose ConstraintLayout with the compose layer relocated to tech.annexflow.constraintlayout.compose, keeping the solver under androidx.constraintlayout.core
+
+constraintlayout.androidNamespace=tech.annexflow.constraintlayout.compose.shaded
+constraintlayout.frameworkBaseName=composeShadedCompose
+constraintlayout.shadeRules=androidx.constraintlayout.compose=tech.annexflow.constraintlayout.compose

--- a/compose-shaded/build.gradle.kts
+++ b/compose-shaded/build.gradle.kts
@@ -1,8 +1,8 @@
 // Copyright 2023, Sergei Gagarin and the project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// The only module with sources. The shaded flavours in `:compose-shaded` and
-// `:compose-shaded-compose` generate theirs from this one — see `build-logic`.
+// Sources are generated from `:compose`; this module has no `src/` of its own.
+// Its flavour is described by `constraintlayout.*` in gradle.properties.
 plugins {
     id("tech.annexflow.constraintlayout-library")
 }

--- a/compose-shaded/gradle.properties
+++ b/compose-shaded/gradle.properties
@@ -1,0 +1,7 @@
+POM_ARTIFACT_ID=constraintlayout-compose-multiplatform-shaded
+POM_NAME=Compose ConstraintLayout (shaded)
+POM_DESCRIPTION=Compose ConstraintLayout with every package relocated to tech.annexflow.constraintlayout
+
+constraintlayout.androidNamespace=tech.annexflow.constraintlayout.compose
+constraintlayout.frameworkBaseName=composeShaded
+constraintlayout.shadeRules=androidx.constraintlayout=tech.annexflow.constraintlayout

--- a/compose/gradle.properties
+++ b/compose/gradle.properties
@@ -1,3 +1,6 @@
 POM_ARTIFACT_ID=constraintlayout-compose-multiplatform
 POM_NAME=Compose ConstraintLayout
 POM_DESCRIPTION=Provides Compose ConstraintLayout for building responsive UIs
+
+constraintlayout.androidNamespace=androidx.constraintlayout.compose
+constraintlayout.frameworkBaseName=compose

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,13 @@ compose-material3 = { module = "org.jetbrains.compose.material3:material3", vers
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-ui-util = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "compose" }
 
+# Plugin artifacts, consumed as `compileOnly` by the `build-logic` convention plugins.
+gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+gradlePlugin-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose" }
+gradlePlugin-composeCompiler = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+gradlePlugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
+
 [plugins]
 
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "constraintlayout-compose-multiplatform"
 pluginManagement {
+    includeBuild("build-logic")
+
     repositories {
         google()
         gradlePluginPortal()
@@ -17,4 +19,9 @@ dependencyResolutionManagement {
 
 include(":sample:androidApp")
 include(":sample:shared")
+
+// The library is published in three flavours. Only `:compose` has sources; the two shaded flavours
+// generate theirs from it at build time — see `build-logic`.
 include(":compose")
+include(":compose-shaded")
+include(":compose-shaded-compose")


### PR DESCRIPTION
The shaded variants lived on two long-lived branches that had to be merged from main over and over. Comparing them against main showed the whole difference is a textual package rename: of every changed line under compose/src, the only ones not explained by the rename were identical-content file moves between source sets.

So generate them instead of storing them. `:compose` stays the only module with sources; `:compose-shaded` and `:compose-shaded-compose` own no src/ at all and have their trees produced by relocate<SourceSet> tasks that rewrite package prefixes in both file contents and directory names. A change to `:compose` now reaches every published flavour on its own.

Binary relocation was not an option: Shadow only rewrites JVM and Android jars, and there is nothing to relocate klibs for js, wasm, native and iOS with.

The three flavours are published as separate artifact ids at one shared version, replacing the version-suffix scheme. A suffix on a shared artifact id let Gradle's version-conflict resolution silently swap one flavour for another in a dependency graph.

The Kotlin Multiplatform configuration the flavours share moves into a build-logic convention plugin; what differs between them is the constraintlayout.* properties in each module's own gradle.properties.

Also corrects the README, which described the -shaded-core flavour as relocating the solver when it relocates the Compose layer and leaves the solver under androidx.constraintlayout.core.