### PR TITLE
fix(core): apply the container minimum size again

### DIFF
--- a/compose/src/commonMain/kotlin/androidx/constraintlayout/core/widgets/ConstraintWidgetContainer.kt
+++ b/compose/src/commonMain/kotlin/androidx/constraintlayout/core/widgets/ConstraintWidgetContainer.kt
@@ -805,26 +805,29 @@ class ConstraintWidgetContainer : WidgetContainer {
                 }
             }
             if (true) {
-                val width = max(mMinWidth, width)
-                if (width > width) {
+                // Named apart from the `width`/`height` properties on purpose: the Java original
+                // reads them back through `getWidth()`/`getHeight()`, so a local of the same name
+                // would shadow the property and reduce both guards below to `x > x`.
+                val minimumWidth = max(mMinWidth, width)
+                if (minimumWidth > width) {
                     if (DEBUG_LAYOUT) {
                         println(
-                            "layout override 2, width from " + width + " vs " + width,
+                            "layout override 2, width from " + width + " vs " + minimumWidth,
                         )
                     }
-                    this.width = width
+                    this.width = minimumWidth
                     mListDimensionBehaviors[DIMENSION_HORIZONTAL] = FIXED
                     wrap_override = true
                     needsSolving = true
                 }
-                val height = max(mMinHeight, height)
-                if (height > height) {
+                val minimumHeight = max(mMinHeight, height)
+                if (minimumHeight > height) {
                     if (DEBUG_LAYOUT) {
                         println(
-                            "layout override 2, height from " + height + " vs " + height,
+                            "layout override 2, height from " + height + " vs " + minimumHeight,
                         )
                     }
-                    this.height = height
+                    this.height = minimumHeight
                     mListDimensionBehaviors[DIMENSION_VERTICAL] = FIXED
                     wrap_override = true
                     needsSolving = true


### PR DESCRIPTION
A defect from the mechanical Java→Kotlin port, found while investigating why `NestedLayout.testNestedLayout` is `@Ignore`d and verified against the AOSP original.

## The defect

`ConstraintWidgetContainer.layout()` clamps the container's own size up to `mMinWidth` / `mMinHeight` once the system is solved. The original reads the current size back through a getter, so the local and the field are distinct values:

```java
int width = Math.max(mMinWidth, getWidth());
if (width > getWidth()) { ... }
```

Translated literally, the Kotlin local shadows the property and the guard collapses to a comparison with itself:

```kotlin
val width = max(mMinWidth, width)
if (width > width) {   // constant false
```

Same for the height branch. Neither minimum has been applied since the port.

There is a second effect. In the original, a firing "override 2" sets `wrap_override`, which suppresses the "override 3" branch below it. With "override 2" dead, "override 3" now runs, compares the minimum-clamped value against `preW`, and can set the width to `preW` — below the very minimum that was meant to be enforced.

Renaming the locals restores both behaviours: the guards compare against the property again, and `if (width > preW)` further down reads the property rather than the shadow, which is what `getWidth()` did in the original.

## Reach and why no test caught it

`Dimension.atLeast(...)` reaches `setMinWidth` through `Dimension.apply`, so this is on the public API path, not dead code.

No test covers it. The suite is ported from upstream, where both spellings agree for as long as the minimum is zero — which is what every existing case uses. A test that pinned this down would be worth adding; this PR does not, to keep the change reviewable against the original.

## Verification

441 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`. `jsTest` is unchanged and still blocked on Kotlin/JS `Float` being a double, as described in #335.

## Related findings, all cleared

Four other suspicious spots were checked against the original and are faithful translations, recorded here so nobody re-opens them:

- `Optimizer.FLAG_RECOMPUTE_BOUNDS` is only ever set to `false`, making the recompute-bounds branch unreachable — but that is true upstream too.
- `HorizontalWidgetRun.computeInsetRatio` compares `dy <= dy` and `dx <= dx`. Upstream assigns `candidateY1 = dy` and `candidateX2 = dx` first; the port inlined them, so the tautology is the original's.
- `GridCore` declares locals named `mSkips` / `mSpans` that shadow the fields. The original does the same with an explicit `this.`, and the Kotlin initialiser reads the property because the local is not yet in scope.
- `>>>` appears once, in `CLElement.hashCode`, and is correctly `ushr`.

No genuine `switch` fallthrough exists in the ported core; the one candidate in `CLParser` is grouped case labels, which `when` expresses with a comma-separated condition.
