### PR TITLE
build(publish): stage and verify releases before uploading them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,18 +29,13 @@ jobs:
       - name: Build shaded flavours
         run: ./gradlew :compose-shaded:assemble :compose-shaded-compose:assemble
       - name: Test
-        run: ./gradlew desktopTest
+        run: ./gradlew :compose:jvmTest
       - name: Test shaded flavours
         run: ./gradlew :compose-shaded:jvmTest :compose-shaded-compose:jvmTest
-      - name: Deploy to Sonatype
-        if: startsWith(github.ref, 'refs/tags/')
-        run: ./gradlew publish
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
+
+      # Publishing is not here. It lives in release.yml, which a tag triggers directly, so a
+      # release is one job that stages, verifies and uploads rather than a step bolted to the end
+      # of a build job that also runs on every push.
 
       - name: Upload reports
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+# A tag publishes; the dispatch publishes a snapshot. The two share every step but the version and
+# the final Gradle task, so the dispatch is a real rehearsal of the release path rather than a
+# second code path that can rot. Debug the workflow with the dispatch before pushing a tag.
+on:
+  push:
+    tags: [ '*' ]
+  workflow_dispatch:
+
+# No cancel-in-progress: two tags pushed close together must publish one after the other, not race.
+# A cancelled publish can leave a deployment open in the Portal.
+#
+# The group is a constant rather than anything derived from github.ref, because for a tag push
+# github.ref is refs/tags/0.9.0 — unique per tag, so every release would get a group to itself and
+# serialize against nothing. One name for the whole workflow is what actually queues a second
+# release behind the first, and it queues the dispatch rehearsal behind a live release too.
+concurrency:
+  group: release
+
+permissions:
+  contents: read
+
+jobs:
+  # macOS is not a preference. Three of the seven targets are Apple ones and cannot be built
+  # anywhere else, and a Kotlin/Native target that cannot be built is dropped from the root module
+  # rather than failing the build — so a publisher on Linux ships root modules with no iOS and no
+  # macOS, silently. The staging check below is what refuses that if this ever moves.
+  publish:
+    name: Publish
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Resolve the version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tags in this repository are bare versions (0.8.0), but a leading `v` is stripped so
+            # a `v0.9.0` tag releases 0.9.0 rather than a version named after the tag style.
+            version="${GITHUB_REF_NAME#v}"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "version_arg=-PconstraintlayoutVersion=$version" >> "$GITHUB_OUTPUT"
+          else
+            # An empty version_arg leaves build.gradle.kts's own -SNAPSHOT default in force.
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "version_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Staged locally first. This is where a root module missing a platform is caught, which is
+      # the failure the whole design is arranged around and the one a green build will not show.
+      #
+      # The version is passed so the check can confirm that what Gradle actually wrote to disk is
+      # the version being released. Nothing else compares the tag to the staged output, and the gap
+      # is not theoretical — if -PconstraintlayoutVersion ever stopped reaching the modules the
+      # version would stay at build.gradle.kts's -SNAPSHOT default, publishAndReleaseToMavenCentral
+      # would route it to the snapshot repository, release nothing at the Portal and exit 0, and
+      # the tag would report a successful release of nothing. On the dispatch path the argument is
+      # empty, which the script treats as "no version to assert".
+      - name: Stage the release
+        run: |
+          ./gradlew publishAllPublicationsToLocalStagingRepository \
+            ${{ steps.version.outputs.version_arg }}
+          scripts/check-staged-release.sh build/localStaging "${{ steps.version.outputs.version }}"
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
+
+      - name: Publish
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
+        run: |
+          if [ "${{ steps.version.outputs.release }}" = "true" ]; then
+            # Uploads one deployment per flavour and releases each once the Portal has validated it.
+            ./gradlew publishAndReleaseToMavenCentral ${{ steps.version.outputs.version_arg }}
+          else
+            # The plugin routes a -SNAPSHOT version to the snapshot repository and performs no
+            # Portal release, so this is the same path minus the irreversible step.
+            ./gradlew publishAllPublicationsToMavenCentralRepository
+          fi
+
+      - name: Upload the staged release
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staged-release
+          path: build/localStaging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,29 @@ To inspect what a flavour will actually compile:
 
 ### Code guidelines
 To check the code style, run `./gradlew spotlessCheck` and fix the errors before you submit any PR.  
+
+### Releasing
+
+Pushing a tag is the whole release. There is no version to bump first: the version comes from the
+tag, and `build.gradle.kts` defaults to a `-SNAPSHOT` for every other build.
+
+```shell
+git tag 0.9.0 && git push origin 0.9.0
+```
+
+`.github/workflows/release.yml` then stages all three flavours into `build/localStaging`, runs
+`scripts/check-staged-release.sh` over what landed there, and only uploads if that passes. The check
+refuses a release whose root modules are missing targets (which is what a publish from a host
+without Xcode silently produces), whose artifacts are unsigned (the signing tasks skip rather than
+fail when no key is configured), or whose staged version is not the tag.
+
+Run the same path without releasing anything by triggering the workflow manually — `workflow_dispatch`
+publishes a snapshot through every step a tag takes, minus the irreversible one. To stage and check
+locally:
+
+```shell
+./gradlew publishAllPublicationsToLocalStagingRepository && scripts/check-staged-release.sh build/localStaging
+```
+
+Without a signing key that reports every artifact as unsigned and exits non-zero, which is correct —
+it is the same thing the workflow would say if the `GPG_KEY` secret went missing.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,5 +21,9 @@ gradlePlugin {
             id = "tech.annexflow.constraintlayout-library"
             implementationClass = "tech.annexflow.buildlogic.ConstraintLayoutLibraryPlugin"
         }
+        register("constraintlayoutPublish") {
+            id = "tech.annexflow.constraintlayout-publish"
+            implementationClass = "tech.annexflow.buildlogic.ConstraintLayoutPublishPlugin"
+        }
     }
 }

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
@@ -32,7 +32,6 @@ class ConstraintLayoutLibraryPlugin : Plugin<Project> {
                 "com.android.kotlin.multiplatform.library",
                 "org.jetbrains.compose",
                 "org.jetbrains.kotlin.plugin.compose",
-                "com.vanniktech.maven.publish",
             ).forEach(pluginManager::apply)
 
             val flavour = LibraryFlavour.of(this)

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutPublishPlugin.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutPublishPlugin.kt
@@ -1,0 +1,133 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.buildlogic
+
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SourcesJar
+import java.io.File
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Everything about how a library flavour reaches Maven Central: coordinates, POM, signing, and the
+ * local staging repository the release workflow inspects before it uploads anything.
+ *
+ * Separate from [ConstraintLayoutLibraryPlugin] because the two answer different questions — that
+ * one is how a flavour is *built*, this one is how it is *shipped* — and because the sample
+ * modules are built and never shipped.
+ */
+class ConstraintLayoutPublishPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            // The `.base` plugin, not `com.vanniktech.maven.publish`: the non-base one configures
+            // itself from SONATYPE_* / POM_* / RELEASE_SIGNING_ENABLED properties and picks a
+            // platform on its own, which would leave the real configuration split between this
+            // file and two gradle.properties. The base plugin configures nothing until asked, so
+            // what is below is the whole of it.
+            pluginManager.apply("com.vanniktech.maven.publish.base")
+
+            val flavour = LibraryFlavour.of(this)
+
+            extensions.configure<MavenPublishBaseExtension> {
+                // Publishes every Kotlin target plus the shared metadata module.
+                //
+                // An empty javadoc jar, which is all Maven Central requires — it checks that the
+                // file is there, not what is in it. Generating real documentation instead is a
+                // one-word change here, but the plugin attaches the javadoc jar to all eight
+                // publications of a flavour, so it was measured at 91 MB of a 152 MB release
+                // against 61 MB of actual library. Sources are published, and those carry the
+                // KDoc.
+                configure(
+                    KotlinMultiplatform(
+                        javadocJar = JavadocJar.Empty(),
+                        sourcesJar = SourcesJar.Sources(),
+                    ),
+                )
+
+                coordinates(
+                    groupId = project.group as String,
+                    artifactId = flavour.artifactId,
+                    version = project.version as String,
+                )
+
+                pom {
+                    name.set(flavour.pomName)
+                    description.set(flavour.pomDescription)
+                    url.set(PROJECT_URL)
+                    inceptionYear.set("2023")
+                    licenses {
+                        license {
+                            name.set("The Apache Software License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("lavmee")
+                            name.set("Sergei Gagarin")
+                        }
+                    }
+                    scm {
+                        url.set(PROJECT_URL)
+                        connection.set("scm:git:$PROJECT_URL.git")
+                        developerConnection.set("scm:git:$PROJECT_URL.git")
+                    }
+                }
+
+                // Credentials come from the plugin's standard Gradle properties or environment
+                // variables — ORG_GRADLE_PROJECT_mavenCentralUsername / …Password /
+                // …signingInMemoryKey — so nothing secret is committed here.
+                //
+                // signAllPublications() wires the signing plugin up; whether a missing key is
+                // fatal is then Gradle's call, and it turns on the version. For a release version
+                // signing is required, so a tag pushed without the GPG_KEY secret dies at the
+                // first sign task. For a -SNAPSHOT it is not: the sign tasks are SKIPPED and the
+                // build succeeds having produced a complete, entirely unsigned set of artifacts.
+                //
+                // That second case is precisely the workflow_dispatch rehearsal — the run whose
+                // whole job is to tell you the secrets are in place before a tag depends on them.
+                // Which is why `scripts/check-staged-release.sh` counts signatures itself instead
+                // of trusting the build's exit code.
+                publishToMavenCentral()
+                signAllPublications()
+            }
+
+            // A local Maven repository the release workflow publishes to before it publishes to
+            // Central. Publishing here is file copying with no network, so it costs almost
+            // nothing, and it buys the two things a release needs and Maven Central will not tell
+            // you: what the release weighs, and whether each root module actually references every
+            // target.
+            //
+            // The second is the failure this arrangement exists to prevent. Three of the seven
+            // targets are Apple ones, so a publish from a host without Xcode produces root modules
+            // that are structurally valid and missing iOS and macOS — a green build, a successful
+            // upload, and consumers who find out. `scripts/check-staged-release.sh` reads what
+            // lands here and refuses that.
+            //
+            // All three flavours stage into one directory under the root build dir so the script
+            // can check the release as a whole rather than a flavour at a time. Addressed through
+            // `rootDir` rather than the root project's model, which a subproject must not reach
+            // into.
+            extensions.configure<PublishingExtension> {
+                repositories.maven {
+                    name = "localStaging"
+                    url = File(rootDir, "build/localStaging").toURI()
+                }
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * The project's home. Referenced by the POM's url and scm entries, so it is declared once
+         * here rather than repeated three times.
+         */
+        const val PROJECT_URL = "https://github.com/Lavmee/constraintlayout-compose-multiplatform"
+    }
+}

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/LibraryFlavour.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/LibraryFlavour.kt
@@ -7,8 +7,8 @@ import org.gradle.api.Project
 
 /**
  * One publishable flavour of the ConstraintLayout Compose Multiplatform library, described by the
- * `constraintlayout.*` properties in the module's own `gradle.properties` — the same place the
- * `POM_*` properties already live.
+ * `constraintlayout.*` properties in the module's own `gradle.properties` — the only per-flavour
+ * configuration there is, since everything else about a flavour is shared by definition.
  *
  * A flavour with empty [shadeRules] compiles its own `src/` tree; that is `:compose`, the single
  * place where sources are edited. A flavour with non-empty [shadeRules] owns no sources at all: its
@@ -20,6 +20,12 @@ internal data class LibraryFlavour(
     val androidNamespace: String,
     /** `baseName` of the produced iOS framework. Must be unique across every module of the build. */
     val frameworkBaseName: String,
+    /** Maven artifact id. Deliberately not the module name — `:compose` publishes as `constraintlayout-compose-multiplatform`. */
+    val artifactId: String,
+    /** POM `<name>`. */
+    val pomName: String,
+    /** POM `<description>`. The one line a consumer reads to tell the flavours apart. */
+    val pomDescription: String,
     /** Package prefixes to rewrite while generating sources, e.g. `androidx.foo` -> `tech.annexflow.foo`. */
     val shadeRules: Map<String, String>,
 ) {
@@ -28,6 +34,9 @@ internal data class LibraryFlavour(
             LibraryFlavour(
                 androidNamespace = project.requiredProperty("constraintlayout.androidNamespace"),
                 frameworkBaseName = project.requiredProperty("constraintlayout.frameworkBaseName"),
+                artifactId = project.requiredProperty("constraintlayout.artifactId"),
+                pomName = project.requiredProperty("constraintlayout.pomName"),
+                pomDescription = project.requiredProperty("constraintlayout.pomDescription"),
                 shadeRules = parseShadeRules(project.findProperty("constraintlayout.shadeRules") as String?),
             )
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,34 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Declared here, applied by the convention plugins in `build-logic`. `apply false` puts each on
+// the build classpath without applying it to the root project, which is what lets a convention
+// plugin reference it by id.
 plugins {
     alias(libs.plugins.multiplatform).apply(false)
     alias(libs.plugins.compose).apply(false)
     alias(libs.plugins.compose.compiler).apply(false)
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.android.kotlin.library).apply(false)
-    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.maven.publish).apply(false)
 }
+
+group = "tech.annexflow.compose"
+
+// The release workflow passes `-PconstraintlayoutVersion=<tag>`; everything else — a local build, a
+// snapshot publish, CI — takes the default. A distinct property name rather than `-Pversion`, which
+// collides with Gradle's own `project.version` handling and is easy to set by accident.
+//
+// The default is a snapshot on purpose: the publish plugin routes a `-SNAPSHOT` version to the
+// snapshot repository and performs no Portal release, so a publish that somehow runs without the
+// property cannot release anything by accident.
+version = providers.gradleProperty("constraintlayoutVersion").getOrElse("0.9.0-SNAPSHOT")
 
 extra.apply {
     set("jvmTarget", "11")
+}
+
+subprojects {
+    group = rootProject.group
+    version = rootProject.version
 }

--- a/compose-shaded-compose/build.gradle.kts
+++ b/compose-shaded-compose/build.gradle.kts
@@ -5,4 +5,5 @@
 // Its flavour is described by `constraintlayout.*` in gradle.properties.
 plugins {
     id("tech.annexflow.constraintlayout-library")
+    id("tech.annexflow.constraintlayout-publish")
 }

--- a/compose-shaded-compose/gradle.properties
+++ b/compose-shaded-compose/gradle.properties
@@ -1,6 +1,6 @@
-POM_ARTIFACT_ID=constraintlayout-compose-multiplatform-shaded-compose
-POM_NAME=Compose ConstraintLayout (compose layer shaded)
-POM_DESCRIPTION=Compose ConstraintLayout with the compose layer relocated to tech.annexflow.constraintlayout.compose, keeping the solver under androidx.constraintlayout.core
+constraintlayout.artifactId=constraintlayout-compose-multiplatform-shaded-compose
+constraintlayout.pomName=Compose ConstraintLayout (compose layer shaded)
+constraintlayout.pomDescription=Compose ConstraintLayout with the compose layer relocated to tech.annexflow.constraintlayout.compose, keeping the solver under androidx.constraintlayout.core
 
 constraintlayout.androidNamespace=tech.annexflow.constraintlayout.compose.shaded
 constraintlayout.frameworkBaseName=composeShadedCompose

--- a/compose-shaded/build.gradle.kts
+++ b/compose-shaded/build.gradle.kts
@@ -5,4 +5,5 @@
 // Its flavour is described by `constraintlayout.*` in gradle.properties.
 plugins {
     id("tech.annexflow.constraintlayout-library")
+    id("tech.annexflow.constraintlayout-publish")
 }

--- a/compose-shaded/gradle.properties
+++ b/compose-shaded/gradle.properties
@@ -1,6 +1,6 @@
-POM_ARTIFACT_ID=constraintlayout-compose-multiplatform-shaded
-POM_NAME=Compose ConstraintLayout (shaded)
-POM_DESCRIPTION=Compose ConstraintLayout with every package relocated to tech.annexflow.constraintlayout
+constraintlayout.artifactId=constraintlayout-compose-multiplatform-shaded
+constraintlayout.pomName=Compose ConstraintLayout (shaded)
+constraintlayout.pomDescription=Compose ConstraintLayout with every package relocated to tech.annexflow.constraintlayout
 
 constraintlayout.androidNamespace=tech.annexflow.constraintlayout.compose
 constraintlayout.frameworkBaseName=composeShaded

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -5,4 +5,5 @@
 // `:compose-shaded-compose` generate theirs from this one — see `build-logic`.
 plugins {
     id("tech.annexflow.constraintlayout-library")
+    id("tech.annexflow.constraintlayout-publish")
 }

--- a/compose/gradle.properties
+++ b/compose/gradle.properties
@@ -1,6 +1,6 @@
-POM_ARTIFACT_ID=constraintlayout-compose-multiplatform
-POM_NAME=Compose ConstraintLayout
-POM_DESCRIPTION=Provides Compose ConstraintLayout for building responsive UIs
+constraintlayout.artifactId=constraintlayout-compose-multiplatform
+constraintlayout.pomName=Compose ConstraintLayout
+constraintlayout.pomDescription=Provides Compose ConstraintLayout for building responsive UIs
 
 constraintlayout.androidNamespace=androidx.constraintlayout.compose
 constraintlayout.frameworkBaseName=compose

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,25 +18,11 @@ android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 
 # Maven Central
-SONATYPE_HOST=CENTRAL_PORTAL
-SONATYPE_AUTOMATIC_RELEASE=true
-RELEASE_SIGNING_ENABLED=true
-
+#
+# Coordinates, POM and signing live in `build-logic`'s publish convention plugin, not here: the
+# `com.vanniktech.maven.publish.base` plugin reads no SONATYPE_*/POM_*/GROUP/VERSION_NAME
+# properties at all. Only the two timeouts below are still property-driven, because the plugin
+# offers no other way to set them. The upload is ~60 MB across three flavours and the Portal can
+# take a while to validate it, so both are generous.
 SONATYPE_CONNECT_TIMEOUT_SECONDS=600
 SONATYPE_CLOSE_TIMEOUT_SECONDS=1800
-
-GROUP=tech.annexflow.compose
-VERSION_NAME=0.8.0
-
-POM_URL=https://github.com/lavmee/constraintlayout-compose-multiplatform/
-POM_SCM_URL=https://github.com/lavmee/constraintlayout-compose-multiplatform/
-POM_SCM_CONNECTION=scm:git:git://github.com/lavmee/constraintlayout-compose-multiplatform.git
-POM_SCM_DEV_CONNECTION=scm:git:git://github.com/lavmee/constraintlayout-compose-multiplatform.git
-
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
-
-POM_DEVELOPER_ID=lavmee
-POM_DEVELOPER_NAME=Sergei Gagarin
-POM_INCEPTION_YEAR=2023

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,4 +39,4 @@ compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-kotlin-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+maven-publish = { id = "com.vanniktech.maven.publish.base", version.ref = "maven-publish" }

--- a/scripts/check-staged-release.sh
+++ b/scripts/check-staged-release.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Verifies a staged release before anything is uploaded, and reports what it weighs.
+#
+# Four assertions, in order of how badly they fail if skipped:
+#
+#  1. Each flavour's root .module must reference all seven targets. A Kotlin/Native target the
+#     build host cannot build is dropped rather than failing the build, so a publish from a host
+#     without Xcode produces root modules that resolve fine and offer no iOS and no macOS. Nothing
+#     else catches this: the build is green, the upload succeeds, and consumers find out.
+#  2. Eight module directories per flavour must be present — the seven targets plus the root.
+#  3. Every publishable artifact must carry a detached signature. Gradle requires signing for a
+#     release version, so a tag with no key configured fails on its own — but not for a -SNAPSHOT,
+#     where the sign tasks are SKIPPED and the staging build succeeds with zero .asc files. That is
+#     the workflow_dispatch rehearsal, the run whose entire purpose is to prove the secrets work
+#     before a tag depends on them, so it is the one run that must not be allowed to pass while
+#     signing nothing.
+#  4. The staged version must be the version being released, when the caller says what that is.
+#     `-PconstraintlayoutVersion` reaching the modules is assumed everywhere and checked nowhere:
+#     if it ever stopped arriving the version would stay at build.gradle.kts's -SNAPSHOT default,
+#     publishAndReleaseToMavenCentral would route it to the snapshot repository, perform no Portal
+#     release, and exit 0 — a tag reporting a successful release of nothing.
+#
+# The size line exists because Maven Central tracks release size as a three-month average per
+# organisation and begins rate limiting on 2026-10-01. Three flavours of a seven-target library is
+# a large release by that measure, so the number is worth seeing on every run rather than
+# discovering later.
+set -euo pipefail
+
+staging="${1:?usage: check-staged-release.sh <staging-repo-dir> [expected-version]}/tech/annexflow/compose"
+
+# Optional, and empty on the workflow_dispatch path, which stages whatever the build's default
+# version is and is not releasing anything. Absent means both version assertions are skipped.
+version="${2:-}"
+
+[ -d "$staging" ] || { echo "No staged release at $staging" >&2; exit 1; }
+
+flavours="constraintlayout-compose-multiplatform
+constraintlayout-compose-multiplatform-shaded
+constraintlayout-compose-multiplatform-shaded-compose"
+
+targets="android jvm js wasm-js macosarm64 iosarm64 iossimulatorarm64"
+
+status=0
+
+if [ -n "$version" ]; then
+    # A release must never stage a snapshot: the publish plugin silently reroutes a -SNAPSHOT
+    # version to the snapshot repository and performs no Portal release, so this is the difference
+    # between publishing and appearing to publish.
+    case "$version" in
+        *-SNAPSHOT)
+            echo "Refusing to stage a release of snapshot version '$version'." >&2
+            echo "publishAndReleaseToMavenCentral would route this to the snapshot repository," >&2
+            echo "release nothing at the Portal, and exit 0." >&2
+            status=1
+            ;;
+    esac
+fi
+
+for flavour in $flavours; do
+    if [ ! -d "$staging/$flavour" ]; then
+        echo "Flavour '$flavour' was not staged at all: $staging/$flavour" >&2
+        status=1
+        continue
+    fi
+
+    # Gradle lays the staged files out as <group>/<artifact>/<version>/, so the directory existing
+    # is proof that the version the caller asked for is the version that was actually written.
+    if [ -n "$version" ] && [ ! -d "$staging/$flavour/$version" ]; then
+        echo "Nothing staged for version '$version' at $staging/$flavour/$version." >&2
+        echo "Staged versions:" >&2
+        find "$staging/$flavour" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; >&2
+        status=1
+    fi
+
+    # Exactly one, not the first of however many. A -SNAPSHOT publish writes uniquely timestamped
+    # filenames, so a staging directory reused across runs accumulates several root modules and
+    # `head -1` picks between them arbitrarily — the target assertion below then passes or fails on
+    # which one `find` happened to walk into first. Refusing to guess is more honest than guessing.
+    root_modules="$(find "$staging/$flavour" -name "$flavour-*.module" 2>/dev/null | sort || true)"
+    if [ -n "$root_modules" ]; then
+        root_count="$(printf '%s\n' "$root_modules" | wc -l | tr -d ' ')"
+    else
+        root_count=0
+    fi
+    if [ "$root_count" -ne 1 ]; then
+        echo "Expected exactly one root .module under $staging/$flavour, found $root_count:" >&2
+        [ "$root_count" -eq 0 ] || printf '%s\n' "$root_modules" >&2
+        echo "Delete the staging directory and stage again." >&2
+        status=1
+        continue
+    fi
+
+    for target in $targets; do
+        if ! grep -q "\"$flavour-$target\"" "$root_modules"; then
+            echo "Root module does not reference $flavour-$target: $root_modules" >&2
+            status=1
+        fi
+    done
+done
+
+# Eight directories per flavour — the seven targets plus the root — and nothing else under the
+# group. Counted across the whole staging repository rather than per flavour because the three
+# flavours' artifact ids are prefixes of one another, so no per-flavour glob can separate them.
+expected_modules=$(( 8 * $(printf '%s\n' "$flavours" | wc -l | tr -d ' ') ))
+modules="$(find "$staging" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+if [ "$modules" -ne "$expected_modules" ]; then
+    echo "Expected $expected_modules module directories (seven targets plus a root, per flavour), found $modules:" >&2
+    find "$staging" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort >&2
+    status=1
+fi
+
+# Everything Maven Central treats as a publishable artifact needs a sibling detached signature.
+# Every unsigned file is reported rather than just the first, because the cause is almost always
+# "no signing key at all" and seeing one name invites fixing one file.
+unsigned=0
+while IFS= read -r artifact; do
+    if [ ! -f "$artifact.asc" ]; then
+        echo "Unsigned: $artifact" >&2
+        unsigned=$((unsigned + 1))
+    fi
+done < <(
+    find "$staging" -type f \
+        \( -name '*.jar' -o -name '*.klib' -o -name '*.aar' -o -name '*.pom' -o -name '*.module' \) |
+        sort
+)
+if [ "$unsigned" -ne 0 ]; then
+    echo "$unsigned staged artifacts have no detached .asc signature." >&2
+    echo "On a snapshot the signing tasks skip rather than fail, so this is what an unset or" >&2
+    echo "misnamed ORG_GRADLE_PROJECT_signingInMemoryKey looks like from here." >&2
+    status=1
+fi
+
+[ "$status" -eq 0 ] || exit "$status"
+
+# Counted without sha256/sha512, because this staging repository is plain `maven-publish` output
+# and the deployment is not. The publish plugin's `Checksum.DEFAULT` is `[MD5, SHA1]`, so those two
+# extensions are all that reaches Maven Central and the rest never leaves the runner. Since the
+# only reason to print this line is Central's release-size budget, counting files it will never see
+# would defeat it.
+shipped="$(find "$staging" -type f ! -name '*.sha256' ! -name '*.sha512' | wc -l | tr -d ' ')"
+bytes="$(find "$staging" -type f ! -name '*.sha256' ! -name '*.sha512' -exec du -k {} + | awk '{s += $1} END {printf "%.1f", s / 1024}')"
+
+echo "Staged release: ${bytes}M, $shipped files, $modules modules."


### PR DESCRIPTION
Publishing was a step bolted to the end of the CI build job: `./gradlew publish` on a tag, with the version hand-edited into gradle.properties beforehand and nothing between the build and Maven Central.

Two failures were invisible there. Three of the seven targets are Apple ones, and a Kotlin/Native target the host cannot build is dropped rather than failing the build — so a publish from a runner without Xcode ships root modules that resolve fine and offer no iOS and no macOS. And on the snapshot path the signing tasks skip rather than fail when no key is configured, so a missing secret produces a complete, entirely unsigned release that only the Portal objects to, after the upload.

Releases now stage into build/localStaging first, where scripts/check-staged-release.sh asserts that each flavour's root module references all seven targets, that all 24 module directories are present, that every artifact carries a detached signature, and that the staged version is the tag. Only then does anything get uploaded. It also prints what the release weighs, against Central's release-size budget.

The version comes from the tag via -PconstraintlayoutVersion, defaulting to a -SNAPSHOT, so there is no version to bump and commit before tagging — and a publish that somehow runs without it cannot release anything, because the plugin routes a snapshot to the snapshot repository.

Publishing configuration moves out of gradle.properties into a `tech.annexflow.constraintlayout-publish` convention plugin, using the `.base` variant of the publish plugin, which reads no SONATYPE_*/POM_* properties at all. Per-flavour POM data joins the rest of the flavour definition in LibraryFlavour.

Also fixes the CI test step, which invoked a `desktopTest` task that has not existed since the sample modules were split up.