### PR TITLE
test(parity): compare the ported solver against upstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Upstream sources vendored verbatim as a comparison oracle — see parity/UPSTREAM.md. Marked so
+# they do not swamp the repository's language statistics or clutter diffs.
+parity/src/oracle/** linguist-vendored

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,10 +16,10 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 # Compile-only, for `:parity`'s vendored upstream sources — they carry @NonNull annotations and are
 # kept byte-identical to upstream, so the annotation has to resolve rather than be stripped.
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
-# Compile-only, for `:parity`'s vendored upstream sources — four of them carry @RestrictTo and the
-# files are kept byte-identical to upstream, so the annotation has to resolve rather than be stripped.
-androidx-annotation-jvm = { module = "androidx.annotation:annotation", version = "1.8.1" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+# Also used compile-only by `:parity`'s vendored upstream sources — four of them carry @RestrictTo
+# and the files are kept byte-identical to upstream, so the annotation has to resolve rather than
+# be stripped.
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 collection = { module = "androidx.collection:collection", version.ref = "collection" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,9 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 # Compile-only, for `:parity`'s vendored upstream sources — they carry @NonNull annotations and are
 # kept byte-identical to upstream, so the annotation has to resolve rather than be stripped.
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
+# Compile-only, for `:parity`'s vendored upstream sources — four of them carry @RestrictTo and the
+# files are kept byte-identical to upstream, so the annotation has to resolve rather than be stripped.
+androidx-annotation-jvm = { module = "androidx.annotation:annotation", version = "1.8.1" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 collection = { module = "androidx.collection:collection", version.ref = "collection" }

--- a/parity/UPSTREAM.md
+++ b/parity/UPSTREAM.md
@@ -1,10 +1,8 @@
-# Vendored upstream parser
+# Vendored upstream core
 
-`src/oracle/java/androidx/constraintlayout/core/parser/` holds ten files copied verbatim from the
-AOSP `androidx/constraintlayout` repository, commit `9abe35da953`, on 2026-08-10:
-
-`CLArray`, `CLContainer`, `CLElement`, `CLKey`, `CLNumber`, `CLObject`, `CLParser`,
-`CLParsingException`, `CLString`, `CLToken`.
+`src/oracle/java/androidx/constraintlayout/core/` holds the whole of `constraintlayout-core` — 138
+files, copied verbatim from the AOSP `androidx/constraintlayout` repository, commit `9abe35da953`,
+on 2026-08-10.
 
 They are the oracle this module compares the port against, so they are never edited — not the
 headers, not the imports, not the formatting. Refreshing them means copying a newer upstream
@@ -14,17 +12,27 @@ changes what "correct" means for every test here.
 To verify they are still pristine against a local AOSP checkout:
 
 ```bash
-diff -r src/oracle/java/androidx/constraintlayout/core/parser \
-        <aosp>/constraintlayout/constraintlayout-core/src/main/java/androidx/constraintlayout/core/parser
+diff -r src/oracle/java/androidx/constraintlayout/core \
+        <aosp>/constraintlayout/constraintlayout-core/src/main/java/androidx/constraintlayout/core
 ```
+
+## Why the whole module rather than a subset
+
+The parser needed ten files. The solver's dependency closure is most of `core`, and a computed
+subset would be fragile: six class names are duplicated across `core` packages — `Barrier`, `Chain`,
+`Guideline`, `GuidelineReference`, `Helper`, `Transition` — so any name-based closure is ambiguous,
+and upstream refactors would move the boundary on every refresh.
+
+`constraintlayout-core` is self-contained: it depends only on `java.*`, `org.jspecify` and
+`androidx.annotation`, the latter two annotation-only. Copying it whole costs nothing in complexity
+and means no future comparison needs further vendoring.
 
 ## Why this module depends on `:compose-shaded`
 
-The vendored files are in package `androidx.constraintlayout.core.parser` — the same package
-`:compose` uses, since the port kept upstream's package names. The two could never share a
-classpath. `:compose-shaded` publishes the identical sources relocated to
-`tech.annexflow.constraintlayout`, so the oracle and the port coexist and can be compared in one
-JVM. Any differential harness on the JVM has to go through the shaded flavour for this reason.
+The vendored files are in package `androidx.constraintlayout.core.*` — the same packages `:compose`
+uses, since the port kept upstream's names. The two could never share a classpath.
+`:compose-shaded` publishes the identical sources relocated to `tech.annexflow.constraintlayout`,
+so the oracle and the port coexist and can be compared in one JVM.
 
 ## Licence
 

--- a/parity/build.gradle.kts
+++ b/parity/build.gradle.kts
@@ -30,6 +30,7 @@ sourceSets {
 
 dependencies {
     "oracleCompileOnly"(libs.jspecify)
+    "oracleCompileOnly"(libs.androidx.annotation.jvm)
     testImplementation(project(":compose-shaded"))
     testImplementation(kotlin("test"))
 }

--- a/parity/build.gradle.kts
+++ b/parity/build.gradle.kts
@@ -30,7 +30,7 @@ sourceSets {
 
 dependencies {
     "oracleCompileOnly"(libs.jspecify)
-    "oracleCompileOnly"(libs.androidx.annotation.jvm)
+    "oracleCompileOnly"(libs.annotation)
     testImplementation(project(":compose-shaded"))
     testImplementation(kotlin("test"))
 }

--- a/parity/src/oracle/java/androidx/constraintlayout/core/ArrayLinkedVariables.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/ArrayLinkedVariables.java
@@ -1,0 +1,707 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core;
+
+import java.util.Arrays;
+
+/**
+ * Store a set of variables and their values in an array-based linked list.
+ *
+ * The general idea is that we want to store a list of variables that need to be ordered,
+ * space efficient, and relatively fast to maintain (add/remove).
+ *
+ * ArrayBackedVariables implements a sparse array, so is rather space efficient, but maintaining
+ * the array sorted is costly,
+ * as we spend quite a bit of time recopying parts of the array on element deletion.
+ *
+ * LinkedVariables implements a standard linked list structure,
+ * and is able to be faster than ArrayBackedVariables
+ * even though it's more costly to set up (pool of objects...),
+ * as the elements removal and maintenance of the structure is a lot more efficient.
+ *
+ * This ArrayLinkedVariables class takes inspiration from both of the above,
+ * and implement a linked list stored in several arrays.
+ * This allows us to be a lot more efficient in terms of setup (no need to deal with pool
+ * of objects...), resetting the structure, and insertion/deletion of elements.
+ */
+public class ArrayLinkedVariables implements ArrayRow.ArrayRowVariables {
+    private static final boolean DEBUG = false;
+
+    static final int NONE = -1;
+    // private static final boolean FULL_NEW_CHECK = false   full validation (debug purposes)
+
+    int mCurrentSize = 0; // current size, accessed by ArrayRow and LinearSystem
+
+    private final ArrayRow mRow; // our owner
+
+    // pointer to the system-wide cache, allowing access to SolverVariables
+    protected final Cache mCache;
+
+    private int mRowSize = 8; // default array size
+
+    private SolverVariable mCandidate = null;
+
+    // mArrayIndices point to indexes in mCache.mIndexedVariables (i.e., the SolverVariables)
+    private int[] mArrayIndices = new int[mRowSize];
+
+    // mArrayNextIndices point to indexes in mArrayIndices
+    private int[] mArrayNextIndices = new int[mRowSize];
+
+    // mArrayValues contain the associated value from mArrayIndices
+    private float[] mArrayValues = new float[mRowSize];
+
+    // mHead point to indexes in mArrayIndices
+    private int mHead = NONE;
+
+    // mLast point to indexes in mArrayIndices
+    //
+    // While mDidFillOnce is not set, mLast is simply incremented
+    // monotonically in order to be sure to traverse the entire array; the idea here is that
+    // when we clear a linked list, we only set the counters to zero without traversing the array
+    // to fill it with NONE values, which would be costly.
+    // But if we do not fill the array with NONE values, we cannot safely simply check if an entry
+    // is set to NONE to know if we can use it or not, as it might contains a previous value...
+    // So, when adding elements, we first ensure with this mechanism of mLast/mDidFillOnce
+    // that we do traverse the array linearly,
+    // avoiding for that first pass the need to check for the value of the item in mArrayIndices.
+    // This does mean that removed elements will leave empty spaces,
+    // but we /then/ set the removed element to NONE,
+    // so that once we did that first traversal filling the array,
+    // we can safely revert to linear traversal
+    // finding an empty spot by checking the values of mArrayIndices
+    // (i.e. finding an item containing NONE).
+    private int mLast = NONE;
+
+    // flag to keep trace if we did a full pass of the array or not, see above description
+    private boolean mDidFillOnce = false;
+    private static float sEpsilon = 0.001f;
+
+    // Example of a basic loop
+    // current or previous point to mArrayIndices
+    //
+    // int current = mHead;
+    // int counter = 0;
+    // while (current != NONE && counter < currentSize) {
+    //  SolverVariable currentVariable = mCache.mIndexedVariables[mArrayIndices[current]];
+    //  float currentValue = mArrayValues[current];
+    //  ...
+    //  current = mArrayNextIndices[current]; counter++;
+    // }
+
+    /**
+     * Constructor
+     *
+     * @param arrayRow the row owning us
+     * @param cache    instances cache
+     */
+    ArrayLinkedVariables(ArrayRow arrayRow, Cache cache) {
+        mRow = arrayRow;
+        mCache = cache;
+        if (DEBUG) {
+            for (int i = 0; i < mArrayIndices.length; i++) {
+                mArrayIndices[i] = NONE;
+            }
+        }
+    }
+
+    /**
+     * Insert a variable with a given value in the linked list
+     *
+     * @param variable the variable to add in the list
+     * @param value    the value of the variable
+     */
+    @Override
+    public final void put(SolverVariable variable, float value) {
+        if (value == 0) {
+            remove(variable, true);
+            return;
+        }
+        // Special casing empty list...
+        if (mHead == NONE) {
+            mHead = 0;
+            mArrayValues[mHead] = value;
+            mArrayIndices[mHead] = variable.id;
+            mArrayNextIndices[mHead] = NONE;
+            variable.usageInRowCount++;
+            variable.addToRow(mRow);
+            mCurrentSize++;
+            if (!mDidFillOnce) {
+                // only increment mLast if we haven't done the first filling pass
+                mLast++;
+                if (mLast >= mArrayIndices.length) {
+                    mDidFillOnce = true;
+                    mLast = mArrayIndices.length - 1;
+                }
+            }
+            return;
+        }
+        int current = mHead;
+        int previous = NONE;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (mArrayIndices[current] == variable.id) {
+                mArrayValues[current] = value;
+                return;
+            }
+            if (mArrayIndices[current] < variable.id) {
+                previous = current;
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+
+        // Not found, we need to insert
+
+        // First, let's find an available spot
+        int availableIndice = mLast + 1; // start from the previous spot
+        if (mDidFillOnce) {
+            // ... but if we traversed the array once, check the last index, which might have been
+            // set by an element removed
+            if (mArrayIndices[mLast] == NONE) {
+                availableIndice = mLast;
+            } else {
+                availableIndice = mArrayIndices.length;
+            }
+        }
+        if (availableIndice >= mArrayIndices.length) {
+            if (mCurrentSize < mArrayIndices.length) {
+                // find an available spot
+                for (int i = 0; i < mArrayIndices.length; i++) {
+                    if (mArrayIndices[i] == NONE) {
+                        availableIndice = i;
+                        break;
+                    }
+                }
+            }
+        }
+        // ... make sure to grow the array as needed
+        if (availableIndice >= mArrayIndices.length) {
+            availableIndice = mArrayIndices.length;
+            mRowSize *= 2;
+            mDidFillOnce = false;
+            mLast = availableIndice - 1;
+            mArrayValues = Arrays.copyOf(mArrayValues, mRowSize);
+            mArrayIndices = Arrays.copyOf(mArrayIndices, mRowSize);
+            mArrayNextIndices = Arrays.copyOf(mArrayNextIndices, mRowSize);
+        }
+
+        // Finally, let's insert the element
+        mArrayIndices[availableIndice] = variable.id;
+        mArrayValues[availableIndice] = value;
+        if (previous != NONE) {
+            mArrayNextIndices[availableIndice] = mArrayNextIndices[previous];
+            mArrayNextIndices[previous] = availableIndice;
+        } else {
+            mArrayNextIndices[availableIndice] = mHead;
+            mHead = availableIndice;
+        }
+        variable.usageInRowCount++;
+        variable.addToRow(mRow);
+        mCurrentSize++;
+        if (!mDidFillOnce) {
+            // only increment mLast if we haven't done the first filling pass
+            mLast++;
+        }
+        if (mCurrentSize >= mArrayIndices.length) {
+            mDidFillOnce = true;
+        }
+        if (mLast >= mArrayIndices.length) {
+            mDidFillOnce = true;
+            mLast = mArrayIndices.length - 1;
+        }
+    }
+
+    /**
+     * Add value to an existing variable
+     *
+     * The code is broadly identical to the put() method, only differing
+     * in in-line deletion, and of course doing an add rather than a put
+     *
+     * @param variable             the variable we want to add
+     * @param value                its value
+     * @param removeFromDefinition if a variable's value becomes zero, it is removed. This parameter
+     *                             is whether the removal is deep now or left shallow until cleanup
+     */
+    @Override
+    public void add(SolverVariable variable, float value, boolean removeFromDefinition) {
+        if (value > -sEpsilon && value < sEpsilon) {
+            return;
+        }
+        // Special casing empty list...
+        if (mHead == NONE) {
+            mHead = 0;
+            mArrayValues[mHead] = value;
+            mArrayIndices[mHead] = variable.id;
+            mArrayNextIndices[mHead] = NONE;
+            variable.usageInRowCount++;
+            variable.addToRow(mRow);
+            mCurrentSize++;
+            if (!mDidFillOnce) {
+                // only increment mLast if we haven't done the first filling pass
+                mLast++;
+                if (mLast >= mArrayIndices.length) {
+                    mDidFillOnce = true;
+                    mLast = mArrayIndices.length - 1;
+                }
+            }
+            return;
+        }
+        int current = mHead;
+        int previous = NONE;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            int idx = mArrayIndices[current];
+            if (idx == variable.id) {
+                float v = mArrayValues[current] + value;
+                if (v > -sEpsilon && v < sEpsilon) {
+                    v = 0;
+                }
+                mArrayValues[current] = v;
+                // Possibly delete immediately
+                if (v == 0) {
+                    if (current == mHead) {
+                        mHead = mArrayNextIndices[current];
+                    } else {
+                        mArrayNextIndices[previous] = mArrayNextIndices[current];
+                    }
+                    if (removeFromDefinition) {
+                        variable.removeFromRow(mRow);
+                    }
+                    if (mDidFillOnce) {
+                        // If we did a full pass already, remember that spot
+                        mLast = current;
+                    }
+                    variable.usageInRowCount--;
+                    mCurrentSize--;
+                }
+                return;
+            }
+            if (mArrayIndices[current] < variable.id) {
+                previous = current;
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+
+        // Not found, we need to insert
+
+        // First, let's find an available spot
+        int availableIndice = mLast + 1; // start from the previous spot
+        if (mDidFillOnce) {
+            // ... but if we traversed the array once, check the last index, which might have been
+            // set by an element removed
+            if (mArrayIndices[mLast] == NONE) {
+                availableIndice = mLast;
+            } else {
+                availableIndice = mArrayIndices.length;
+            }
+        }
+        if (availableIndice >= mArrayIndices.length) {
+            if (mCurrentSize < mArrayIndices.length) {
+                // find an available spot
+                for (int i = 0; i < mArrayIndices.length; i++) {
+                    if (mArrayIndices[i] == NONE) {
+                        availableIndice = i;
+                        break;
+                    }
+                }
+            }
+        }
+        // ... make sure to grow the array as needed
+        if (availableIndice >= mArrayIndices.length) {
+            availableIndice = mArrayIndices.length;
+            mRowSize *= 2;
+            mDidFillOnce = false;
+            mLast = availableIndice - 1;
+            mArrayValues = Arrays.copyOf(mArrayValues, mRowSize);
+            mArrayIndices = Arrays.copyOf(mArrayIndices, mRowSize);
+            mArrayNextIndices = Arrays.copyOf(mArrayNextIndices, mRowSize);
+        }
+
+        // Finally, let's insert the element
+        mArrayIndices[availableIndice] = variable.id;
+        mArrayValues[availableIndice] = value;
+        if (previous != NONE) {
+            mArrayNextIndices[availableIndice] = mArrayNextIndices[previous];
+            mArrayNextIndices[previous] = availableIndice;
+        } else {
+            mArrayNextIndices[availableIndice] = mHead;
+            mHead = availableIndice;
+        }
+        variable.usageInRowCount++;
+        variable.addToRow(mRow);
+        mCurrentSize++;
+        if (!mDidFillOnce) {
+            // only increment mLast if we haven't done the first filling pass
+            mLast++;
+        }
+        if (mLast >= mArrayIndices.length) {
+            mDidFillOnce = true;
+            mLast = mArrayIndices.length - 1;
+        }
+    }
+
+    /**
+     * Update the current list with a new definition
+     *
+     * @param definition           the row containing the definition
+     * @param removeFromDefinition if a variable's value becomes zero, it is removed. This parameter
+     *                             is whether the removal is deep now or left shallow until cleanup
+     */
+    @Override
+    public float use(ArrayRow definition, boolean removeFromDefinition) {
+        float value = get(definition.mVariable);
+        remove(definition.mVariable, removeFromDefinition);
+        ArrayRow.ArrayRowVariables definitionVariables = definition.variables;
+        int definitionSize = definitionVariables.getCurrentSize();
+        for (int i = 0; i < definitionSize; i++) {
+            SolverVariable definitionVariable = definitionVariables.getVariable(i);
+            float definitionValue = definitionVariables.get(definitionVariable);
+            this.add(definitionVariable, definitionValue * value, removeFromDefinition);
+        }
+        return value;
+    }
+
+    /**
+     * Remove a variable from the list
+     *
+     * @param variable             the variable we want to remove
+     * @param removeFromDefinition if a variable's value becomes zero, it is removed. This parameter
+     *                             is whether the removal is deep now or left shallow until cleanup
+     * @return the value of the removed variable
+     */
+    @Override
+    public final float remove(SolverVariable variable, boolean removeFromDefinition) {
+        if (mCandidate == variable) {
+            mCandidate = null;
+        }
+        if (mHead == NONE) {
+            return 0;
+        }
+        int current = mHead;
+        int previous = NONE;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            int idx = mArrayIndices[current];
+            if (idx == variable.id) {
+                if (current == mHead) {
+                    mHead = mArrayNextIndices[current];
+                } else {
+                    mArrayNextIndices[previous] = mArrayNextIndices[current];
+                }
+
+                if (removeFromDefinition) {
+                    variable.removeFromRow(mRow);
+                }
+                variable.usageInRowCount--;
+                mCurrentSize--;
+                mArrayIndices[current] = NONE;
+                if (mDidFillOnce) {
+                    // If we did a full pass already, remember that spot
+                    mLast = current;
+                }
+                return mArrayValues[current];
+            }
+            previous = current;
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return 0;
+    }
+
+    /**
+     * Clear the list of variables
+     */
+    @Override
+    public final void clear() {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            SolverVariable variable = mCache.mIndexedVariables[mArrayIndices[current]];
+            if (variable != null) {
+                variable.removeFromRow(mRow);
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+
+        mHead = NONE;
+        mLast = NONE;
+        mDidFillOnce = false;
+        mCurrentSize = 0;
+    }
+
+    /**
+     * Returns true if the variable is contained in the list
+     *
+     * @param variable the variable we are looking for
+     * @return return true if we found the variable
+     */
+    @Override
+    public boolean contains(SolverVariable variable) {
+        if (mHead == NONE) {
+            return false;
+        }
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (mArrayIndices[current] == variable.id) {
+                return true;
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return false;
+    }
+
+    @Override
+    public int indexOf(SolverVariable variable) {
+        if (mHead == NONE) {
+            return -1;
+        }
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (mArrayIndices[current] == variable.id) {
+                return current;
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return -1;
+    }
+
+
+    /**
+     * Returns true if at least one of the variable is positive
+     *
+     * @return true if at least one of the variable is positive
+     */
+    boolean hasAtLeastOnePositiveVariable() {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (mArrayValues[current] > 0) {
+                return true;
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return false;
+    }
+
+    /**
+     * Invert the values of all the variables in the list
+     */
+    @Override
+    public void invert() {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            mArrayValues[current] *= -1;
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+    }
+
+    /**
+     * Divide the values of all the variables in the list
+     * by the given amount
+     *
+     * @param amount amount to divide by
+     */
+    @Override
+    public void divideByAmount(float amount) {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            mArrayValues[current] /= amount;
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+    }
+
+    public int getHead() {
+        return mHead;
+    }
+
+    @Override
+    public int getCurrentSize() {
+        return mCurrentSize;
+    }
+
+    /**
+     * get Id in mCache.mIndexedVariables given the index
+     */
+    public final int getId(int index) {
+        return mArrayIndices[index];
+    }
+
+    /**
+     * get value in mArrayValues given the index
+     */
+    public final float getValue(int index) {
+        return mArrayValues[index];
+    }
+
+    /**
+     * Get the next index in mArrayIndices given the current one
+     */
+    public final int getNextIndice(int index) {
+        return mArrayNextIndices[index];
+    }
+
+    /**
+     * TODO: check if still needed
+     * Return a pivot candidate
+     *
+     * @return return a variable we can pivot on
+     */
+    SolverVariable getPivotCandidate() {
+        if (mCandidate == null) {
+            // if no candidate is known, let's figure it out
+            int current = mHead;
+            int counter = 0;
+            SolverVariable pivot = null;
+            while (current != NONE && counter < mCurrentSize) {
+                if (mArrayValues[current] < 0) {
+                    // We can return the first negative candidate as in ArrayLinkedVariables
+                    // they are already sorted by id
+
+                    SolverVariable v = mCache.mIndexedVariables[mArrayIndices[current]];
+                    if (pivot == null || pivot.strength < v.strength) {
+                        pivot = v;
+                    }
+                }
+                current = mArrayNextIndices[current];
+                counter++;
+            }
+            return pivot;
+        }
+        return mCandidate;
+    }
+
+    /**
+     * Return a variable from its position in the linked list
+     *
+     * @param index the index of the variable we want to return
+     * @return the variable found, or null
+     */
+    @Override
+    public SolverVariable getVariable(int index) {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (counter == index) {
+                return mCache.mIndexedVariables[mArrayIndices[current]];
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return null;
+    }
+
+    /**
+     * Return the value of a variable from its position in the linked list
+     *
+     * @param index the index of the variable we want to look up
+     * @return the value of the found variable, or 0 if not found
+     */
+    @Override
+    public float getVariableValue(int index) {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (counter == index) {
+                return mArrayValues[current];
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return 0;
+    }
+
+    /**
+     * Return the value of a variable, 0 if not found
+     *
+     * @param v the variable we are looking up
+     * @return the value of the found variable, or 0 if not found
+     */
+    @Override
+    public final float get(SolverVariable v) {
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            if (mArrayIndices[current] == v.id) {
+                return mArrayValues[current];
+            }
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return 0;
+    }
+
+    /**
+     * Show size in bytes
+     *
+     * @return size in bytes
+     */
+    @Override
+    public int sizeInBytes() {
+        int size = 0;
+        size += 3 * (mArrayIndices.length * 4);
+        size += 9 * 4;
+        return size;
+    }
+
+    /**
+     * print out the variables and their values
+     */
+    @Override
+    public void display() {
+        int count = mCurrentSize;
+        System.out.print("{ ");
+        for (int i = 0; i < count; i++) {
+            SolverVariable v = getVariable(i);
+            if (v == null) {
+                continue;
+            }
+            System.out.print(v + " = " + getVariableValue(i) + " ");
+        }
+        System.out.println(" }");
+    }
+
+    /**
+     * Returns a string representation of the list
+     *
+     * @return a string containing a representation of the list
+     */
+    @Override
+    public String toString() {
+        String result = "";
+        int current = mHead;
+        int counter = 0;
+        while (current != NONE && counter < mCurrentSize) {
+            result += " -> ";
+            result += mArrayValues[current] + " : ";
+            result += mCache.mIndexedVariables[mArrayIndices[current]];
+            current = mArrayNextIndices[current];
+            counter++;
+        }
+        return result;
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/ArrayRow.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/ArrayRow.java
@@ -1,0 +1,813 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+import static androidx.constraintlayout.core.SolverVariable.STRENGTH_EQUALITY;
+import static androidx.constraintlayout.core.SolverVariable.STRENGTH_HIGH;
+import static androidx.constraintlayout.core.SolverVariable.STRENGTH_HIGHEST;
+import static androidx.constraintlayout.core.SolverVariable.STRENGTH_LOW;
+import static androidx.constraintlayout.core.SolverVariable.STRENGTH_MEDIUM;
+
+import java.util.ArrayList;
+
+public class ArrayRow implements LinearSystem.Row {
+    private static final boolean DEBUG = false;
+
+    SolverVariable mVariable = null;
+    float mConstantValue = 0;
+    boolean mUsed = false;
+    private static final boolean FULL_NEW_CHECK = false; // full validation (debug purposes)
+
+    ArrayList<SolverVariable> mVariablesToUpdate = new ArrayList<>();
+
+    public ArrayRowVariables variables;
+
+    public interface ArrayRowVariables {
+
+        // @TODO: add description
+        int getCurrentSize();
+
+        // @TODO: add description
+        SolverVariable getVariable(int index);
+
+        // @TODO: add description
+        float getVariableValue(int index);
+
+        // @TODO: add description
+        float get(SolverVariable variable);
+
+        // @TODO: add description
+        int indexOf(SolverVariable variable);
+
+        // @TODO: add description
+        void display();
+
+        // @TODO: add description
+        void clear();
+
+        // @TODO: add description
+        boolean contains(SolverVariable variable);
+
+        // @TODO: add description
+        void put(SolverVariable variable, float value);
+
+        // @TODO: add description
+        int sizeInBytes();
+
+        // @TODO: add description
+        void invert();
+
+        // @TODO: add description
+        float remove(SolverVariable v, boolean removeFromDefinition);
+
+        // @TODO: add description
+        void divideByAmount(float amount);
+
+        // @TODO: add description
+        void add(SolverVariable v, float value, boolean removeFromDefinition);
+
+        // @TODO: add description
+        float use(ArrayRow definition, boolean removeFromDefinition);
+    }
+
+    boolean mIsSimpleDefinition = false;
+
+    public ArrayRow() {
+    }
+
+    public ArrayRow(Cache cache) {
+        variables = new ArrayLinkedVariables(this, cache);
+        //variables = new OptimizedSolverVariableValues(this, cache);
+    }
+
+    boolean hasKeyVariable() {
+        return !(
+                (mVariable == null)
+                        || (mVariable.mType != SolverVariable.Type.UNRESTRICTED
+                        && mConstantValue < 0)
+        );
+    }
+
+    // @TODO: add description
+    @Override
+    public String toString() {
+        return toReadableString();
+    }
+
+    String toReadableString() {
+        String s = "";
+        if (mVariable == null) {
+            s += "0";
+        } else {
+            s += mVariable;
+        }
+        s += " = ";
+        boolean addedVariable = false;
+        if (mConstantValue != 0) {
+            s += mConstantValue;
+            addedVariable = true;
+        }
+        int count = variables.getCurrentSize();
+        for (int i = 0; i < count; i++) {
+            SolverVariable v = variables.getVariable(i);
+            if (v == null) {
+                continue;
+            }
+            float amount = variables.getVariableValue(i);
+            if (amount == 0) {
+                continue;
+            }
+            String name = v.toString();
+            if (!addedVariable) {
+                if (amount < 0) {
+                    s += "- ";
+                    amount *= -1;
+                }
+            } else {
+                if (amount > 0) {
+                    s += " + ";
+                } else {
+                    s += " - ";
+                    amount *= -1;
+                }
+            }
+            if (amount == 1) {
+                s += name;
+            } else {
+                s += amount + " " + name;
+            }
+            addedVariable = true;
+        }
+        if (!addedVariable) {
+            s += "0.0";
+        }
+        if (DEBUG) {
+            variables.display();
+        }
+        return s;
+    }
+
+    // @TODO: add description
+    public void reset() {
+        mVariable = null;
+        variables.clear();
+        mConstantValue = 0;
+        mIsSimpleDefinition = false;
+    }
+
+    boolean hasVariable(SolverVariable v) {
+        return variables.contains(v);
+    }
+
+    ArrayRow createRowDefinition(SolverVariable variable, int value) {
+        this.mVariable = variable;
+        variable.computedValue = value;
+        mConstantValue = value;
+        mIsSimpleDefinition = true;
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowEquals(SolverVariable variable, int value) {
+        if (value < 0) {
+            mConstantValue = -1 * value;
+            variables.put(variable, 1);
+        } else {
+            mConstantValue = value;
+            variables.put(variable, -1);
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowEquals(SolverVariable variableA,
+            SolverVariable variableB,
+            int margin) {
+        boolean inverse = false;
+        if (margin != 0) {
+            int m = margin;
+            if (m < 0) {
+                m = -1 * m;
+                inverse = true;
+            }
+            mConstantValue = m;
+        }
+        if (!inverse) {
+            variables.put(variableA, -1);
+            variables.put(variableB, 1);
+        } else {
+            variables.put(variableA, 1);
+            variables.put(variableB, -1);
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    ArrayRow addSingleError(SolverVariable error, int sign) {
+        variables.put(error, (float) sign);
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowGreaterThan(SolverVariable variableA,
+            SolverVariable variableB, SolverVariable slack,
+            int margin) {
+        boolean inverse = false;
+        if (margin != 0) {
+            int m = margin;
+            if (m < 0) {
+                m = -1 * m;
+                inverse = true;
+            }
+            mConstantValue = m;
+        }
+        if (!inverse) {
+            variables.put(variableA, -1);
+            variables.put(variableB, 1);
+            variables.put(slack, 1);
+        } else {
+            variables.put(variableA, 1);
+            variables.put(variableB, -1);
+            variables.put(slack, -1);
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowGreaterThan(SolverVariable a, int b, SolverVariable slack) {
+        mConstantValue = b;
+        variables.put(a, -1);
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowLowerThan(SolverVariable variableA, SolverVariable variableB,
+            SolverVariable slack, int margin) {
+        boolean inverse = false;
+        if (margin != 0) {
+            int m = margin;
+            if (m < 0) {
+                m = -1 * m;
+                inverse = true;
+            }
+            mConstantValue = m;
+        }
+        if (!inverse) {
+            variables.put(variableA, -1);
+            variables.put(variableB, 1);
+            variables.put(slack, -1);
+        } else {
+            variables.put(variableA, 1);
+            variables.put(variableB, -1);
+            variables.put(slack, 1);
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowEqualMatchDimensions(float currentWeight,
+            float totalWeights, float nextWeight,
+            SolverVariable variableStartA,
+            SolverVariable variableEndA,
+            SolverVariable variableStartB,
+            SolverVariable variableEndB) {
+        mConstantValue = 0;
+        if (totalWeights == 0 || (currentWeight == nextWeight)) {
+            // endA - startA == endB - startB
+            // 0 = startA - endA + endB - startB
+            variables.put(variableStartA, 1);
+            variables.put(variableEndA, -1);
+            variables.put(variableEndB, 1);
+            variables.put(variableStartB, -1);
+        } else {
+            if (currentWeight == 0) {
+                variables.put(variableStartA, 1);
+                variables.put(variableEndA, -1);
+            } else if (nextWeight == 0) {
+                variables.put(variableStartB, 1);
+                variables.put(variableEndB, -1);
+            } else {
+                float cw = currentWeight / totalWeights;
+                float nw = nextWeight / totalWeights;
+                float w = cw / nw;
+
+                // endA - startA == w * (endB - startB)
+                // 0 = startA - endA + w * (endB - startB)
+                variables.put(variableStartA, 1);
+                variables.put(variableEndA, -1);
+                variables.put(variableEndB, w);
+                variables.put(variableStartB, -w);
+            }
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow createRowEqualDimension(float currentWeight,
+            float totalWeights, float nextWeight,
+            SolverVariable variableStartA, int marginStartA,
+            SolverVariable variableEndA, int marginEndA,
+            SolverVariable variableStartB, int marginStartB,
+            SolverVariable variableEndB, int marginEndB) {
+        if (totalWeights == 0 || (currentWeight == nextWeight)) {
+            // endA - startA + marginStartA + marginEndA
+            //      == endB - startB + marginStartB + marginEndB
+            // 0 = startA - endA - marginStartA - marginEndA
+            //      + endB - startB + marginStartB + marginEndB
+            // 0 = (- marginStartA - marginEndA + marginStartB + marginEndB)
+            //      + startA - endA + endB - startB
+            mConstantValue = -marginStartA - marginEndA + marginStartB + marginEndB;
+            variables.put(variableStartA, 1);
+            variables.put(variableEndA, -1);
+            variables.put(variableEndB, 1);
+            variables.put(variableStartB, -1);
+        } else {
+            float cw = currentWeight / totalWeights;
+            float nw = nextWeight / totalWeights;
+            float w = cw / nw;
+            // (endA - startA + marginStartA + marginEndA) =
+            //      w * (endB - startB) + marginStartB + marginEndB;
+            // 0 = (startA - endA - marginStartA - marginEndA)
+            //      + w * (endB - startB) + marginStartB + marginEndB
+            // 0 = (- marginStartA - marginEndA + marginStartB + marginEndB)
+            //      + startA - endA + w * endB - w * startB
+            mConstantValue = -marginStartA - marginEndA + w * marginStartB + w * marginEndB;
+            variables.put(variableStartA, 1);
+            variables.put(variableEndA, -1);
+            variables.put(variableEndB, w);
+            variables.put(variableStartB, -w);
+        }
+        return this;
+    }
+
+    ArrayRow createRowCentering(SolverVariable variableA, SolverVariable variableB,
+            int marginA, float bias, SolverVariable variableC,
+            SolverVariable variableD, int marginB) {
+        if (variableB == variableC) {
+            // centering on the same position
+            // B - A == D - B
+            // 0 = A + D - 2 * B
+            variables.put(variableA, 1);
+            variables.put(variableD, 1);
+            variables.put(variableB, -2);
+            return this;
+        }
+        if (bias == 0.5f) {
+            // don't bother applying the bias, we are centered
+            // A - B = C - D
+            // 0 = A - B - C + D
+            // with margin:
+            // A - B - Ma = C - D - Mb
+            // 0 = A - B - C + D - Ma + Mb
+            variables.put(variableA, 1f);
+            variables.put(variableB, -1f);
+            variables.put(variableC, -1f);
+            variables.put(variableD, 1f);
+            if (marginA > 0 || marginB > 0) {
+                mConstantValue = -marginA + marginB;
+            }
+        } else if (bias <= 0) {
+            // A = B + m
+            variables.put(variableA, -1);
+            variables.put(variableB, 1);
+            mConstantValue = marginA;
+        } else if (bias >= 1) {
+            // D = C - m
+            variables.put(variableD, -1);
+            variables.put(variableC, 1);
+            mConstantValue = -marginB;
+        } else {
+            variables.put(variableA, 1 * (1 - bias));
+            variables.put(variableB, -1 * (1 - bias));
+            variables.put(variableC, -1 * bias);
+            variables.put(variableD, 1 * bias);
+            if (marginA > 0 || marginB > 0) {
+                mConstantValue = -marginA * (1 - bias) + marginB * bias;
+            }
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ArrayRow addError(LinearSystem system, int strength) {
+        variables.put(system.createErrorVariable(strength, "ep"), 1);
+        variables.put(system.createErrorVariable(strength, "em"), -1);
+        return this;
+    }
+
+    ArrayRow createRowDimensionPercent(SolverVariable variableA,
+            SolverVariable variableC, float percent) {
+        variables.put(variableA, -1);
+        variables.put(variableC, percent);
+        return this;
+    }
+
+    /**
+     * Create a constraint to express {@code A = B + (C - D)} * ratio
+     * We use this for ratio, where for example {@code Right = Left + (Bottom - Top) * percent}
+     *
+     * @param variableA variable A
+     * @param variableB variable B
+     * @param variableC variable C
+     * @param variableD variable D
+     * @param ratio     ratio between AB and CD
+     * @return the row
+     */
+    public ArrayRow createRowDimensionRatio(SolverVariable variableA, SolverVariable variableB,
+            SolverVariable variableC, SolverVariable variableD,
+            float ratio) {
+        // A = B + (C - D) * ratio
+        variables.put(variableA, -1);
+        variables.put(variableB, 1);
+        variables.put(variableC, ratio);
+        variables.put(variableD, -ratio);
+        return this;
+    }
+
+    /**
+     * Create a constraint to express At + (Ab-At)/2 = Bt + (Bb-Bt)/2 - angle
+     */
+    public ArrayRow createRowWithAngle(SolverVariable at,
+            SolverVariable ab,
+            SolverVariable bt,
+            SolverVariable bb,
+            float angleComponent) {
+        variables.put(bt, 0.5f);
+        variables.put(bb, 0.5f);
+        variables.put(at, -0.5f);
+        variables.put(ab, -0.5f);
+        mConstantValue = -angleComponent;
+        return this;
+    }
+
+    int sizeInBytes() {
+        int size = 0;
+        if (mVariable != null) {
+            size += 4; // object
+        }
+        size += 4; // constantValue
+        size += 4; // used
+
+        size += variables.sizeInBytes();
+        return size;
+    }
+
+    void ensurePositiveConstant() {
+        // Ensure that if we have a constant it's positive
+        if (mConstantValue < 0) {
+            // If not, simply multiply the equation by -1
+            mConstantValue *= -1;
+            variables.invert();
+        }
+    }
+
+    /**
+     * Pick a subject variable out of the existing ones.
+     * - if a variable is unrestricted
+     * - or if it's a negative new variable (not found elsewhere)
+     * - otherwise we have to add a new additional variable
+     *
+     * @return true if we added an extra variable to the system
+     */
+    boolean chooseSubject(LinearSystem system) {
+        boolean addedExtra = false;
+        SolverVariable pivotCandidate = chooseSubjectInVariables(system);
+        if (pivotCandidate == null) {
+            // need to add extra variable
+            addedExtra = true;
+        } else {
+            pivot(pivotCandidate);
+        }
+        if (variables.getCurrentSize() == 0) {
+            mIsSimpleDefinition = true;
+        }
+        return addedExtra;
+    }
+
+    /**
+     * Pick a subject variable out of the existing ones.
+     * - if a variable is unrestricted
+     * - or if it's a negative new variable (not found elsewhere)
+     * - otherwise we return null
+     *
+     * @return a candidate variable we can pivot on or null if not found
+     */
+    SolverVariable chooseSubjectInVariables(LinearSystem system) {
+        // if unrestricted, pick it
+        // if restricted, needs to be < 0 and new
+        //
+        SolverVariable restrictedCandidate = null;
+        SolverVariable unrestrictedCandidate = null;
+        float unrestrictedCandidateAmount = 0;
+        float restrictedCandidateAmount = 0;
+        boolean unrestrictedCandidateIsNew = false;
+        boolean restrictedCandidateIsNew = false;
+
+        final int currentSize = variables.getCurrentSize();
+        for (int i = 0; i < currentSize; i++) {
+            float amount = variables.getVariableValue(i);
+            SolverVariable variable = variables.getVariable(i);
+            if (variable.mType == SolverVariable.Type.UNRESTRICTED) {
+                if (unrestrictedCandidate == null) {
+                    unrestrictedCandidate = variable;
+                    unrestrictedCandidateAmount = amount;
+                    unrestrictedCandidateIsNew = isNew(variable, system);
+                } else if (unrestrictedCandidateAmount > amount) {
+                    unrestrictedCandidate = variable;
+                    unrestrictedCandidateAmount = amount;
+                    unrestrictedCandidateIsNew = isNew(variable, system);
+                } else if (!unrestrictedCandidateIsNew && isNew(variable, system)) {
+                    unrestrictedCandidate = variable;
+                    unrestrictedCandidateAmount = amount;
+                    unrestrictedCandidateIsNew = true;
+                }
+            } else if (unrestrictedCandidate == null) {
+                if (amount < 0) {
+                    if (restrictedCandidate == null) {
+                        restrictedCandidate = variable;
+                        restrictedCandidateAmount = amount;
+                        restrictedCandidateIsNew = isNew(variable, system);
+                    } else if (restrictedCandidateAmount > amount) {
+                        restrictedCandidate = variable;
+                        restrictedCandidateAmount = amount;
+                        restrictedCandidateIsNew = isNew(variable, system);
+                    } else if (!restrictedCandidateIsNew && isNew(variable, system)) {
+                        restrictedCandidate = variable;
+                        restrictedCandidateAmount = amount;
+                        restrictedCandidateIsNew = true;
+                    }
+                }
+            }
+        }
+
+        if (unrestrictedCandidate != null) {
+            return unrestrictedCandidate;
+        }
+        return restrictedCandidate;
+    }
+
+    /**
+     * Returns true if the variable is new to the system, i.e. is already present
+     * in one of the rows. This function is called while choosing the subject of a new row.
+     *
+     * @param variable the variable to check for
+     * @param system   the linear system we check
+     */
+    private boolean isNew(SolverVariable variable, LinearSystem system) {
+        if (FULL_NEW_CHECK) {
+            boolean isNew = true;
+            for (int i = 0; i < system.mNumRows; i++) {
+                ArrayRow row = system.mRows[i];
+                if (row.hasVariable(variable)) {
+                    isNew = false;
+                }
+            }
+            if (variable.usageInRowCount <= 1 != isNew) {
+                System.out.println("Problem with usage tracking");
+            }
+            return isNew;
+        }
+        // We maintain a usage count -- variables are ref counted if they are present
+        // in the right side of a row or not. If the count is zero or one, the variable
+        // is new (if one, it means it exist in a row, but this is the row we insert)
+        return variable.usageInRowCount <= 1;
+    }
+
+    void pivot(SolverVariable v) {
+        if (mVariable != null) {
+            // first, move back the variable to its column
+            variables.put(mVariable, -1f);
+            mVariable.mDefinitionId = -1;
+            mVariable = null;
+        }
+
+        float amount = variables.remove(v, true) * -1;
+        mVariable = v;
+        if (amount == 1) {
+            return;
+        }
+        mConstantValue = mConstantValue / amount;
+        variables.divideByAmount(amount);
+    }
+
+    // Row compatibility
+
+    @Override
+    public boolean isEmpty() {
+        return (mVariable == null && mConstantValue == 0 && variables.getCurrentSize() == 0);
+    }
+
+    @Override
+    public void updateFromRow(LinearSystem system,
+            ArrayRow definition,
+            boolean removeFromDefinition) {
+        float value = variables.use(definition, removeFromDefinition);
+
+        mConstantValue += definition.mConstantValue * value;
+        if (removeFromDefinition) {
+            definition.mVariable.removeFromRow(this);
+        }
+        if (LinearSystem.SIMPLIFY_SYNONYMS
+                && mVariable != null && variables.getCurrentSize() == 0) {
+            mIsSimpleDefinition = true;
+            system.hasSimpleDefinition = true;
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public void updateFromFinalVariable(LinearSystem system,
+            SolverVariable variable,
+            boolean removeFromDefinition) {
+        if (variable == null || !variable.isFinalValue) {
+            return;
+        }
+        float value = variables.get(variable);
+        mConstantValue += variable.computedValue * value;
+        variables.remove(variable, removeFromDefinition);
+        if (removeFromDefinition) {
+            variable.removeFromRow(this);
+        }
+        if (LinearSystem.SIMPLIFY_SYNONYMS
+                && variables.getCurrentSize() == 0) {
+            mIsSimpleDefinition = true;
+            system.hasSimpleDefinition = true;
+        }
+    }
+
+    // @TODO: add description
+    public void updateFromSynonymVariable(LinearSystem system,
+            SolverVariable variable,
+            boolean removeFromDefinition) {
+        if (variable == null || !variable.mIsSynonym) {
+            return;
+        }
+        float value = variables.get(variable);
+        mConstantValue += variable.mSynonymDelta * value;
+        variables.remove(variable, removeFromDefinition);
+        if (removeFromDefinition) {
+            variable.removeFromRow(this);
+        }
+        variables.add(system.mCache.mIndexedVariables[variable.mSynonym],
+                value, removeFromDefinition);
+        if (LinearSystem.SIMPLIFY_SYNONYMS
+                && variables.getCurrentSize() == 0) {
+            mIsSimpleDefinition = true;
+            system.hasSimpleDefinition = true;
+        }
+    }
+
+    private SolverVariable pickPivotInVariables(boolean[] avoid, SolverVariable exclude) {
+        boolean all = true;
+        float value = 0;
+        SolverVariable pivot = null;
+        SolverVariable pivotSlack = null;
+        float valueSlack = 0;
+
+        final int currentSize = variables.getCurrentSize();
+        for (int i = 0; i < currentSize; i++) {
+            float currentValue = variables.getVariableValue(i);
+            if (currentValue < 0) {
+                // We can return the first negative candidate as in ArrayLinkedVariables
+                // they are already sorted by id
+                SolverVariable v = variables.getVariable(i);
+                if (!((avoid != null && avoid[v.id]) || (v == exclude))) {
+                    if (all) {
+                        if (v.mType == SolverVariable.Type.SLACK
+                                || v.mType == SolverVariable.Type.ERROR) {
+                            if (currentValue < value) {
+                                value = currentValue;
+                                pivot = v;
+                            }
+                        }
+                    } else {
+                        if (v.mType == SolverVariable.Type.SLACK) {
+                            if (currentValue < valueSlack) {
+                                valueSlack = currentValue;
+                                pivotSlack = v;
+                            }
+                        } else if (v.mType == SolverVariable.Type.ERROR) {
+                            if (currentValue < value) {
+                                value = currentValue;
+                                pivot = v;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (all) {
+            return pivot;
+        }
+        return pivot != null ? pivot : pivotSlack;
+    }
+
+    // @TODO: add description
+    public SolverVariable pickPivot(SolverVariable exclude) {
+        return pickPivotInVariables(null, exclude);
+    }
+
+    @Override
+    public SolverVariable getPivotCandidate(LinearSystem system, boolean[] avoid) {
+        return pickPivotInVariables(avoid, null);
+    }
+
+    @Override
+    public void clear() {
+        variables.clear();
+        mVariable = null;
+        mConstantValue = 0;
+    }
+
+    /**
+     * Used to initiate a goal from a given row (to see if we can remove an extra var)
+     */
+    @Override
+    public void initFromRow(@SuppressWarnings("HiddenTypeParameter") LinearSystem.Row row) {
+        if (row instanceof ArrayRow) {
+            ArrayRow copiedRow = (ArrayRow) row;
+            mVariable = null;
+            variables.clear();
+            for (int i = 0; i < copiedRow.variables.getCurrentSize(); i++) {
+                SolverVariable var = copiedRow.variables.getVariable(i);
+                float val = copiedRow.variables.getVariableValue(i);
+                variables.add(var, val, true);
+            }
+        }
+    }
+
+    @Override
+    public void addError(SolverVariable error) {
+        float weight = 1;
+        if (error.strength == STRENGTH_LOW) {
+            weight = 1F;
+        } else if (error.strength == STRENGTH_MEDIUM) {
+            weight = 1E3F;
+        } else if (error.strength == STRENGTH_HIGH) {
+            weight = 1E6F;
+        } else if (error.strength == STRENGTH_HIGHEST) {
+            weight = 1E9F;
+        } else if (error.strength == STRENGTH_EQUALITY) {
+            weight = 1E12F;
+        }
+        variables.put(error, weight);
+    }
+
+    @Override
+    public SolverVariable getKey() {
+        return mVariable;
+    }
+
+    @Override
+    public void updateFromSystem(LinearSystem system) {
+        if (system.mRows.length == 0) {
+            return;
+        }
+
+        boolean done = false;
+        while (!done) {
+            int currentSize = variables.getCurrentSize();
+            for (int i = 0; i < currentSize; i++) {
+                SolverVariable variable = variables.getVariable(i);
+                if (variable.mDefinitionId != -1 || variable.isFinalValue || variable.mIsSynonym) {
+                    mVariablesToUpdate.add(variable);
+                }
+            }
+            final int size = mVariablesToUpdate.size();
+            if (size > 0) {
+                for (int i = 0; i < size; i++) {
+                    SolverVariable variable = mVariablesToUpdate.get(i);
+                    if (variable.isFinalValue) {
+                        updateFromFinalVariable(system, variable, true);
+                    } else if (variable.mIsSynonym) {
+                        updateFromSynonymVariable(system, variable, true);
+                    } else {
+                        updateFromRow(system, system.mRows[variable.mDefinitionId], true);
+                    }
+                }
+                mVariablesToUpdate.clear();
+            } else {
+                done = true;
+            }
+        }
+        if (LinearSystem.SIMPLIFY_SYNONYMS
+                && mVariable != null && variables.getCurrentSize() == 0) {
+            mIsSimpleDefinition = true;
+            system.hasSimpleDefinition = true;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/Cache.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/Cache.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core;
+
+/**
+ * Cache for common objects
+ */
+public class Cache {
+    Pools.Pool<ArrayRow> mOptimizedArrayRowPool = new Pools.SimplePool<>(256);
+    Pools.Pool<ArrayRow> mArrayRowPool = new Pools.SimplePool<>(256);
+    Pools.Pool<SolverVariable> mSolverVariablePool = new Pools.SimplePool<>(256);
+    SolverVariable[] mIndexedVariables = new SolverVariable[32];
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/GoalRow.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/GoalRow.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+public class GoalRow extends ArrayRow {
+
+    public GoalRow(Cache cache) {
+        super(cache);
+    }
+
+    @Override
+    public void addError(SolverVariable error) {
+        super.addError(error);
+        // error variables in the goal shouldn't be tracked (we only care if they are
+        // in the system rows)
+        error.usageInRowCount--;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/LinearSystem.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/LinearSystem.java
@@ -1,0 +1,1542 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+import androidx.constraintlayout.core.widgets.Chain;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Represents and solves a system of linear equations.
+ */
+public class LinearSystem {
+
+    public static final boolean FULL_DEBUG = false;
+    public static final boolean DEBUG = false;
+    private static final boolean DO_NOT_USE = false;
+
+    private static final boolean DEBUG_CONSTRAINTS = FULL_DEBUG;
+
+    public static boolean USE_DEPENDENCY_ORDERING = false;
+    public static boolean USE_BASIC_SYNONYMS = true;
+    public static boolean SIMPLIFY_SYNONYMS = true;
+    public static boolean USE_SYNONYMS = true;
+    public static boolean SKIP_COLUMNS = true;
+    public static boolean OPTIMIZED_ENGINE = false;
+
+    /*
+     * Default size for the object pools
+     */
+    private int mPoolSize = 1000;
+    public boolean hasSimpleDefinition = false;
+
+    /*
+     * Variable counter
+     */
+    int mVariablesID = 0;
+
+    /*
+     * Store a map between name->SolverVariable and SolverVariable->Float for the resolution.
+     */
+    private HashMap<String, SolverVariable> mVariables = null;
+
+    /*
+     * The goal that is used when minimizing the system.
+     */
+    private Row mGoal;
+
+    private int mTableSize = 32; // default table size for the allocation
+    private int mMaxColumns = mTableSize;
+    ArrayRow[] mRows = null;
+
+    // if true, will use graph optimizations
+    public boolean graphOptimizer = false;
+    public boolean newgraphOptimizer = false;
+
+    // Used in optimize()
+    private boolean[] mAlreadyTestedCandidates = new boolean[mTableSize];
+
+    int mNumColumns = 1;
+    int mNumRows = 0;
+    private int mMaxRows = mTableSize;
+
+    final Cache mCache;
+
+    private SolverVariable[] mPoolVariables = new SolverVariable[mPoolSize];
+    private int mPoolVariablesCount = 0;
+
+    public static Metrics sMetrics;
+    private Row mTempGoal;
+
+    static class ValuesRow extends ArrayRow {
+        ValuesRow(Cache cache) {
+            variables = new SolverVariableValues(this, cache);
+        }
+    }
+
+    public LinearSystem() {
+        mRows = new ArrayRow[mTableSize];
+        releaseRows();
+        mCache = new Cache();
+        mGoal = new PriorityGoalRow(mCache);
+        if (OPTIMIZED_ENGINE) {
+            mTempGoal = new ValuesRow(mCache);
+        } else {
+            mTempGoal = new ArrayRow(mCache);
+        }
+    }
+
+    // @TODO: add description
+    public void fillMetrics(Metrics metrics) {
+        sMetrics = metrics;
+    }
+
+    public static Metrics getMetrics() {
+        return sMetrics;
+    }
+
+    interface Row {
+        SolverVariable getPivotCandidate(LinearSystem system, boolean[] avoid);
+
+        void clear();
+
+        void initFromRow(Row row);
+
+        void addError(SolverVariable variable);
+
+        void updateFromSystem(LinearSystem system);
+
+        SolverVariable getKey();
+
+        boolean isEmpty();
+
+        void updateFromRow(LinearSystem system, ArrayRow definition, boolean b);
+
+        void updateFromFinalVariable(LinearSystem system,
+                SolverVariable variable,
+                boolean removeFromDefinition);
+    }
+
+    /*--------------------------------------------------------------------------------------------*/
+    // Memory management
+    /*--------------------------------------------------------------------------------------------*/
+
+    /**
+     * Reallocate memory to accommodate increased amount of variables
+     */
+    private void increaseTableSize() {
+        if (DEBUG) {
+            System.out.println("###########################");
+            System.out.println("### INCREASE TABLE TO " + (mTableSize * 2) + " (num rows: "
+                    + mNumRows + ", num cols: " + mNumColumns + "/" + mMaxColumns + ")");
+            System.out.println("###########################");
+        }
+        mTableSize *= 2;
+        mRows = Arrays.copyOf(mRows, mTableSize);
+        mCache.mIndexedVariables = Arrays.copyOf(mCache.mIndexedVariables, mTableSize);
+        mAlreadyTestedCandidates = new boolean[mTableSize];
+        mMaxColumns = mTableSize;
+        mMaxRows = mTableSize;
+        if (sMetrics != null) {
+            sMetrics.tableSizeIncrease++;
+            sMetrics.maxTableSize = Math.max(sMetrics.maxTableSize, mTableSize);
+            sMetrics.lastTableSize = sMetrics.maxTableSize;
+        }
+    }
+
+    /**
+     * Release ArrayRows back to their pool
+     */
+    private void releaseRows() {
+        if (OPTIMIZED_ENGINE) {
+            for (int i = 0; i < mNumRows; i++) {
+                ArrayRow row = mRows[i];
+                if (row != null) {
+                    mCache.mOptimizedArrayRowPool.release(row);
+                }
+                mRows[i] = null;
+            }
+        } else {
+            for (int i = 0; i < mNumRows; i++) {
+                ArrayRow row = mRows[i];
+                if (row != null) {
+                    mCache.mArrayRowPool.release(row);
+                }
+                mRows[i] = null;
+            }
+        }
+    }
+
+    /**
+     * Reset the LinearSystem object so that it can be reused.
+     */
+    public void reset() {
+        if (DEBUG) {
+            System.out.println("##################");
+            System.out.println("## RESET SYSTEM ##");
+            System.out.println("##################");
+        }
+        for (int i = 0; i < mCache.mIndexedVariables.length; i++) {
+            SolverVariable variable = mCache.mIndexedVariables[i];
+            if (variable != null) {
+                variable.reset();
+            }
+        }
+        mCache.mSolverVariablePool.releaseAll(mPoolVariables, mPoolVariablesCount);
+        mPoolVariablesCount = 0;
+
+        Arrays.fill(mCache.mIndexedVariables, null);
+        if (mVariables != null) {
+            mVariables.clear();
+        }
+        mVariablesID = 0;
+        mGoal.clear();
+        mNumColumns = 1;
+        for (int i = 0; i < mNumRows; i++) {
+            if (mRows[i] != null) {
+                mRows[i].mUsed = false;
+            }
+        }
+        releaseRows();
+        mNumRows = 0;
+        if (OPTIMIZED_ENGINE) {
+            mTempGoal = new ValuesRow(mCache);
+        } else {
+            mTempGoal = new ArrayRow(mCache);
+        }
+    }
+
+    /*--------------------------------------------------------------------------------------------*/
+    // Creation of rows / variables / errors
+    /*--------------------------------------------------------------------------------------------*/
+
+    // @TODO: add description
+    public SolverVariable createObjectVariable(Object anchor) {
+        if (anchor == null) {
+            return null;
+        }
+        if (mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        SolverVariable variable = null;
+        if (anchor instanceof ConstraintAnchor) {
+            variable = ((ConstraintAnchor) anchor).getSolverVariable();
+            if (variable == null) {
+                ((ConstraintAnchor) anchor).resetSolverVariable(mCache);
+                variable = ((ConstraintAnchor) anchor).getSolverVariable();
+            }
+            if (variable.id == -1
+                    || variable.id > mVariablesID
+                    || mCache.mIndexedVariables[variable.id] == null) {
+                if (variable.id != -1) {
+                    variable.reset();
+                }
+                mVariablesID++;
+                mNumColumns++;
+                variable.id = mVariablesID;
+                variable.mType = SolverVariable.Type.UNRESTRICTED;
+                mCache.mIndexedVariables[mVariablesID] = variable;
+            }
+        }
+        return variable;
+    }
+
+    public static long ARRAY_ROW_CREATION = 0;
+    public static long OPTIMIZED_ARRAY_ROW_CREATION = 0;
+
+    // @TODO: add description
+    public ArrayRow createRow() {
+        ArrayRow row;
+        if (OPTIMIZED_ENGINE) {
+            row = mCache.mOptimizedArrayRowPool.acquire();
+            if (row == null) {
+                row = new ValuesRow(mCache);
+                OPTIMIZED_ARRAY_ROW_CREATION++;
+            } else {
+                row.reset();
+            }
+        } else {
+            row = mCache.mArrayRowPool.acquire();
+            if (row == null) {
+                row = new ArrayRow(mCache);
+                ARRAY_ROW_CREATION++;
+            } else {
+                row.reset();
+            }
+        }
+        SolverVariable.increaseErrorId();
+        return row;
+    }
+
+    // @TODO: add description
+    public SolverVariable createSlackVariable() {
+        if (sMetrics != null) {
+            sMetrics.slackvariables++;
+        }
+        if (mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        SolverVariable variable = acquireSolverVariable(SolverVariable.Type.SLACK, null);
+        mVariablesID++;
+        mNumColumns++;
+        variable.id = mVariablesID;
+        mCache.mIndexedVariables[mVariablesID] = variable;
+        return variable;
+    }
+
+    // @TODO: add description
+    public SolverVariable createExtraVariable() {
+        if (sMetrics != null) {
+            sMetrics.extravariables++;
+        }
+        if (mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        SolverVariable variable = acquireSolverVariable(SolverVariable.Type.SLACK, null);
+        mVariablesID++;
+        mNumColumns++;
+        variable.id = mVariablesID;
+        mCache.mIndexedVariables[mVariablesID] = variable;
+        return variable;
+    }
+
+//    private void addError(ArrayRow row)
+//        row.addError(this, SolverVariable.STRENGTH_NONE);
+//
+//
+//    private void addSingleError(ArrayRow row, int sign)
+//        addSingleError(row, sign, SolverVariable.STRENGTH_NONE);
+//
+
+    void addSingleError(ArrayRow row, int sign, int strength) {
+        String prefix = null;
+        if (DEBUG) {
+            if (sign > 0) {
+                prefix = "ep";
+            } else {
+                prefix = "em";
+            }
+            prefix = "em";
+        }
+        SolverVariable error = createErrorVariable(strength, prefix);
+        row.addSingleError(error, sign);
+    }
+
+    private SolverVariable createVariable(String name, SolverVariable.Type type) {
+        if (sMetrics != null) {
+            sMetrics.variables++;
+        }
+        if (mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        SolverVariable variable = acquireSolverVariable(type, null);
+        variable.setName(name);
+        mVariablesID++;
+        mNumColumns++;
+        variable.id = mVariablesID;
+        if (mVariables == null) {
+            mVariables = new HashMap<>();
+        }
+        mVariables.put(name, variable);
+        mCache.mIndexedVariables[mVariablesID] = variable;
+        return variable;
+    }
+
+    // @TODO: add description
+    public SolverVariable createErrorVariable(int strength, String prefix) {
+        if (sMetrics != null) {
+            sMetrics.errors++;
+        }
+        if (mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        SolverVariable variable = acquireSolverVariable(SolverVariable.Type.ERROR, prefix);
+        mVariablesID++;
+        mNumColumns++;
+        variable.id = mVariablesID;
+        variable.strength = strength;
+        mCache.mIndexedVariables[mVariablesID] = variable;
+        mGoal.addError(variable);
+        return variable;
+    }
+
+    /**
+     * Returns a SolverVariable instance of the given type
+     *
+     * @param type type of the SolverVariable
+     * @return instance of SolverVariable
+     */
+    private SolverVariable acquireSolverVariable(SolverVariable.Type type, String prefix) {
+        SolverVariable variable = mCache.mSolverVariablePool.acquire();
+        if (variable == null) {
+            variable = new SolverVariable(type, prefix);
+            variable.setType(type, prefix);
+        } else {
+            variable.reset();
+            variable.setType(type, prefix);
+        }
+        if (mPoolVariablesCount >= mPoolSize) {
+            mPoolSize *= 2;
+            mPoolVariables = Arrays.copyOf(mPoolVariables, mPoolSize);
+        }
+        mPoolVariables[mPoolVariablesCount++] = variable;
+        return variable;
+    }
+
+    /*--------------------------------------------------------------------------------------------*/
+    // Accessors of rows / variables / errors
+    /*--------------------------------------------------------------------------------------------*/
+
+    /**
+     * Simple accessor for the current goal. Used when minimizing the system's goal.
+     *
+     * @return the current goal.
+     */
+    Row getGoal() {
+        return mGoal;
+    }
+
+    ArrayRow getRow(int n) {
+        return mRows[n];
+    }
+
+    float getValueFor(String name) {
+        SolverVariable v = getVariable(name, SolverVariable.Type.UNRESTRICTED);
+        if (v == null) {
+            return 0;
+        }
+        return v.computedValue;
+    }
+
+    // @TODO: add description
+    public int getObjectVariableValue(Object object) {
+        ConstraintAnchor anchor = (ConstraintAnchor) object;
+        if (Chain.USE_CHAIN_OPTIMIZATION) {
+            if (anchor.hasFinalValue()) {
+                return anchor.getFinalValue();
+            }
+        }
+        SolverVariable variable = anchor.getSolverVariable();
+        if (variable != null) {
+            return (int) (variable.computedValue + 0.5f);
+        }
+        return 0;
+    }
+
+    /**
+     * Returns a SolverVariable instance given a name and a type.
+     *
+     * @param name name of the variable
+     * @param type {@link SolverVariable.Type type} of the variable
+     * @return a SolverVariable instance
+     */
+    SolverVariable getVariable(String name, SolverVariable.Type type) {
+        if (mVariables == null) {
+            mVariables = new HashMap<>();
+        }
+        SolverVariable variable = mVariables.get(name);
+        if (variable == null) {
+            variable = createVariable(name, type);
+        }
+        return variable;
+    }
+
+    /*--------------------------------------------------------------------------------------------*/
+    // System resolution
+    /*--------------------------------------------------------------------------------------------*/
+
+    /**
+     * Minimize the current goal of the system.
+     */
+    public void minimize() throws Exception {
+        if (sMetrics != null) {
+            sMetrics.minimize++;
+        }
+        if (mGoal.isEmpty()) {
+            if (DEBUG) {
+                System.out.println("\n*** SKIPPING MINIMIZE! ***\n");
+            }
+            computeValues();
+            return;
+        }
+        if (DEBUG) {
+            System.out.println("\n*** MINIMIZE ***\n");
+        }
+        if (graphOptimizer || newgraphOptimizer) {
+            if (sMetrics != null) {
+                sMetrics.graphOptimizer++;
+            }
+            boolean fullySolved = true;
+            for (int i = 0; i < mNumRows; i++) {
+                ArrayRow r = mRows[i];
+                if (!r.mIsSimpleDefinition) {
+                    fullySolved = false;
+                    break;
+                }
+            }
+            if (!fullySolved) {
+                minimizeGoal(mGoal);
+            } else {
+                if (sMetrics != null) {
+                    sMetrics.fullySolved++;
+                }
+                computeValues();
+            }
+        } else {
+            minimizeGoal(mGoal);
+        }
+        if (DEBUG) {
+            System.out.println("\n*** END MINIMIZE ***\n");
+        }
+    }
+
+    /**
+     * Minimize the given goal with the current system.
+     *
+     * @param goal the goal to minimize.
+     */
+    void minimizeGoal(Row goal) throws Exception {
+        if (sMetrics != null) {
+            sMetrics.minimizeGoal++;
+            sMetrics.maxVariables = Math.max(sMetrics.maxVariables, mNumColumns);
+            sMetrics.maxRows = Math.max(sMetrics.maxRows, mNumRows);
+        }
+        // First, let's make sure that the system is in Basic Feasible Solved Form (BFS), i.e.
+        // all the constants of the restricted variables should be positive.
+        if (DEBUG) {
+            System.out.println("minimize goal: " + goal);
+        }
+        // we don't need this for now as we incrementally built the system
+        // goal.updateFromSystem(this);
+        if (DEBUG) {
+            displayReadableRows();
+        }
+        enforceBFS(goal);
+        if (DEBUG) {
+            System.out.println("Goal after enforcing BFS " + goal);
+            displayReadableRows();
+        }
+        optimize(goal, false);
+        if (DEBUG) {
+            System.out.println("Goal after optimization " + goal);
+            displayReadableRows();
+        }
+        computeValues();
+    }
+
+    final void cleanupRows() {
+        int i = 0;
+        while (i < mNumRows) {
+            ArrayRow current = mRows[i];
+            if (current.variables.getCurrentSize() == 0) {
+                current.mIsSimpleDefinition = true;
+            }
+            if (current.mIsSimpleDefinition) {
+                current.mVariable.computedValue = current.mConstantValue;
+                current.mVariable.removeFromRow(current);
+                for (int j = i; j < mNumRows - 1; j++) {
+                    mRows[j] = mRows[j + 1];
+                }
+                mRows[mNumRows - 1] = null;
+                mNumRows--;
+                i--;
+                if (OPTIMIZED_ENGINE) {
+                    mCache.mOptimizedArrayRowPool.release(current);
+                } else {
+                    mCache.mArrayRowPool.release(current);
+                }
+            }
+            i++;
+        }
+    }
+
+    /**
+     * Add the equation to the system
+     *
+     * @param row the equation we want to add expressed as a system row.
+     */
+    public void addConstraint(ArrayRow row) {
+        if (row == null) {
+            return;
+        }
+        if (sMetrics != null) {
+            sMetrics.constraints++;
+            if (row.mIsSimpleDefinition) {
+                sMetrics.simpleconstraints++;
+            }
+        }
+        if (mNumRows + 1 >= mMaxRows || mNumColumns + 1 >= mMaxColumns) {
+            increaseTableSize();
+        }
+        if (DEBUG) {
+            System.out.println("addConstraint <" + row.toReadableString() + ">");
+            displayReadableRows();
+        }
+
+        boolean added = false;
+        if (!row.mIsSimpleDefinition) {
+            // Update the equation with the variables already defined in the system
+            row.updateFromSystem(this);
+
+            if (row.isEmpty()) {
+                return;
+            }
+
+            // First, ensure that if we have a constant it's positive
+            row.ensurePositiveConstant();
+
+            if (DEBUG) {
+                System.out.println("addConstraint, updated row : " + row.toReadableString());
+            }
+
+            // Then pick a good variable to use for the row
+            if (row.chooseSubject(this)) {
+                // extra variable added... let's try to see if we can remove it
+                SolverVariable extra = createExtraVariable();
+                row.mVariable = extra;
+                int numRows = mNumRows;
+                addRow(row);
+                if (mNumRows == numRows + 1) {
+                    added = true;
+                    mTempGoal.initFromRow(row);
+                    optimize(mTempGoal, true);
+                    if (extra.mDefinitionId == -1) {
+                        if (DEBUG) {
+                            System.out.println("row added is 0, so get rid of it");
+                        }
+                        if (row.mVariable == extra) {
+                            // move extra to be parametric
+                            SolverVariable pivotCandidate = row.pickPivot(extra);
+                            if (pivotCandidate != null) {
+                                if (sMetrics != null) {
+                                    sMetrics.pivots++;
+                                }
+                                row.pivot(pivotCandidate);
+                            }
+                        }
+                        if (!row.mIsSimpleDefinition) {
+                            row.mVariable.updateReferencesWithNewDefinition(this, row);
+                        }
+                        if (OPTIMIZED_ENGINE) {
+                            mCache.mOptimizedArrayRowPool.release(row);
+                        } else {
+                            mCache.mArrayRowPool.release(row);
+                        }
+                        mNumRows--;
+                    }
+                }
+            }
+
+            if (!row.hasKeyVariable()) {
+                // Can happen if row resolves to nil
+                if (DEBUG) {
+                    System.out.println("No variable found to pivot on " + row.toReadableString());
+                    displayReadableRows();
+                }
+                return;
+            }
+        }
+        if (!added) {
+            addRow(row);
+        }
+    }
+
+    private void addRow(ArrayRow row) {
+        if (SIMPLIFY_SYNONYMS && row.mIsSimpleDefinition) {
+            row.mVariable.setFinalValue(this, row.mConstantValue);
+        } else {
+            mRows[mNumRows] = row;
+            row.mVariable.mDefinitionId = mNumRows;
+            mNumRows++;
+            row.mVariable.updateReferencesWithNewDefinition(this, row);
+        }
+        if (DEBUG) {
+            System.out.println("Row added: " + row);
+            System.out.println("here is the system:");
+            displayReadableRows();
+        }
+        if (SIMPLIFY_SYNONYMS && hasSimpleDefinition) {
+            // compact the rows...
+            for (int i = 0; i < mNumRows; i++) {
+                if (mRows[i] == null) {
+                    System.out.println("WTF");
+                }
+                if (mRows[i] != null && mRows[i].mIsSimpleDefinition) {
+                    ArrayRow removedRow = mRows[i];
+                    removedRow.mVariable.setFinalValue(this, removedRow.mConstantValue);
+                    if (OPTIMIZED_ENGINE) {
+                        mCache.mOptimizedArrayRowPool.release(removedRow);
+                    } else {
+                        mCache.mArrayRowPool.release(removedRow);
+                    }
+                    mRows[i] = null;
+                    int lastRow = i + 1;
+                    for (int j = i + 1; j < mNumRows; j++) {
+                        mRows[j - 1] = mRows[j];
+                        if (mRows[j - 1].mVariable.mDefinitionId == j) {
+                            mRows[j - 1].mVariable.mDefinitionId = j - 1;
+                        }
+                        lastRow = j;
+                    }
+                    if (lastRow < mNumRows) {
+                        mRows[lastRow] = null;
+                    }
+                    mNumRows--;
+                    i--;
+                }
+            }
+            hasSimpleDefinition = false;
+        }
+    }
+
+    // @TODO: add description
+    public void removeRow(ArrayRow row) {
+        if (row.mIsSimpleDefinition && row.mVariable != null) {
+            if (row.mVariable.mDefinitionId != -1) {
+                for (int i = row.mVariable.mDefinitionId; i < mNumRows - 1; i++) {
+                    SolverVariable rowVariable = mRows[i + 1].mVariable;
+                    if (rowVariable.mDefinitionId == i + 1) {
+                        rowVariable.mDefinitionId = i;
+                    }
+                    mRows[i] = mRows[i + 1];
+                }
+                mNumRows--;
+            }
+            if (!row.mVariable.isFinalValue) {
+                row.mVariable.setFinalValue(this, row.mConstantValue);
+            }
+            if (OPTIMIZED_ENGINE) {
+                mCache.mOptimizedArrayRowPool.release(row);
+            } else {
+                mCache.mArrayRowPool.release(row);
+            }
+        }
+    }
+
+    /**
+     * Optimize the system given a goal to minimize. The system should be in BFS form.
+     *
+     * @param goal goal to optimize.
+     * @return number of iterations.
+     */
+    private int optimize(Row goal, boolean b) {
+        if (sMetrics != null) {
+            sMetrics.optimize++;
+        }
+        boolean done = false;
+        int tries = 0;
+        for (int i = 0; i < mNumColumns; i++) {
+            mAlreadyTestedCandidates[i] = false;
+        }
+
+        if (DEBUG) {
+            System.out.println("\n****************************");
+            System.out.println("*       OPTIMIZATION       *");
+            System.out.println("* mNumColumns: " + mNumColumns);
+            System.out.println("* GOAL: " + goal + " " + b);
+            System.out.println("****************************\n");
+        }
+
+        while (!done) {
+            if (sMetrics != null) {
+                sMetrics.iterations++;
+            }
+            tries++;
+            if (DEBUG) {
+                System.out.println("\n******************************");
+                System.out.println("* iteration: " + tries);
+            }
+            if (tries >= 2 * mNumColumns) {
+                if (DEBUG) {
+                    System.out.println("=> Exit optimization because tries "
+                            + tries + " >= " + (2 * mNumColumns));
+                }
+                return tries;
+            }
+
+            if (goal.getKey() != null) {
+                mAlreadyTestedCandidates[goal.getKey().id] = true;
+            }
+            SolverVariable pivotCandidate = goal.getPivotCandidate(this, mAlreadyTestedCandidates);
+            if (DEBUG) {
+                System.out.println("* Pivot candidate: " + pivotCandidate);
+                System.out.println("******************************\n");
+            }
+            if (pivotCandidate != null) {
+                if (mAlreadyTestedCandidates[pivotCandidate.id]) {
+                    if (DEBUG) {
+                        System.out.println("* Pivot candidate " + pivotCandidate
+                                + " already tested, let's bail");
+                    }
+                    return tries;
+                } else {
+                    mAlreadyTestedCandidates[pivotCandidate.id] = true;
+                }
+            }
+
+            if (pivotCandidate != null) {
+                if (DEBUG) {
+                    System.out.println("valid pivot candidate: " + pivotCandidate);
+                }
+                // there's a negative variable in the goal that we can pivot on.
+                // We now need to select which equation of the system we should do
+                // the pivot on.
+
+                // Let's try to find the equation in the system that we can pivot on.
+                // The rules are simple:
+                // - only look at restricted variables equations (i.e. Cs)
+                // - only look at equations containing the column we are trying to pivot on (duh)
+                // - select preferably an equation with strong strength over weak strength
+
+                float min = Float.MAX_VALUE;
+                int pivotRowIndex = -1;
+
+                for (int i = 0; i < mNumRows; i++) {
+                    ArrayRow current = mRows[i];
+                    SolverVariable variable = current.mVariable;
+                    if (variable.mType == SolverVariable.Type.UNRESTRICTED) {
+                        // skip unrestricted variables equations (to only look at Cs)
+                        continue;
+                    }
+                    if (current.mIsSimpleDefinition) {
+                        continue;
+                    }
+
+                    if (current.hasVariable(pivotCandidate)) {
+                        if (DEBUG) {
+                            System.out.println("equation " + i + " "
+                                    + current + " contains " + pivotCandidate);
+                        }
+                        // the current row does contains the variable
+                        // we want to pivot on
+                        float a_j = current.variables.get(pivotCandidate);
+                        if (a_j < 0) {
+                            float value = -current.mConstantValue / a_j;
+                            if (value < min) {
+                                min = value;
+                                pivotRowIndex = i;
+                            }
+                        }
+                    }
+                }
+                // At this point, we ought to have an equation to pivot on
+
+                if (pivotRowIndex > -1) {
+                    // We found an equation to pivot on
+                    if (DEBUG) {
+                        System.out.println("We pivot on " + pivotRowIndex);
+                    }
+                    ArrayRow pivotEquation = mRows[pivotRowIndex];
+                    pivotEquation.mVariable.mDefinitionId = -1;
+                    if (sMetrics != null) {
+                        sMetrics.pivots++;
+                    }
+                    pivotEquation.pivot(pivotCandidate);
+                    pivotEquation.mVariable.mDefinitionId = pivotRowIndex;
+                    pivotEquation.mVariable.updateReferencesWithNewDefinition(this, pivotEquation);
+                    if (DEBUG) {
+                        System.out.println("new system after pivot:");
+                        displayReadableRows();
+                        System.out.println("optimizing: " + goal);
+                    }
+                    /*
+                    try {
+                        enforceBFS(goal);
+                    } catch (Exception e) {
+                        System.out.println("### EXCEPTION " + e);
+                        e.printStackTrace();
+                    }
+                    */
+                    // now that we pivoted, we're going to continue looping on the next goal
+                    // columns, until we exhaust all the possibilities of improving the system
+                } else {
+                    if (DEBUG) {
+                        System.out.println("we couldn't find an equation to pivot upon");
+                    }
+                }
+
+            } else {
+                // There is no candidate goals columns we should try to pivot on,
+                // so let's exit the loop.
+                if (DEBUG) {
+                    System.out.println("no more candidate goals to pivot on, let's exit");
+                }
+                done = true;
+            }
+        }
+        return tries;
+    }
+
+    /**
+     * Make sure that the system is in Basic Feasible Solved form (BFS).
+     *
+     * @param goal the row representing the system goal
+     * @return number of iterations
+     */
+    private int enforceBFS(Row goal) throws Exception {
+        int tries = 0;
+        boolean done;
+
+        if (DEBUG) {
+            System.out.println("\n#################");
+            System.out.println("# ENFORCING BFS #");
+            System.out.println("#################\n");
+        }
+
+        // At this point, we might not be in Basic Feasible Solved form (BFS),
+        // i.e. one of the restricted equation has a negative constant.
+        // Let's check if that's the case or not.
+        boolean infeasibleSystem = false;
+        for (int i = 0; i < mNumRows; i++) {
+            SolverVariable variable = mRows[i].mVariable;
+            if (variable.mType == SolverVariable.Type.UNRESTRICTED) {
+                continue; // C can be either positive or negative.
+            }
+            if (mRows[i].mConstantValue < 0) {
+                infeasibleSystem = true;
+                break;
+            }
+        }
+
+        // The system happens to not be in BFS form, we need to go back to it to properly solve it.
+        if (infeasibleSystem) {
+            if (DEBUG) {
+                System.out.println("the current system is infeasible, let's try to fix this.");
+            }
+
+            // Going back to BFS form can be done by selecting any equations in Cs containing
+            // a negative constant, then selecting a potential pivot variable that would remove
+            // this negative constant. Once we have
+            done = false;
+            tries = 0;
+            while (!done) {
+                if (sMetrics != null) {
+                    sMetrics.bfs++;
+                }
+                tries++;
+                if (DEBUG) {
+                    System.out.println("iteration on infeasible system " + tries);
+                }
+                float min = Float.MAX_VALUE;
+                int strength = 0;
+                int pivotRowIndex = -1;
+                int pivotColumnIndex = -1;
+
+                for (int i = 0; i < mNumRows; i++) {
+                    ArrayRow current = mRows[i];
+                    SolverVariable variable = current.mVariable;
+                    if (variable.mType == SolverVariable.Type.UNRESTRICTED) {
+                        // skip unrestricted variables equations, as C
+                        // can be either positive or negative.
+                        continue;
+                    }
+                    if (current.mIsSimpleDefinition) {
+                        continue;
+                    }
+                    if (current.mConstantValue < 0) {
+                        // let's examine this row, see if we can find a good pivot
+                        if (DEBUG) {
+                            System.out.println("looking at pivoting on row " + current);
+                        }
+                        if (SKIP_COLUMNS) {
+                            final int size = current.variables.getCurrentSize();
+                            for (int j = 0; j < size; j++) {
+                                SolverVariable candidate = current.variables.getVariable(j);
+                                float a_j = current.variables.get(candidate);
+                                if (a_j <= 0) {
+                                    continue;
+                                }
+                                if (DEBUG) {
+                                    System.out.println("candidate for pivot " + candidate);
+                                }
+                                for (int k = 0; k < SolverVariable.MAX_STRENGTH; k++) {
+                                    float value = candidate.mStrengthVector[k] / a_j;
+                                    if ((value < min && k == strength) || k > strength) {
+                                        min = value;
+                                        pivotRowIndex = i;
+                                        pivotColumnIndex = candidate.id;
+                                        strength = k;
+                                    }
+                                }
+                            }
+                        } else {
+                            for (int j = 1; j < mNumColumns; j++) {
+                                SolverVariable candidate = mCache.mIndexedVariables[j];
+                                float a_j = current.variables.get(candidate);
+                                if (a_j <= 0) {
+                                    continue;
+                                }
+                                if (DEBUG) {
+                                    System.out.println("candidate for pivot " + candidate);
+                                }
+                                for (int k = 0; k < SolverVariable.MAX_STRENGTH; k++) {
+                                    float value = candidate.mStrengthVector[k] / a_j;
+                                    if ((value < min && k == strength) || k > strength) {
+                                        min = value;
+                                        pivotRowIndex = i;
+                                        pivotColumnIndex = j;
+                                        strength = k;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (pivotRowIndex != -1) {
+                    // We have a pivot!
+                    ArrayRow pivotEquation = mRows[pivotRowIndex];
+                    if (DEBUG) {
+                        System.out.println("Pivoting on " + pivotEquation.mVariable + " with "
+                                + mCache.mIndexedVariables[pivotColumnIndex]);
+                    }
+                    pivotEquation.mVariable.mDefinitionId = -1;
+                    if (sMetrics != null) {
+                        sMetrics.pivots++;
+                    }
+                    pivotEquation.pivot(mCache.mIndexedVariables[pivotColumnIndex]);
+                    pivotEquation.mVariable.mDefinitionId = pivotRowIndex;
+                    pivotEquation.mVariable.updateReferencesWithNewDefinition(this, pivotEquation);
+
+                    if (DEBUG) {
+                        System.out.println("new goal after pivot: " + goal);
+                        displayRows();
+                    }
+                } else {
+                    done = true;
+                }
+                if (tries > mNumColumns / 2) {
+                    // fail safe -- tried too many times
+                    done = true;
+                }
+            }
+        }
+
+        if (DEBUG) {
+            System.out.println("the current system should now be feasible ["
+                    + infeasibleSystem + "] after " + tries + " iterations");
+            displayReadableRows();
+
+            // Let's make sure the system is correct
+            //noinspection UnusedAssignment
+            infeasibleSystem = false;
+            for (int i = 0; i < mNumRows; i++) {
+                SolverVariable variable = mRows[i].mVariable;
+                if (variable.mType == SolverVariable.Type.UNRESTRICTED) {
+                    continue; // C can be either positive or negative.
+                }
+                if (mRows[i].mConstantValue < 0) {
+                    //noinspection UnusedAssignment
+                    infeasibleSystem = true;
+                    break;
+                }
+            }
+
+            if (DEBUG && infeasibleSystem) {
+                System.out.println("IMPOSSIBLE SYSTEM, WTF");
+                throw new Exception();
+            }
+            if (infeasibleSystem) {
+                return tries;
+            }
+        }
+
+        return tries;
+    }
+
+    private void computeValues() {
+        for (int i = 0; i < mNumRows; i++) {
+            ArrayRow row = mRows[i];
+            row.mVariable.computedValue = row.mConstantValue;
+        }
+    }
+
+    /*--------------------------------------------------------------------------------------------*/
+    // Display utility functions
+    /*--------------------------------------------------------------------------------------------*/
+
+    @SuppressWarnings("unused")
+    private void displayRows() {
+        displaySolverVariables();
+        String s = "";
+        for (int i = 0; i < mNumRows; i++) {
+            s += mRows[i];
+            s += "\n";
+        }
+        s += mGoal + "\n";
+        System.out.println(s);
+    }
+
+    // @TODO: add description
+    public void displayReadableRows() {
+        displaySolverVariables();
+        String s = " num vars " + mVariablesID + "\n";
+        for (int i = 0; i < mVariablesID + 1; i++) {
+            SolverVariable variable = mCache.mIndexedVariables[i];
+            if (variable != null && variable.isFinalValue) {
+                s += " $[" + i + "] => " + variable + " = " + variable.computedValue + "\n";
+            }
+        }
+        s += "\n";
+        for (int i = 0; i < mVariablesID + 1; i++) {
+            SolverVariable variable = mCache.mIndexedVariables[i];
+            if (variable != null && variable.mIsSynonym) {
+                SolverVariable synonym = mCache.mIndexedVariables[variable.mSynonym];
+                s += " ~[" + i + "] => " + variable + " = "
+                        + synonym + " + " + variable.mSynonymDelta + "\n";
+            }
+        }
+        s += "\n\n #  ";
+        for (int i = 0; i < mNumRows; i++) {
+            s += mRows[i].toReadableString();
+            s += "\n #  ";
+        }
+        if (mGoal != null) {
+            s += "Goal: " + mGoal + "\n";
+        }
+        System.out.println(s);
+    }
+
+    // @TODO: add description
+    @SuppressWarnings("unused")
+    public void displayVariablesReadableRows() {
+        displaySolverVariables();
+        String s = "";
+        for (int i = 0; i < mNumRows; i++) {
+            if (mRows[i].mVariable.mType == SolverVariable.Type.UNRESTRICTED) {
+                s += mRows[i].toReadableString();
+                s += "\n";
+            }
+        }
+        s += mGoal + "\n";
+        System.out.println(s);
+    }
+
+
+    // @TODO: add description
+    @SuppressWarnings("unused")
+    public int getMemoryUsed() {
+        int actualRowSize = 0;
+        for (int i = 0; i < mNumRows; i++) {
+            if (mRows[i] != null) {
+                actualRowSize += mRows[i].sizeInBytes();
+            }
+        }
+        return actualRowSize;
+    }
+
+    @SuppressWarnings("unused")
+    public int getNumEquations() {
+        return mNumRows;
+    }
+
+    @SuppressWarnings("unused")
+    public int getNumVariables() {
+        return mVariablesID;
+    }
+
+    /**
+     * Display current system information
+     */
+    void displaySystemInformation() {
+        int count = 0;
+        int rowSize = 0;
+        for (int i = 0; i < mTableSize; i++) {
+            if (mRows[i] != null) {
+                rowSize += mRows[i].sizeInBytes();
+            }
+        }
+        int actualRowSize = 0;
+        for (int i = 0; i < mNumRows; i++) {
+            if (mRows[i] != null) {
+                actualRowSize += mRows[i].sizeInBytes();
+            }
+        }
+
+        System.out.println("Linear System -> Table size: " + mTableSize
+                + " (" + getDisplaySize(mTableSize * mTableSize)
+                + ") -- row sizes: " + getDisplaySize(rowSize)
+                + ", actual size: " + getDisplaySize(actualRowSize)
+                + " rows: " + mNumRows + "/" + mMaxRows
+                + " cols: " + mNumColumns + "/" + mMaxColumns
+                + " " + count + " occupied cells, " + getDisplaySize(count)
+        );
+    }
+
+    private void displaySolverVariables() {
+        String s = "Display Rows (" + mNumRows + "x" + mNumColumns + ")\n";
+        /*
+        s += ":\n\t | C | ";
+        for (int i = 1; i <= mNumColumns; i++) {
+            SolverVariable v = mCache.mIndexedVariables[i];
+            s += v;
+            s += " | ";
+        }
+        s += "\n";
+        */
+        System.out.println(s);
+    }
+
+    private String getDisplaySize(int n) {
+        int mb = (n * 4) / 1024 / 1024;
+        if (mb > 0) {
+            return "" + mb + " Mb";
+        }
+        int kb = (n * 4) / 1024;
+        if (kb > 0) {
+            return "" + kb + " Kb";
+        }
+        return "" + (n * 4) + " bytes";
+    }
+
+    public Cache getCache() {
+        return mCache;
+    }
+
+    private String getDisplayStrength(int strength) {
+        if (strength == SolverVariable.STRENGTH_LOW) {
+            return "LOW";
+        }
+        if (strength == SolverVariable.STRENGTH_MEDIUM) {
+            return "MEDIUM";
+        }
+        if (strength == SolverVariable.STRENGTH_HIGH) {
+            return "HIGH";
+        }
+        if (strength == SolverVariable.STRENGTH_HIGHEST) {
+            return "HIGHEST";
+        }
+        if (strength == SolverVariable.STRENGTH_EQUALITY) {
+            return "EQUALITY";
+        }
+        if (strength == SolverVariable.STRENGTH_FIXED) {
+            return "FIXED";
+        }
+        if (strength == SolverVariable.STRENGTH_BARRIER) {
+            return "BARRIER";
+        }
+        return "NONE";
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////
+    // Equations
+    ////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Add an equation of the form a >= b + margin
+     *
+     * @param a        variable a
+     * @param b        variable b
+     * @param margin   margin
+     * @param strength strength used
+     */
+    public void addGreaterThan(SolverVariable a, SolverVariable b, int margin, int strength) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> " + a + " >= " + b + (margin != 0 ? " + " + margin : "")
+                    + " " + getDisplayStrength(strength));
+        }
+        ArrayRow row = createRow();
+        SolverVariable slack = createSlackVariable();
+        slack.strength = 0;
+        row.createRowGreaterThan(a, b, slack, margin);
+        if (strength != SolverVariable.STRENGTH_FIXED) {
+            float slackValue = row.variables.get(slack);
+            addSingleError(row, (int) (-1 * slackValue), strength);
+        }
+        addConstraint(row);
+    }
+
+    // @TODO: add description
+    public void addGreaterBarrier(SolverVariable a,
+            SolverVariable b,
+            int margin,
+            boolean hasMatchConstraintWidgets) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> Barrier " + a + " >= " + b);
+        }
+        ArrayRow row = createRow();
+        SolverVariable slack = createSlackVariable();
+        slack.strength = 0;
+        row.createRowGreaterThan(a, b, slack, margin);
+        addConstraint(row);
+    }
+
+    /**
+     * Add an equation of the form a <= b + margin
+     *
+     * @param a        variable a
+     * @param b        variable b
+     * @param margin   margin
+     * @param strength strength used
+     */
+    public void addLowerThan(SolverVariable a, SolverVariable b, int margin, int strength) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> " + a + " <= " + b + (margin != 0 ? " + " + margin : "")
+                    + " " + getDisplayStrength(strength));
+        }
+        ArrayRow row = createRow();
+        SolverVariable slack = createSlackVariable();
+        slack.strength = 0;
+        row.createRowLowerThan(a, b, slack, margin);
+        if (strength != SolverVariable.STRENGTH_FIXED) {
+            float slackValue = row.variables.get(slack);
+            addSingleError(row, (int) (-1 * slackValue), strength);
+        }
+        addConstraint(row);
+    }
+
+    // @TODO: add description
+    public void addLowerBarrier(SolverVariable a,
+            SolverVariable b,
+            int margin,
+            boolean hasMatchConstraintWidgets) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> Barrier " + a + " <= " + b);
+        }
+        ArrayRow row = createRow();
+        SolverVariable slack = createSlackVariable();
+        slack.strength = 0;
+        row.createRowLowerThan(a, b, slack, margin);
+        addConstraint(row);
+    }
+
+    /**
+     * Add an equation of the form (1 - bias) * (a - b) = bias * (c - d)
+     *
+     * @param a        variable a
+     * @param b        variable b
+     * @param m1       margin 1
+     * @param bias     bias between ab - cd
+     * @param c        variable c
+     * @param d        variable d
+     * @param m2       margin 2
+     * @param strength strength used
+     */
+    public void addCentering(SolverVariable a, SolverVariable b, int m1, float bias,
+            SolverVariable c, SolverVariable d, int m2, int strength) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> [center bias: " + bias + "] : " + a + " - " + b
+                    + " - " + m1
+                    + " = " + c + " - " + d + " - " + m2
+                    + " " + getDisplayStrength(strength));
+        }
+        ArrayRow row = createRow();
+        row.createRowCentering(a, b, m1, bias, c, d, m2);
+        if (strength != SolverVariable.STRENGTH_FIXED) {
+            row.addError(this, strength);
+        }
+        addConstraint(row);
+    }
+
+    // @TODO: add description
+    public void addRatio(SolverVariable a,
+            SolverVariable b,
+            SolverVariable c,
+            SolverVariable d,
+            float ratio,
+            int strength) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> [ratio: " + ratio + "] : " + a + " = " + b
+                    + " + (" + c + " - " + d + ") * " + ratio + " " + getDisplayStrength(strength));
+        }
+        ArrayRow row = createRow();
+        row.createRowDimensionRatio(a, b, c, d, ratio);
+        if (strength != SolverVariable.STRENGTH_FIXED) {
+            row.addError(this, strength);
+        }
+        addConstraint(row);
+    }
+
+    // @TODO: add description
+    public void addSynonym(SolverVariable a, SolverVariable b, int margin) {
+        if (a.mDefinitionId == -1 && margin == 0) {
+            if (DEBUG_CONSTRAINTS) {
+                System.out.println("(S) -> " + a + " = " + b + (margin != 0 ? " + " + margin : ""));
+            }
+            if (b.mIsSynonym) {
+                margin += (int) b.mSynonymDelta;
+                b = mCache.mIndexedVariables[b.mSynonym];
+            }
+            if (a.mIsSynonym) {
+                margin -= (int) a.mSynonymDelta;
+                a = mCache.mIndexedVariables[a.mSynonym];
+            } else {
+                a.setSynonym(this, b, 0);
+            }
+        } else {
+            addEquality(a, b, margin, SolverVariable.STRENGTH_FIXED);
+        }
+    }
+
+    /**
+     * Add an equation of the form a = b + margin
+     *
+     * @param a        variable a
+     * @param b        variable b
+     * @param margin   margin used
+     * @param strength strength used
+     */
+    public ArrayRow addEquality(SolverVariable a, SolverVariable b, int margin, int strength) {
+        if (sMetrics != null) {
+            sMetrics.mSimpleEquations++;
+        }
+        if (USE_BASIC_SYNONYMS && strength == SolverVariable.STRENGTH_FIXED
+                && b.isFinalValue && a.mDefinitionId == -1) {
+            if (DEBUG_CONSTRAINTS) {
+                System.out.println("=> " + a + " = " + b + (margin != 0 ? " + " + margin : "")
+                        + " = " + (b.computedValue + margin) + " (Synonym)");
+            }
+            a.setFinalValue(this, b.computedValue + margin);
+            return null;
+        }
+        if (DO_NOT_USE && USE_SYNONYMS && strength == SolverVariable.STRENGTH_FIXED
+                && a.mDefinitionId == -1 && margin == 0) {
+            if (DEBUG_CONSTRAINTS) {
+                System.out.println("(S) -> " + a + " = " + b + (margin != 0 ? " + " + margin : "")
+                        + " " + getDisplayStrength(strength));
+            }
+            if (b.mIsSynonym) {
+                margin += (int) b.mSynonymDelta;
+                b = mCache.mIndexedVariables[b.mSynonym];
+            }
+            if (a.mIsSynonym) {
+                margin -= (int) a.mSynonymDelta;
+                a = mCache.mIndexedVariables[a.mSynonym];
+            } else {
+                a.setSynonym(this, b, margin);
+                return null;
+            }
+        }
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> " + a + " = " + b + (margin != 0 ? " + " + margin : "")
+                    + " " + getDisplayStrength(strength));
+        }
+        ArrayRow row = createRow();
+        row.createRowEquals(a, b, margin);
+        if (strength != SolverVariable.STRENGTH_FIXED) {
+            row.addError(this, strength);
+        }
+        addConstraint(row);
+        return row;
+    }
+
+    /**
+     * Add an equation of the form a = value
+     *
+     * @param a     variable a
+     * @param value the value we set
+     */
+    public void addEquality(SolverVariable a, int value) {
+        if (sMetrics != null) {
+            sMetrics.mSimpleEquations++;
+        }
+        if (USE_BASIC_SYNONYMS && a.mDefinitionId == -1) {
+            if (DEBUG_CONSTRAINTS) {
+                System.out.println("=> " + a + " = " + value + " (Synonym)");
+            }
+            a.setFinalValue(this, value);
+            for (int i = 0; i < mVariablesID + 1; i++) {
+                SolverVariable variable = mCache.mIndexedVariables[i];
+                if (variable != null && variable.mIsSynonym && variable.mSynonym == a.id) {
+                    variable.setFinalValue(this, value + variable.mSynonymDelta);
+                }
+            }
+            return;
+        }
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> " + a + " = " + value);
+        }
+        int idx = a.mDefinitionId;
+        if (a.mDefinitionId != -1) {
+            ArrayRow row = mRows[idx];
+            if (row.mIsSimpleDefinition) {
+                row.mConstantValue = value;
+            } else {
+                if (row.variables.getCurrentSize() == 0) {
+                    row.mIsSimpleDefinition = true;
+                    row.mConstantValue = value;
+                } else {
+                    ArrayRow newRow = createRow();
+                    newRow.createRowEquals(a, value);
+                    addConstraint(newRow);
+                }
+            }
+        } else {
+            ArrayRow row = createRow();
+            row.createRowDefinition(a, value);
+            addConstraint(row);
+        }
+    }
+
+    /**
+     * Create a constraint to express A = C * percent
+     *
+     * @param linearSystem the system we create the row on
+     * @param variableA    variable a
+     * @param variableC    variable c
+     * @param percent      the percent used
+     * @return the created row
+     */
+    public static ArrayRow createRowDimensionPercent(LinearSystem linearSystem,
+            SolverVariable variableA,
+            SolverVariable variableC,
+            float percent) {
+        if (DEBUG_CONSTRAINTS) {
+            System.out.println("-> " + variableA + " = " + variableC + " * " + percent);
+        }
+        ArrayRow row = linearSystem.createRow();
+        return row.createRowDimensionPercent(variableA, variableC, percent);
+    }
+
+    /**
+     * Add the equations constraining a widget center to another widget center, positioned
+     * on a circle, following an angle and radius
+     *
+     * @param widget the constrained widget
+     * @param target the constrained-to widget
+     * @param angle  from 0 to 360
+     * @param radius the distance between the two centers
+     */
+    public void addCenterPoint(ConstraintWidget widget,
+            ConstraintWidget target,
+            float angle,
+            int radius) {
+
+        SolverVariable Al = createObjectVariable(widget.getAnchor(ConstraintAnchor.Type.LEFT));
+        SolverVariable At = createObjectVariable(widget.getAnchor(ConstraintAnchor.Type.TOP));
+        SolverVariable Ar = createObjectVariable(widget.getAnchor(ConstraintAnchor.Type.RIGHT));
+        SolverVariable Ab = createObjectVariable(widget.getAnchor(ConstraintAnchor.Type.BOTTOM));
+
+        SolverVariable Bl = createObjectVariable(target.getAnchor(ConstraintAnchor.Type.LEFT));
+        SolverVariable Bt = createObjectVariable(target.getAnchor(ConstraintAnchor.Type.TOP));
+        SolverVariable Br = createObjectVariable(target.getAnchor(ConstraintAnchor.Type.RIGHT));
+        SolverVariable Bb = createObjectVariable(target.getAnchor(ConstraintAnchor.Type.BOTTOM));
+
+        ArrayRow row = createRow();
+        float angleComponent = (float) (Math.sin(angle) * radius);
+        row.createRowWithAngle(At, Ab, Bt, Bb, angleComponent);
+        addConstraint(row);
+        row = createRow();
+        angleComponent = (float) (Math.cos(angle) * radius);
+        row.createRowWithAngle(Al, Ar, Bl, Br, angleComponent);
+        addConstraint(row);
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/Metrics.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/Metrics.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core;
+
+import java.util.ArrayList;
+
+/**
+ * Utility class to track metrics during the system resolution
+ */
+public class Metrics {
+    public long measuresWidgetsDuration; // time spent in child measures in nanoseconds
+    public long measuresLayoutDuration; // time spent in child measures in nanoseconds
+    public long measuredWidgets;
+    public long measuredMatchWidgets;
+    public long measures;
+    public long additionalMeasures;
+    public long resolutions;
+    public long tableSizeIncrease;
+    public long minimize;
+    public long constraints;
+    public long simpleconstraints;
+    public long optimize;
+    public long iterations;
+    public long pivots;
+    public long bfs;
+    public long variables;
+    public long errors;
+    public long slackvariables;
+    public long extravariables;
+    public long maxTableSize;
+    public long fullySolved;
+    public long graphOptimizer;
+    public long graphSolved;
+    public long linearSolved;
+    public long resolvedWidgets;
+    public long minimizeGoal;
+    public long maxVariables;
+    public long maxRows;
+    public long nonresolvedWidgets;
+    public ArrayList<String> problematicLayouts = new ArrayList<>();
+    public long lastTableSize;
+    public long widgets;
+    public long measuresWrap;
+    public long measuresWrapInfeasible;
+    public long infeasibleDetermineGroups;
+    public long determineGroups;
+    public long layouts;
+    public long grouping;
+    public int mNumberOfLayouts; // the number of times ConstraintLayout onLayout gets called
+    public int mNumberOfMeasures; // the number of times child measures gets called
+    public long mMeasureDuration; // time spent in measure in nanoseconds
+    public long mChildCount; // number of child Views of ConstraintLayout
+    public long mMeasureCalls; // number of time CL onMeasure is called
+    public long mSolverPasses;
+    public long mEquations;
+    public long mVariables;
+    public long mSimpleEquations;
+
+    // @TODO: add description
+    @Override
+    public String toString() {
+        return "\n*** Metrics ***\n"
+                + "measures: " + measures + "\n"
+                + "measuresWrap: " + measuresWrap + "\n"
+                + "measuresWrapInfeasible: " + measuresWrapInfeasible + "\n"
+                + "determineGroups: " + determineGroups + "\n"
+                + "infeasibleDetermineGroups: " + infeasibleDetermineGroups + "\n"
+                + "graphOptimizer: " + graphOptimizer + "\n"
+                + "widgets: " + widgets + "\n"
+                + "graphSolved: " + graphSolved + "\n"
+                + "linearSolved: " + linearSolved + "\n";
+    }
+
+    // @TODO: add description
+    public void reset() {
+        measures = 0;
+        widgets = 0;
+        additionalMeasures = 0;
+        resolutions = 0;
+        tableSizeIncrease = 0;
+        maxTableSize = 0;
+        lastTableSize = 0;
+        maxVariables = 0;
+        maxRows = 0;
+        minimize = 0;
+        minimizeGoal = 0;
+        constraints = 0;
+        simpleconstraints = 0;
+        optimize = 0;
+        iterations = 0;
+        pivots = 0;
+        bfs = 0;
+        variables = 0;
+        errors = 0;
+        slackvariables = 0;
+        extravariables = 0;
+        fullySolved = 0;
+        graphOptimizer = 0;
+        graphSolved = 0;
+        resolvedWidgets = 0;
+        nonresolvedWidgets = 0;
+        linearSolved = 0;
+        problematicLayouts.clear();
+        mNumberOfMeasures = 0;
+        mNumberOfLayouts = 0;
+        measuresWidgetsDuration = 0;
+        measuresLayoutDuration = 0;
+        mChildCount = 0;
+        mMeasureDuration = 0;
+        mMeasureCalls = 0;
+        mSolverPasses = 0;
+        mVariables = 0;
+        mEquations = 0;
+        mSimpleEquations = 0;
+    }
+
+    /**
+     * Copy the values from and existing Metrics class
+     * @param metrics
+     */
+    public void copy(Metrics metrics) {
+        mVariables = metrics.mVariables;
+        mEquations = metrics.mEquations;
+        mSimpleEquations = metrics.mSimpleEquations;
+        mNumberOfMeasures = metrics.mNumberOfMeasures;
+        mNumberOfLayouts = metrics.mNumberOfLayouts;
+        mMeasureDuration = metrics.mMeasureDuration;
+        mChildCount = metrics.mChildCount;
+        mMeasureCalls = metrics.mMeasureCalls;
+        measuresWidgetsDuration = metrics.measuresWidgetsDuration;
+        mSolverPasses = metrics.mSolverPasses;
+
+        measuresLayoutDuration = metrics.measuresLayoutDuration;
+        measures = metrics.measures;
+        widgets = metrics.widgets;
+        additionalMeasures = metrics.additionalMeasures;
+        resolutions = metrics.resolutions;
+        tableSizeIncrease = metrics.tableSizeIncrease;
+        maxTableSize = metrics.maxTableSize;
+        lastTableSize = metrics.lastTableSize;
+        maxVariables = metrics.maxVariables;
+        maxRows = metrics.maxRows;
+        minimize = metrics.minimize;
+        minimizeGoal = metrics.minimizeGoal;
+        constraints = metrics.constraints;
+        simpleconstraints = metrics.simpleconstraints;
+        optimize = metrics.optimize;
+        iterations = metrics.iterations;
+        pivots = metrics.pivots;
+        bfs = metrics.bfs;
+        variables = metrics.variables;
+        errors = metrics.errors;
+        slackvariables = metrics.slackvariables;
+        extravariables = metrics.extravariables;
+        fullySolved = metrics.fullySolved;
+        graphOptimizer = metrics.graphOptimizer;
+        graphSolved = metrics.graphSolved;
+        resolvedWidgets = metrics.resolvedWidgets;
+        nonresolvedWidgets = metrics.nonresolvedWidgets;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/Pools.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/Pools.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+/**
+ * Helper class for crating pools of objects. An example use looks like this:
+ * <pre>
+ * public class MyPooledClass {
+ *
+ *     private static final SimplePool<MyPooledClass> sPool =
+ *             new SimplePool<MyPooledClass>(10);
+ *
+ *     public static MyPooledClass obtain() {
+ *         MyPooledClass instance = sPool.acquire();
+ *         return (instance != null) ? instance : new MyPooledClass();
+ *     }
+ *
+ *     public void recycle() {
+ *          // Clear state if needed.
+ *          sPool.release(this);
+ *     }
+ *
+ *     . . .
+ * }
+ * </pre>
+ */
+final class Pools {
+    private static final boolean DEBUG = false;
+
+    /**
+     * Interface for managing a pool of objects.
+     *
+     * @param <T> The pooled type.
+     */
+    interface Pool<T> {
+
+        /**
+         * @return An instance from the pool if such, null otherwise.
+         */
+        T acquire();
+
+        /**
+         * Release an instance to the pool.
+         *
+         * @param instance The instance to release.
+         * @return Whether the instance was put in the pool.
+         * @throws IllegalStateException If the instance is already in the pool.
+         */
+        boolean release(T instance);
+
+        /**
+         * Try releasing all instances at the same time
+         *
+         * @param variables the variables to release
+         * @param count     the number of variables to release
+         */
+        void releaseAll(T[] variables, int count);
+    }
+
+    private Pools() {
+        /* do nothing - hiding constructor */
+    }
+
+    /**
+     * Simple (non-synchronized) pool of objects.
+     *
+     * @param <T> The pooled type.
+     */
+    static class SimplePool<T> implements Pool<T> {
+        private final Object[] mPool;
+
+        private int mPoolSize;
+
+        /**
+         * Creates a new instance.
+         *
+         * @param maxPoolSize The max pool size.
+         * @throws IllegalArgumentException If the max pool size is less than zero.
+         */
+        SimplePool(int maxPoolSize) {
+            if (maxPoolSize <= 0) {
+                throw new IllegalArgumentException("The max pool size must be > 0");
+            }
+            mPool = new Object[maxPoolSize];
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public T acquire() {
+            if (mPoolSize > 0) {
+                final int lastPooledIndex = mPoolSize - 1;
+                T instance = (T) mPool[lastPooledIndex];
+                mPool[lastPooledIndex] = null;
+                mPoolSize--;
+                return instance;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean release(T instance) {
+            if (DEBUG) {
+                if (isInPool(instance)) {
+                    throw new IllegalStateException("Already in the pool!");
+                }
+            }
+            if (mPoolSize < mPool.length) {
+                mPool[mPoolSize] = instance;
+                mPoolSize++;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void releaseAll(T[] variables, int count) {
+            if (count > variables.length) {
+                count = variables.length;
+            }
+            for (int i = 0; i < count; i++) {
+                T instance = variables[i];
+                if (DEBUG) {
+                    if (isInPool(instance)) {
+                        throw new IllegalStateException("Already in the pool!");
+                    }
+                }
+                if (mPoolSize < mPool.length) {
+                    mPool[mPoolSize] = instance;
+                    mPoolSize++;
+                }
+            }
+        }
+
+        private boolean isInPool(T instance) {
+            for (int i = 0; i < mPoolSize; i++) {
+                if (mPool[i] == instance) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/PriorityGoalRow.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/PriorityGoalRow.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * Implements a row containing goals taking in account priorities.
+ */
+public class PriorityGoalRow extends ArrayRow {
+    private static final float EPSILON = 0.0001f;
+    @SuppressWarnings("unused") private static final boolean DEBUG = false;
+
+    private int mTableSize = 128;
+    private SolverVariable[] mArrayGoals = new SolverVariable[mTableSize];
+    private SolverVariable[] mSortArray = new SolverVariable[mTableSize];
+    private int mNumGoals = 0;
+    GoalVariableAccessor mAccessor = new GoalVariableAccessor(this);
+
+    class GoalVariableAccessor {
+        SolverVariable mVariable;
+        PriorityGoalRow mRow;
+
+        GoalVariableAccessor(PriorityGoalRow row) {
+            this.mRow = row;
+        }
+
+        public void init(SolverVariable variable) {
+            this.mVariable = variable;
+        }
+
+        public boolean addToGoal(SolverVariable other, float value) {
+            if (mVariable.inGoal) {
+                boolean empty = true;
+                for (int i = 0; i < SolverVariable.MAX_STRENGTH; i++) {
+                    mVariable.mGoalStrengthVector[i] += other.mGoalStrengthVector[i] * value;
+                    float v = mVariable.mGoalStrengthVector[i];
+                    if (Math.abs(v) < EPSILON) {
+                        mVariable.mGoalStrengthVector[i] = 0;
+                    } else {
+                        empty = false;
+                    }
+                }
+                if (empty) {
+                    removeGoal(mVariable);
+                }
+            } else {
+                for (int i = 0; i < SolverVariable.MAX_STRENGTH; i++) {
+                    float strength = other.mGoalStrengthVector[i];
+                    if (strength != 0) {
+                        float v = value * strength;
+                        if (Math.abs(v) < EPSILON) {
+                            v = 0;
+                        }
+                        mVariable.mGoalStrengthVector[i] = v;
+                    } else {
+                        mVariable.mGoalStrengthVector[i] = 0;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        public void add(SolverVariable other) {
+            for (int i = 0; i < SolverVariable.MAX_STRENGTH; i++) {
+                mVariable.mGoalStrengthVector[i] += other.mGoalStrengthVector[i];
+                float value = mVariable.mGoalStrengthVector[i];
+                if (Math.abs(value) < EPSILON) {
+                    mVariable.mGoalStrengthVector[i] = 0;
+                }
+            }
+        }
+
+        public final boolean isNegative() {
+            for (int i = SolverVariable.MAX_STRENGTH - 1; i >= 0; i--) {
+                float value = mVariable.mGoalStrengthVector[i];
+                if (value > 0) {
+                    return false;
+                }
+                if (value < 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public final boolean isSmallerThan(SolverVariable other) {
+            for (int i = SolverVariable.MAX_STRENGTH - 1; i >= 0; i--) {
+                float comparedValue = other.mGoalStrengthVector[i];
+                float value = mVariable.mGoalStrengthVector[i];
+                if (value == comparedValue) {
+                    continue;
+                }
+                return value < comparedValue;
+            }
+            return false;
+        }
+
+        public final boolean isNull() {
+            for (int i = 0; i < SolverVariable.MAX_STRENGTH; i++) {
+                if (mVariable.mGoalStrengthVector[i] != 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void reset() {
+            Arrays.fill(mVariable.mGoalStrengthVector, 0);
+        }
+
+        @Override
+        public String toString() {
+            String result = "[ ";
+            if (mVariable != null) {
+                for (int i = 0; i < SolverVariable.MAX_STRENGTH; i++) {
+                    result += mVariable.mGoalStrengthVector[i] + " ";
+                }
+            }
+            result += "] " + mVariable;
+            return result;
+        }
+
+    }
+
+    @Override
+    public void clear() {
+        mNumGoals = 0;
+        mConstantValue = 0;
+    }
+
+    Cache mCache;
+
+    public PriorityGoalRow(Cache cache) {
+        super(cache);
+        mCache = cache;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return mNumGoals == 0;
+    }
+
+    static final int NOT_FOUND = -1;
+
+    @Override
+    public SolverVariable getPivotCandidate(LinearSystem system, boolean[] avoid) {
+        int pivot = NOT_FOUND;
+        for (int i = 0; i < mNumGoals; i++) {
+            SolverVariable variable = mArrayGoals[i];
+            if (avoid[variable.id]) {
+                continue;
+            }
+            mAccessor.init(variable);
+            if (pivot == NOT_FOUND) {
+                if (mAccessor.isNegative()) {
+                    pivot = i;
+                }
+            } else if (mAccessor.isSmallerThan(mArrayGoals[pivot])) {
+                pivot = i;
+            }
+        }
+        if (pivot == NOT_FOUND) {
+            return null;
+        }
+        return mArrayGoals[pivot];
+    }
+
+    @Override
+    public void addError(SolverVariable error) {
+        mAccessor.init(error);
+        mAccessor.reset();
+        error.mGoalStrengthVector[error.strength] = 1;
+        addToGoal(error);
+    }
+
+    private void addToGoal(SolverVariable variable) {
+        if (mNumGoals + 1 > mArrayGoals.length) {
+            mArrayGoals = Arrays.copyOf(mArrayGoals, mArrayGoals.length * 2);
+            mSortArray = Arrays.copyOf(mArrayGoals, mArrayGoals.length * 2);
+        }
+        mArrayGoals[mNumGoals] = variable;
+        mNumGoals++;
+
+        if (mNumGoals > 1 && mArrayGoals[mNumGoals - 1].id > variable.id) {
+            for (int i = 0; i < mNumGoals; i++) {
+                mSortArray[i] = mArrayGoals[i];
+            }
+            Arrays.sort(mSortArray, 0, mNumGoals, new Comparator<SolverVariable>() {
+                @Override
+                public int compare(SolverVariable variable1, SolverVariable variable2) {
+                    return variable1.id - variable2.id;
+                }
+            });
+            for (int i = 0; i < mNumGoals; i++) {
+                mArrayGoals[i] = mSortArray[i];
+            }
+        }
+
+        variable.inGoal = true;
+        variable.addToRow(this);
+    }
+
+    private void removeGoal(SolverVariable variable) {
+        for (int i = 0; i < mNumGoals; i++) {
+            if (mArrayGoals[i] == variable) {
+                for (int j = i; j < mNumGoals - 1; j++) {
+                    mArrayGoals[j] = mArrayGoals[j + 1];
+                }
+                mNumGoals--;
+                variable.inGoal = false;
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void updateFromRow(LinearSystem system,
+            ArrayRow definition,
+            boolean removeFromDefinition) {
+        SolverVariable goalVariable = definition.mVariable;
+        if (goalVariable == null) {
+            return;
+        }
+
+        ArrayRowVariables rowVariables = definition.variables;
+        int currentSize = rowVariables.getCurrentSize();
+        for (int i = 0; i < currentSize; i++) {
+            SolverVariable solverVariable = rowVariables.getVariable(i);
+            float value = rowVariables.getVariableValue(i);
+            mAccessor.init(solverVariable);
+            if (mAccessor.addToGoal(goalVariable, value)) {
+                addToGoal(solverVariable);
+            }
+            mConstantValue += definition.mConstantValue * value;
+        }
+        removeGoal(goalVariable);
+    }
+
+    @Override
+    public String toString() {
+        String result = "";
+        result += " goal -> (" + mConstantValue + ") : ";
+        for (int i = 0; i < mNumGoals; i++) {
+            SolverVariable v = mArrayGoals[i];
+            mAccessor.init(v);
+            result += mAccessor + " ";
+        }
+        return result;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/SolverVariable.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/SolverVariable.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+import static androidx.constraintlayout.core.LinearSystem.FULL_DEBUG;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Represents a given variable used in the {@link LinearSystem linear expression solver}.
+ */
+public class SolverVariable implements Comparable<SolverVariable> {
+
+    private static final boolean INTERNAL_DEBUG = FULL_DEBUG;
+    private static final boolean VAR_USE_HASH = false;
+    private static final boolean DO_NOT_USE = false;
+
+
+    @SuppressWarnings("WeakerAccess")
+    public static final int STRENGTH_NONE = 0;
+    public static final int STRENGTH_LOW = 1;
+    public static final int STRENGTH_MEDIUM = 2;
+    public static final int STRENGTH_HIGH = 3;
+    @SuppressWarnings("WeakerAccess")
+    public static final int STRENGTH_HIGHEST = 4;
+    public static final int STRENGTH_EQUALITY = 5;
+    public static final int STRENGTH_BARRIER = 6;
+    public static final int STRENGTH_CENTERING = 7;
+    public static final int STRENGTH_FIXED = 8;
+
+    private static int sUniqueSlackId = 1;
+    private static int sUniqueErrorId = 1;
+    private static int sUniqueUnrestrictedId = 1;
+    private static int sUniqueConstantId = 1;
+    private static int sUniqueId = 1;
+    public boolean inGoal;
+
+    private String mName;
+
+    public int id = -1;
+    int mDefinitionId = -1;
+    public int strength = 0;
+    public float computedValue;
+    public boolean isFinalValue = false;
+
+    static final int MAX_STRENGTH = 9;
+    float[] mStrengthVector = new float[MAX_STRENGTH];
+    float[] mGoalStrengthVector = new float[MAX_STRENGTH];
+
+    Type mType;
+
+    ArrayRow[] mClientEquations = new ArrayRow[16];
+    int mClientEquationsCount = 0;
+    public int usageInRowCount = 0;
+    boolean mIsSynonym = false;
+    int mSynonym = -1;
+    float mSynonymDelta = 0;
+
+    /**
+     * Type of variables
+     */
+    public enum Type {
+        /**
+         * The variable can take negative or positive values
+         */
+        UNRESTRICTED,
+        /**
+         * The variable is actually not a variable :) , but a constant number
+         */
+        CONSTANT,
+        /**
+         * The variable is restricted to positive values and represents a slack
+         */
+        SLACK,
+        /**
+         * The variable is restricted to positive values and represents an error
+         */
+        ERROR,
+        /**
+         * Unknown (invalid) type.
+         */
+        UNKNOWN
+    }
+
+    static void increaseErrorId() {
+        sUniqueErrorId++;
+    }
+
+    private static String getUniqueName(Type type, String prefix) {
+        if (prefix != null) {
+            return prefix + sUniqueErrorId;
+        }
+        switch (type) {
+            case UNRESTRICTED:
+                return "U" + ++sUniqueUnrestrictedId;
+            case CONSTANT:
+                return "C" + ++sUniqueConstantId;
+            case SLACK:
+                return "S" + ++sUniqueSlackId;
+            case ERROR: {
+                return "e" + ++sUniqueErrorId;
+            }
+            case UNKNOWN:
+                return "V" + ++sUniqueId;
+        }
+        throw new AssertionError(type.name());
+    }
+
+    /**
+     * Base constructor
+     *
+     * @param name the variable name
+     * @param type the type of the variable
+     */
+    public SolverVariable(String name, Type type) {
+        mName = name;
+        mType = type;
+    }
+
+    public SolverVariable(Type type, String prefix) {
+        mType = type;
+        if (INTERNAL_DEBUG) {
+            //mName = getUniqueName(type, prefix);
+        }
+    }
+
+    void clearStrengths() {
+        for (int i = 0; i < MAX_STRENGTH; i++) {
+            mStrengthVector[i] = 0;
+        }
+    }
+
+    String strengthsToString() {
+        String representation = this + "[";
+        boolean negative = false;
+        boolean empty = true;
+        for (int j = 0; j < mStrengthVector.length; j++) {
+            representation += mStrengthVector[j];
+            if (mStrengthVector[j] > 0) {
+                negative = false;
+            } else if (mStrengthVector[j] < 0) {
+                negative = true;
+            }
+            if (mStrengthVector[j] != 0) {
+                empty = false;
+            }
+            if (j < mStrengthVector.length - 1) {
+                representation += ", ";
+            } else {
+                representation += "] ";
+            }
+        }
+        if (negative) {
+            representation += " (-)";
+        }
+        if (empty) {
+            representation += " (*)";
+        }
+        // representation += " {id: " + id + "}";
+        return representation;
+    }
+
+    HashSet<ArrayRow> mInRows = VAR_USE_HASH ? new HashSet<ArrayRow>() : null;
+
+    // @TODO: add description
+    public final void addToRow(ArrayRow row) {
+        if (VAR_USE_HASH) {
+            mInRows.add(row);
+        } else {
+            for (int i = 0; i < mClientEquationsCount; i++) {
+                if (mClientEquations[i] == row) {
+                    return;
+                }
+            }
+            if (mClientEquationsCount >= mClientEquations.length) {
+                mClientEquations = Arrays.copyOf(mClientEquations, mClientEquations.length * 2);
+            }
+            mClientEquations[mClientEquationsCount] = row;
+            mClientEquationsCount++;
+        }
+    }
+
+    // @TODO: add description
+    public final void removeFromRow(ArrayRow row) {
+        if (VAR_USE_HASH) {
+            mInRows.remove(row);
+        } else {
+            final int count = mClientEquationsCount;
+            for (int i = 0; i < count; i++) {
+                if (mClientEquations[i] == row) {
+                    for (int j = i; j < count - 1; j++) {
+                        mClientEquations[j] = mClientEquations[j + 1];
+                    }
+                    mClientEquationsCount--;
+                    return;
+                }
+            }
+        }
+    }
+
+    // @TODO: add description
+    public final void updateReferencesWithNewDefinition(LinearSystem system, ArrayRow definition) {
+        if (VAR_USE_HASH) {
+            for (ArrayRow row : mInRows) {
+                row.updateFromRow(system, definition, false);
+            }
+            mInRows.clear();
+        } else {
+            final int count = mClientEquationsCount;
+            for (int i = 0; i < count; i++) {
+                mClientEquations[i].updateFromRow(system, definition, false);
+            }
+            mClientEquationsCount = 0;
+        }
+    }
+
+    // @TODO: add description
+    public void setFinalValue(LinearSystem system, float value) {
+        if (DO_NOT_USE && INTERNAL_DEBUG) {
+            System.out.println("Set final value for " + this + " of " + value);
+        }
+        computedValue = value;
+        isFinalValue = true;
+        mIsSynonym = false;
+        mSynonym = -1;
+        mSynonymDelta = 0;
+        final int count = mClientEquationsCount;
+        mDefinitionId = -1;
+        for (int i = 0; i < count; i++) {
+            mClientEquations[i].updateFromFinalVariable(system, this, false);
+        }
+        mClientEquationsCount = 0;
+    }
+
+    // @TODO: add description
+    public void setSynonym(LinearSystem system, SolverVariable synonymVariable, float value) {
+        if (INTERNAL_DEBUG) {
+            System.out.println("Set synonym for " + this + " = " + synonymVariable + " + " + value);
+        }
+        mIsSynonym = true;
+        mSynonym = synonymVariable.id;
+        mSynonymDelta = value;
+        final int count = mClientEquationsCount;
+        mDefinitionId = -1;
+        for (int i = 0; i < count; i++) {
+            mClientEquations[i].updateFromSynonymVariable(system, this, false);
+        }
+        mClientEquationsCount = 0;
+        system.displayReadableRows();
+    }
+
+    // @TODO: add description
+    public void reset() {
+        mName = null;
+        mType = Type.UNKNOWN;
+        strength = SolverVariable.STRENGTH_NONE;
+        id = -1;
+        mDefinitionId = -1;
+        computedValue = 0;
+        isFinalValue = false;
+        mIsSynonym = false;
+        mSynonym = -1;
+        mSynonymDelta = 0;
+        if (VAR_USE_HASH) {
+            mInRows.clear();
+        } else {
+            final int count = mClientEquationsCount;
+            for (int i = 0; i < count; i++) {
+                mClientEquations[i] = null;
+            }
+            mClientEquationsCount = 0;
+        }
+        usageInRowCount = 0;
+        inGoal = false;
+        Arrays.fill(mGoalStrengthVector, 0);
+    }
+
+    /**
+     * Accessor for the name
+     *
+     * @return the name of the variable
+     */
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    // @TODO: add description
+    public void setType(Type type, String prefix) {
+        mType = type;
+        if (INTERNAL_DEBUG && mName == null) {
+            mName = getUniqueName(type, prefix);
+        }
+    }
+
+    @Override
+    public int compareTo(SolverVariable v) {
+        return this.id - v.id;
+    }
+
+    /**
+     * Override the toString() method to display the variable
+     */
+    @Override
+    public String toString() {
+        String result = "";
+        if (INTERNAL_DEBUG) {
+            result += mName + "(" + id + "):" + strength;
+            if (mIsSynonym) {
+                result += ":S(" + mSynonym + ")";
+            }
+            if (isFinalValue) {
+                result += ":F(" + computedValue + ")";
+            }
+        } else {
+            if (mName != null) {
+                result += mName;
+            } else {
+                result += id;
+            }
+        }
+        return result;
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/SolverVariableValues.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/SolverVariableValues.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core;
+
+import java.util.Arrays;
+
+/**
+ * Store a set of variables and their values in an array-based linked list coupled
+ * with a custom hashmap.
+ */
+public class SolverVariableValues implements ArrayRow.ArrayRowVariables {
+
+    private static final boolean DEBUG = false;
+    @SuppressWarnings("unused") private static final boolean HASH = true;
+    private static float sEpsilon = 0.001f;
+    private final int mNone = -1;
+    private int mSize = 16;
+    private int mHashSize = 16;
+
+    int[] mKeys = new int[mSize];
+    int[] mNextKeys = new int[mSize];
+
+    int[] mVariables = new int[mSize];
+    float[] mValues = new float[mSize];
+    int[] mPrevious = new int[mSize];
+    int[] mNext = new int[mSize];
+    int mCount = 0;
+    int mHead = -1;
+
+    private final ArrayRow mRow; // our owner
+    // pointer to the system-wide cache, allowing access to SolverVariables
+    protected final Cache mCache;
+
+    SolverVariableValues(ArrayRow row, Cache cache) {
+        mRow = row;
+        mCache = cache;
+        clear();
+    }
+
+    @Override
+    public int getCurrentSize() {
+        return mCount;
+    }
+
+    @Override
+    public SolverVariable getVariable(int index) {
+        final int count = mCount;
+        if (count == 0) {
+            return null;
+        }
+        int j = mHead;
+        for (int i = 0; i < count; i++) {
+            if (i == index && j != mNone) {
+                return mCache.mIndexedVariables[mVariables[j]];
+            }
+            j = mNext[j];
+            if (j == mNone) {
+                break;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public float getVariableValue(int index) {
+        final int count = mCount;
+        int j = mHead;
+        for (int i = 0; i < count; i++) {
+            if (i == index) {
+                return mValues[j];
+            }
+            j = mNext[j];
+            if (j == mNone) {
+                break;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean contains(SolverVariable variable) {
+        return indexOf(variable) != mNone;
+    }
+
+    @Override
+    public int indexOf(SolverVariable variable) {
+        if (mCount == 0 || variable == null) {
+            return mNone;
+        }
+        int id = variable.id;
+        int key = id % mHashSize;
+        key = mKeys[key];
+        if (key == mNone) {
+            return mNone;
+        }
+        if (mVariables[key] == id) {
+            return key;
+        }
+        while (mNextKeys[key] != mNone && mVariables[mNextKeys[key]] != id) {
+            key = mNextKeys[key];
+        }
+        if (mNextKeys[key] == mNone) {
+            return mNone;
+        }
+        if (mVariables[mNextKeys[key]] == id) {
+            return mNextKeys[key];
+        }
+        return mNone;
+    }
+
+    @Override
+    public float get(SolverVariable variable) {
+        final int index = indexOf(variable);
+        if (index != mNone) {
+            return mValues[index];
+        }
+        return 0;
+    }
+
+    @Override
+    public void display() {
+        final int count = mCount;
+        System.out.print("{ ");
+        for (int i = 0; i < count; i++) {
+            SolverVariable v = getVariable(i);
+            if (v == null) {
+                continue;
+            }
+            System.out.print(v + " = " + getVariableValue(i) + " ");
+        }
+        System.out.println(" }");
+    }
+
+    @Override
+    public String toString() {
+        String str = hashCode() + " { ";
+        final int count = mCount;
+        for (int i = 0; i < count; i++) {
+            SolverVariable v = getVariable(i);
+            if (v == null) {
+                continue;
+            }
+            str += v + " = " + getVariableValue(i) + " ";
+            int index = indexOf(v);
+            str += "[p: ";
+            if (mPrevious[index] != mNone) {
+                str += mCache.mIndexedVariables[mVariables[mPrevious[index]]];
+            } else {
+                str += "none";
+            }
+            str += ", n: ";
+            if (mNext[index] != mNone) {
+                str += mCache.mIndexedVariables[mVariables[mNext[index]]];
+            } else {
+                str += "none";
+            }
+            str += "]";
+        }
+        str += " }";
+        return str;
+    }
+
+    @Override
+    public void clear() {
+        if (DEBUG) {
+            System.out.println(this + " <clear>");
+        }
+        final int count = mCount;
+        for (int i = 0; i < count; i++) {
+            SolverVariable v = getVariable(i);
+            if (v != null) {
+                v.removeFromRow(mRow);
+            }
+        }
+        for (int i = 0; i < mSize; i++) {
+            mVariables[i] = mNone;
+            mNextKeys[i] = mNone;
+        }
+        for (int i = 0; i < mHashSize; i++) {
+            mKeys[i] = mNone;
+        }
+        mCount = 0;
+        mHead = -1;
+    }
+
+    private void increaseSize() {
+        int size = this.mSize * 2;
+        mVariables = Arrays.copyOf(mVariables, size);
+        mValues = Arrays.copyOf(mValues, size);
+        mPrevious = Arrays.copyOf(mPrevious, size);
+        mNext = Arrays.copyOf(mNext, size);
+        mNextKeys = Arrays.copyOf(mNextKeys, size);
+        for (int i = this.mSize; i < size; i++) {
+            mVariables[i] = mNone;
+            mNextKeys[i] = mNone;
+        }
+        this.mSize = size;
+    }
+
+    private void addToHashMap(SolverVariable variable, int index) {
+        if (DEBUG) {
+            System.out.println(this.hashCode() + " hash add " + variable.id + " @ " + index);
+        }
+        int hash = variable.id % mHashSize;
+        int key = mKeys[hash];
+        if (key == mNone) {
+            mKeys[hash] = index;
+            if (DEBUG) {
+                System.out.println(this.hashCode() + " hash add "
+                        + variable.id + " @ " + index + " directly on keys " + hash);
+            }
+        } else {
+            while (mNextKeys[key] != mNone) {
+                key = mNextKeys[key];
+            }
+            mNextKeys[key] = index;
+            if (DEBUG) {
+                System.out.println(this.hashCode() + " hash add "
+                        + variable.id + " @ " + index + " as nextkey of " + key);
+            }
+        }
+        mNextKeys[index] = mNone;
+        if (DEBUG) {
+            displayHash();
+        }
+    }
+
+    private void displayHash() {
+        for (int i = 0; i < mHashSize; i++) {
+            if (mKeys[i] != mNone) {
+                String str = this.hashCode() + " hash [" + i + "] => ";
+                int key = mKeys[i];
+                boolean done = false;
+                while (!done) {
+                    str += " " + mVariables[key];
+                    if (mNextKeys[key] != mNone) {
+                        key = mNextKeys[key];
+                    } else {
+                        done = true;
+                    }
+                }
+                System.out.println(str);
+            }
+        }
+    }
+
+    private void removeFromHashMap(SolverVariable variable) {
+        if (DEBUG) {
+            System.out.println(this.hashCode() + " hash remove " + variable.id);
+        }
+        int hash = variable.id % mHashSize;
+        int key = mKeys[hash];
+        if (key == mNone) {
+            if (DEBUG) {
+                displayHash();
+            }
+            return;
+        }
+        int id = variable.id;
+        // let's first find it
+        if (mVariables[key] == id) {
+            mKeys[hash] = mNextKeys[key];
+            mNextKeys[key] = mNone;
+        } else {
+            while (mNextKeys[key] != mNone && mVariables[mNextKeys[key]] != id) {
+                key = mNextKeys[key];
+            }
+            int currentKey = mNextKeys[key];
+            if (currentKey != mNone && mVariables[currentKey] == id) {
+                mNextKeys[key] = mNextKeys[currentKey];
+                mNextKeys[currentKey] = mNone;
+            }
+        }
+        if (DEBUG) {
+            displayHash();
+        }
+    }
+
+    private void addVariable(int index, SolverVariable variable, float value) {
+        mVariables[index] = variable.id;
+        mValues[index] = value;
+        mPrevious[index] = mNone;
+        mNext[index] = mNone;
+        variable.addToRow(mRow);
+        variable.usageInRowCount++;
+        mCount++;
+    }
+
+    private int findEmptySlot() {
+        for (int i = 0; i < mSize; i++) {
+            if (mVariables[i] == mNone) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void insertVariable(int index, SolverVariable variable, float value) {
+        int availableSlot = findEmptySlot();
+        addVariable(availableSlot, variable, value);
+        if (index != mNone) {
+            mPrevious[availableSlot] = index;
+            mNext[availableSlot] = mNext[index];
+            mNext[index] = availableSlot;
+        } else {
+            mPrevious[availableSlot] = mNone;
+            if (mCount > 0) {
+                mNext[availableSlot] = mHead;
+                mHead = availableSlot;
+            } else {
+                mNext[availableSlot] = mNone;
+            }
+        }
+        if (mNext[availableSlot] != mNone) {
+            mPrevious[mNext[availableSlot]] = availableSlot;
+        }
+        addToHashMap(variable, availableSlot);
+    }
+
+    @Override
+    public void put(SolverVariable variable, float value) {
+        if (DEBUG) {
+            System.out.println(this + " <put> " + variable.id + " = " + value);
+        }
+        if (value > -sEpsilon && value < sEpsilon) {
+            remove(variable, true);
+            return;
+        }
+        if (mCount == 0) {
+            addVariable(0, variable, value);
+            addToHashMap(variable, 0);
+            mHead = 0;
+        } else {
+            final int index = indexOf(variable);
+            if (index != mNone) {
+                mValues[index] = value;
+            } else {
+                if (mCount + 1 >= mSize) {
+                    increaseSize();
+                }
+                final int count = mCount;
+                int previousItem = -1;
+                int j = mHead;
+                for (int i = 0; i < count; i++) {
+                    if (mVariables[j] == variable.id) {
+                        mValues[j] = value;
+                        return;
+                    }
+                    if (mVariables[j] < variable.id) {
+                        previousItem = j;
+                    }
+                    j = mNext[j];
+                    if (j == mNone) {
+                        break;
+                    }
+                }
+                insertVariable(previousItem, variable, value);
+            }
+        }
+    }
+
+    @Override
+    public int sizeInBytes() {
+        return 0;
+    }
+
+    @Override
+    public float remove(SolverVariable v, boolean removeFromDefinition) {
+        if (DEBUG) {
+            System.out.println(this + " <remove> " + v.id);
+        }
+        int index = indexOf(v);
+        if (index == mNone) {
+            return 0;
+        }
+        removeFromHashMap(v);
+        float value = mValues[index];
+        if (mHead == index) {
+            mHead = mNext[index];
+        }
+        mVariables[index] = mNone;
+        if (mPrevious[index] != mNone) {
+            mNext[mPrevious[index]] = mNext[index];
+        }
+        if (mNext[index] != mNone) {
+            mPrevious[mNext[index]] = mPrevious[index];
+        }
+        mCount--;
+        v.usageInRowCount--;
+        if (removeFromDefinition) {
+            v.removeFromRow(mRow);
+        }
+        return value;
+    }
+
+    @Override
+    public void add(SolverVariable v, float value, boolean removeFromDefinition) {
+        if (DEBUG) {
+            System.out.println(this + " <add> " + v.id + " = " + value);
+        }
+        if (value > -sEpsilon && value < sEpsilon) {
+            return;
+        }
+        final int index = indexOf(v);
+        if (index == mNone) {
+            put(v, value);
+        } else {
+            mValues[index] += value;
+            if (mValues[index] > -sEpsilon && mValues[index] < sEpsilon) {
+                mValues[index] = 0;
+                remove(v, removeFromDefinition);
+            }
+        }
+    }
+
+    @Override
+    public float use(ArrayRow definition, boolean removeFromDefinition) {
+        float value = get(definition.mVariable);
+        remove(definition.mVariable, removeFromDefinition);
+        if (false) {
+            ArrayRow.ArrayRowVariables definitionVariables = definition.variables;
+            int definitionSize = definitionVariables.getCurrentSize();
+            for (int i = 0; i < definitionSize; i++) {
+                SolverVariable definitionVariable = definitionVariables.getVariable(i);
+                float definitionValue = definitionVariables.get(definitionVariable);
+                this.add(definitionVariable, definitionValue * value, removeFromDefinition);
+            }
+            return value;
+        }
+        SolverVariableValues localDef = (SolverVariableValues) definition.variables;
+        final int definitionSize = localDef.getCurrentSize();
+        int j = localDef.mHead;
+        if (false) {
+            for (int i = 0; i < definitionSize; i++) {
+                float definitionValue = localDef.mValues[j];
+                SolverVariable definitionVariable =
+                        mCache.mIndexedVariables[localDef.mVariables[j]];
+                add(definitionVariable, definitionValue * value, removeFromDefinition);
+                j = localDef.mNext[j];
+                if (j == mNone) {
+                    break;
+                }
+            }
+        } else {
+            j = 0;
+            for (int i = 0; j < definitionSize; i++) {
+                if (localDef.mVariables[i] != mNone) {
+                    float definitionValue = localDef.mValues[i];
+                    SolverVariable definitionVariable =
+                            mCache.mIndexedVariables[localDef.mVariables[i]];
+                    add(definitionVariable, definitionValue * value, removeFromDefinition);
+                    j++;
+                }
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public void invert() {
+        final int count = mCount;
+        int j = mHead;
+        for (int i = 0; i < count; i++) {
+            mValues[j] *= -1;
+            j = mNext[j];
+            if (j == mNone) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void divideByAmount(float amount) {
+        final int count = mCount;
+        int j = mHead;
+        for (int i = 0; i < count; i++) {
+            mValues[j] /= amount;
+            j = mNext[j];
+            if (j == mNone) {
+                break;
+            }
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Barrier.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Barrier.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+
+public class Barrier extends Helper {
+    private Constraint.Side mDirection = null;
+    private int mMargin = Integer.MIN_VALUE;
+    private ArrayList<Ref> references = new ArrayList<>();
+
+    public Barrier(String name) {
+        super(name, new HelperType(typeMap.get(Type.BARRIER)));
+    }
+
+    public Barrier(String name, String config) {
+        super(name, new HelperType(typeMap.get(Type.BARRIER)), config);
+        configMap = convertConfigToMap();
+        if (configMap.containsKey("contains")) {
+            Ref.addStringToReferences(configMap.get("contains"), references);
+        }
+    }
+
+    /**
+     * Get the direction of the Barrier
+     *
+     * @return direction
+     */
+    public Constraint.Side getDirection() {
+        return mDirection;
+    }
+
+    /**
+     * Set the direction of the Barrier
+     *
+     * @param direction
+     */
+    public void setDirection(Constraint.Side direction) {
+        mDirection = direction;
+        configMap.put("direction", sideMap.get(direction));
+    }
+
+    /**
+     * Get the margin of the Barrier
+     *
+     * @return margin
+     */
+    public int getMargin() {
+        return mMargin;
+    }
+
+    /**
+     * Set the margin of the Barrier
+     *
+     * @param margin
+     */
+    public void setMargin(int margin) {
+        mMargin = margin;
+        configMap.put("margin", String.valueOf(margin));
+    }
+
+    /**
+     * Convert references into a String representation
+     *
+     * @return a String representation of references
+     */
+    public String referencesToString() {
+        if (references.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder("[");
+        for (Ref ref : references) {
+            builder.append(ref.toString());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Add a new reference
+     *
+     * @param ref reference
+     * @return Barrier
+     */
+    public Barrier addReference(Ref ref) {
+        references.add(ref);
+        configMap.put("contains", referencesToString());
+        return this;
+    }
+
+    /**
+     * Add a new reference
+     *
+     * @param ref reference in a String representation
+     * @return Chain
+     */
+    public Barrier addReference(String ref) {
+        return addReference(Ref.parseStringToRef(ref));
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Chain.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Chain.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class Chain extends Helper {
+    public enum Style {
+        PACKED,
+        SPREAD,
+        SPREAD_INSIDE
+    }
+
+    private Style mStyle = null;
+    protected ArrayList<Ref> references = new ArrayList<>();
+    final static protected Map<Style, String> styleMap = new HashMap<>();
+    static {
+        styleMap.put(Style.SPREAD, "'spread'");
+        styleMap.put(Style.SPREAD_INSIDE, "'spread_inside'");
+        styleMap.put(Style.PACKED, "'packed'");
+    }
+
+    public Chain(String name) {
+        super(name, new HelperType(""));
+    }
+
+    public Style getStyle() {
+        return mStyle;
+    }
+
+    public void setStyle(Style style) {
+        mStyle = style;
+        configMap.put("style", styleMap.get(style));
+    }
+
+    /**
+     * convert references to a String representation
+     *
+     * @return a String representation of references
+     */
+    public String referencesToString() {
+        if (references.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder("[");
+        for (Ref ref : references) {
+            builder.append(ref.toString());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Add a new reference
+     *
+     * @param ref reference
+     * @return Chain
+     */
+    public Chain addReference(Ref ref) {
+        references.add(ref);
+        configMap.put("contains", referencesToString());
+        return this;
+    }
+
+    /**
+     * Add a new reference
+     *
+     * @param ref reference in a String representation
+     * @return Chain
+     */
+    public Chain addReference(String ref) {
+        return addReference(Ref.parseStringToRef(ref));
+    }
+
+    public class Anchor {
+        final Constraint.Side mSide;
+        Constraint.Anchor mConnection = null;
+        int mMargin;
+        int mGoneMargin = Integer.MIN_VALUE;
+
+        Anchor(Constraint.Side side) {
+            mSide = side;
+        }
+
+        public String getId() {
+            return name;
+        }
+
+        public void build(StringBuilder builder) {
+            if (mConnection != null) {
+                builder.append(mSide.toString().toLowerCase())
+                        .append(":").append(this).append(",\n");
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder ret = new StringBuilder("[");
+
+            if (mConnection != null) {
+                ret.append("'").append(mConnection.getId()).append("',")
+                        .append("'").append(mConnection.mSide.toString().toLowerCase()).append("'");
+            }
+
+            if (mMargin != 0) {
+                ret.append(",").append(mMargin);
+            }
+
+            if (mGoneMargin != Integer.MIN_VALUE) {
+                if ( mMargin == 0) {
+                    ret.append(",0,").append(mGoneMargin);
+                } else {
+                    ret.append(",").append(mGoneMargin);
+                }
+            }
+            ret.append("]");
+            return ret.toString();
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Constraint.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Constraint.java
@@ -1,0 +1,1047 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides the API for creating a Constraint Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ */
+public class Constraint {
+
+    private final String mId;
+    public static final Constraint PARENT = new Constraint("parent");
+
+    public Constraint(String id) {
+        mId = id;
+    }
+
+    public class VAnchor extends Anchor {
+        VAnchor(VSide side) {
+            super(Side.valueOf(side.name()));
+        }
+    }
+
+    public class HAnchor extends Anchor {
+        HAnchor(HSide side) {
+            super(Side.valueOf(side.name()));
+        }
+    }
+
+    public class Anchor {
+        final Side mSide;
+        Anchor mConnection = null;
+        int mMargin;
+        int mGoneMargin = Integer.MIN_VALUE;
+
+        Anchor(Side side) {
+            mSide = side;
+        }
+
+        public String getId() {
+            return mId;
+        }
+
+        Constraint getParent() {
+            return Constraint.this;
+        }
+
+        public void build(StringBuilder builder) {
+            if (mConnection != null) {
+                builder.append(mSide.toString().toLowerCase())
+                        .append(":").append(this).append(",\n");
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder ret = new StringBuilder("[");
+
+            if (mConnection != null) {
+                ret.append("'").append(mConnection.getId()).append("',")
+                        .append("'").append(mConnection.mSide.toString().toLowerCase()).append("'");
+            }
+
+            if (mMargin != 0) {
+                ret.append(",").append(mMargin);
+            }
+
+            if (mGoneMargin != Integer.MIN_VALUE) {
+                if ( mMargin == 0) {
+                    ret.append(",0,").append(mGoneMargin);
+                } else {
+                    ret.append(",").append(mGoneMargin);
+                }
+            }
+
+            ret.append("]");
+            return ret.toString();
+        }
+    }
+
+    public enum Behaviour {
+        SPREAD,
+        WRAP,
+        PERCENT,
+        RATIO,
+        RESOLVED,
+    }
+
+    public enum ChainMode {
+        SPREAD,
+        SPREAD_INSIDE,
+        PACKED,
+    }
+
+    public enum VSide {
+        TOP,
+        BOTTOM,
+        BASELINE
+    }
+
+    public enum HSide {
+        LEFT,
+        RIGHT,
+        START,
+        END
+    }
+
+    public enum Side {
+        LEFT,
+        RIGHT,
+        TOP,
+        BOTTOM,
+        START,
+        END,
+        BASELINE
+    }
+
+    static int UNSET = Integer.MIN_VALUE;
+    static Map<ChainMode, String> chainModeMap = new HashMap<>();
+    static {
+        chainModeMap.put(ChainMode.SPREAD, "spread");
+        chainModeMap.put(ChainMode.SPREAD_INSIDE, "spread_inside");
+        chainModeMap.put(ChainMode.PACKED, "packed");
+    }
+
+    String helperType = null;
+    String helperJason = null;
+
+    private HAnchor mLeft = new HAnchor(HSide.LEFT);
+    private HAnchor mRight = new HAnchor(HSide.RIGHT);
+    private VAnchor mTop = new VAnchor(VSide.TOP);
+    private VAnchor mBottom = new VAnchor(VSide.BOTTOM);
+    private HAnchor mStart = new HAnchor(HSide.START);
+    private HAnchor mEnd = new HAnchor(HSide.END);
+    private VAnchor mBaseline = new VAnchor(VSide.BASELINE);
+    private int mWidth = UNSET;
+    private int mHeight = UNSET;
+    private float mHorizontalBias = Float.NaN;
+    private float mVerticalBias = Float.NaN;
+    private String mDimensionRatio = null;
+    private String mCircleConstraint = null;
+    private int mCircleRadius = Integer.MIN_VALUE;
+    private float mCircleAngle = Float.NaN;
+    private int mEditorAbsoluteX = Integer.MIN_VALUE;
+    private int mEditorAbsoluteY = Integer.MIN_VALUE;
+    private float mVerticalWeight = Float.NaN;
+    private float mHorizontalWeight = Float.NaN;
+    private ChainMode mHorizontalChainStyle = null;
+    private ChainMode mVerticalChainStyle = null;
+    private Behaviour mWidthDefault = null;
+    private Behaviour mHeightDefault = null;
+    private int mWidthMax = UNSET;
+    private int mHeightMax = UNSET;
+    private int mWidthMin = UNSET;
+    private int mHeightMin = UNSET;
+    private float mWidthPercent = Float.NaN;
+    private float mHeightPercent = Float.NaN;
+    private String[] mReferenceIds = null;
+    private boolean mConstrainedWidth = false;
+    private boolean mConstrainedHeight = false;
+
+    /**
+     * get left anchor
+     *
+     * @return left anchor
+     */
+    public HAnchor getLeft() {
+        return mLeft;
+    }
+
+    /**
+     * get right anchor
+     *
+     * @return right anchor
+     */
+    public HAnchor getRight() {
+        return mRight;
+    }
+
+    /**
+     * get top anchor
+     *
+     * @return top anchor
+     */
+    public VAnchor getTop() {
+        return mTop;
+    }
+
+    /**
+     * get bottom anchor
+     *
+     * @return bottom anchor
+     */
+    public VAnchor getBottom() {
+        return mBottom;
+    }
+
+    /**
+     * get start anchor
+     *
+     * @return start anchor
+     */
+    public HAnchor getStart() {
+        return mStart;
+    }
+
+    /**
+     * get end anchor
+     *
+     * @return end anchor
+     */
+    public HAnchor getEnd() {
+        return mEnd;
+    }
+
+    /**
+     * get baseline anchor
+     *
+     * @return baseline anchor
+     */
+    public VAnchor getBaseline() {
+        return mBaseline;
+    }
+
+    /**
+     * get horizontalBias
+     *
+     * @return horizontalBias
+     */
+    public float getHorizontalBias() {
+        return mHorizontalBias;
+    }
+
+    /**
+     * set horizontalBias
+     *
+     * @param horizontalBias
+     */
+    public void setHorizontalBias(float horizontalBias) {
+        this.mHorizontalBias = horizontalBias;
+    }
+
+    /**
+     * get verticalBias
+     *
+     * @return verticalBias
+     */
+    public float getVerticalBias() {
+        return mVerticalBias;
+    }
+
+    /**
+     * set verticalBias
+     *
+     * @param verticalBias
+     */
+    public void setVerticalBias(float verticalBias) {
+        this.mVerticalBias = verticalBias;
+    }
+
+    /**
+     * get dimensionRatio
+     *
+     * @return dimensionRatio
+     */
+    public String getDimensionRatio() {
+        return mDimensionRatio;
+    }
+
+    /**
+     * set dimensionRatio
+     *
+     * @param dimensionRatio
+     */
+    public void setDimensionRatio(String dimensionRatio) {
+        this.mDimensionRatio = dimensionRatio;
+    }
+
+    /**
+     * get circleConstraint
+     *
+     * @return circleConstraint
+     */
+    public String getCircleConstraint() {
+        return mCircleConstraint;
+    }
+
+    /**
+     * set circleConstraint
+     *
+     * @param circleConstraint
+     */
+    public void setCircleConstraint(String circleConstraint) {
+        this.mCircleConstraint = circleConstraint;
+    }
+
+    /**
+     * get circleRadius
+     *
+     * @return circleRadius
+     */
+    public int getCircleRadius() {
+        return mCircleRadius;
+    }
+
+    /**
+     * set circleRadius
+     *
+     * @param circleRadius
+     */
+    public void setCircleRadius(int circleRadius) {
+        this.mCircleRadius = circleRadius;
+    }
+
+    /**
+     * get circleAngle
+     *
+     * @return circleAngle
+     */
+    public float getCircleAngle() {
+        return mCircleAngle;
+    }
+
+    /**
+     * set circleAngle
+     *
+     * @param circleAngle
+     */
+    public void setCircleAngle(float circleAngle) {
+        this.mCircleAngle = circleAngle;
+    }
+
+    /**
+     * get editorAbsoluteX
+     * @return editorAbsoluteX
+     */
+    public int getEditorAbsoluteX() {
+        return mEditorAbsoluteX;
+    }
+
+    /**
+     * set editorAbsoluteX
+     * @param editorAbsoluteX
+     */
+    public void setEditorAbsoluteX(int editorAbsoluteX) {
+        mEditorAbsoluteX = editorAbsoluteX;
+    }
+
+    /**
+     * get editorAbsoluteY
+     * @return editorAbsoluteY
+     */
+    public int getEditorAbsoluteY() {
+        return mEditorAbsoluteY;
+    }
+
+    /**
+     * set editorAbsoluteY
+     * @param editorAbsoluteY
+     */
+    public void setEditorAbsoluteY(int editorAbsoluteY) {
+        mEditorAbsoluteY = editorAbsoluteY;
+    }
+
+    /**
+     * get verticalWeight
+     *
+     * @return verticalWeight
+     */
+    public float getVerticalWeight() {
+        return mVerticalWeight;
+    }
+
+    /**
+     * set verticalWeight
+     *
+     * @param verticalWeight
+     */
+    public void setVerticalWeight(float verticalWeight) {
+        this.mVerticalWeight = verticalWeight;
+    }
+
+    /**
+     * get horizontalWeight
+     *
+     * @return horizontalWeight
+     */
+    public float getHorizontalWeight() {
+        return mHorizontalWeight;
+    }
+
+    /**
+     * set horizontalWeight
+     *
+     * @param horizontalWeight
+     */
+    public void setHorizontalWeight(float horizontalWeight) {
+        this.mHorizontalWeight = horizontalWeight;
+    }
+
+    /**
+     * get horizontalChainStyle
+     *
+     * @return horizontalChainStyle
+     */
+    public ChainMode getHorizontalChainStyle() {
+        return mHorizontalChainStyle;
+    }
+
+    /**
+     * set horizontalChainStyle
+     *
+     * @param horizontalChainStyle
+     */
+    public void setHorizontalChainStyle(
+            ChainMode horizontalChainStyle) {
+        this.mHorizontalChainStyle = horizontalChainStyle;
+    }
+
+    /**
+     * get verticalChainStyle
+     *
+     * @return verticalChainStyle
+     */
+    @SuppressWarnings("HiddenTypeParameter")
+    public ChainMode getVerticalChainStyle() {
+        return mVerticalChainStyle;
+    }
+
+    /**
+     * set verticalChainStyle
+     *
+     * @param verticalChainStyle
+     */
+    public void setVerticalChainStyle(
+            @SuppressWarnings("HiddenTypeParameter") ChainMode verticalChainStyle) {
+        this.mVerticalChainStyle = verticalChainStyle;
+    }
+
+    /**
+     * get widthDefault
+     *
+     * @return widthDefault
+     */
+    @SuppressWarnings("HiddenTypeParameter")
+    public Behaviour getWidthDefault() {
+        return mWidthDefault;
+    }
+
+    /**
+     * set widthDefault
+     *
+     * @param widthDefault
+     */
+    public void setWidthDefault(@SuppressWarnings("HiddenTypeParameter")
+            Behaviour widthDefault) {
+        this.mWidthDefault = widthDefault;
+    }
+
+    /**
+     * get heightDefault
+     *
+     * @return heightDefault
+     */
+    @SuppressWarnings("HiddenTypeParameter")
+    public Behaviour getHeightDefault() {
+        return mHeightDefault;
+    }
+
+    /**
+     * set heightDefault
+     *
+     * @param heightDefault
+     */
+    public void setHeightDefault(@SuppressWarnings("HiddenTypeParameter")
+            Behaviour heightDefault) {
+        this.mHeightDefault = heightDefault;
+    }
+
+    /**
+     * get widthMax
+     *
+     * @return widthMax
+     */
+    public int getWidthMax() {
+        return mWidthMax;
+    }
+
+    /**
+     * set widthMax
+     *
+     * @param widthMax
+     */
+    public void setWidthMax(int widthMax) {
+        this.mWidthMax = widthMax;
+    }
+
+    /**
+     * get heightMax
+     *
+     * @return heightMax
+     */
+    public int getHeightMax() {
+        return mHeightMax;
+    }
+
+    /**
+     * set heightMax
+     *
+     * @param heightMax
+     */
+    public void setHeightMax(int heightMax) {
+        this.mHeightMax = heightMax;
+    }
+
+    /**
+     * get widthMin
+     *
+     * @return widthMin
+     */
+    public int getWidthMin() {
+        return mWidthMin;
+    }
+
+    /**
+     * set widthMin
+     *
+     * @param widthMin
+     */
+    public void setWidthMin(int widthMin) {
+        this.mWidthMin = widthMin;
+    }
+
+    /**
+     * get heightMin
+     *
+     * @return heightMin
+     */
+    public int getHeightMin() {
+        return mHeightMin;
+    }
+
+    /**
+     * set heightMin
+     *
+     * @param heightMin
+     */
+    public void setHeightMin(int heightMin) {
+        this.mHeightMin = heightMin;
+    }
+
+    /**
+     * get widthPercent
+     *
+     * @return
+     */
+    public float getWidthPercent() {
+        return mWidthPercent;
+    }
+
+    /**
+     * set widthPercent
+     *
+     * @param widthPercent
+     */
+    public void setWidthPercent(float widthPercent) {
+        this.mWidthPercent = widthPercent;
+    }
+
+    /**
+     * get heightPercent
+     *
+     * @return heightPercent
+     */
+    public float getHeightPercent() {
+        return mHeightPercent;
+    }
+
+    /**
+     * set heightPercent
+     *
+     * @param heightPercent
+     */
+    public void setHeightPercent(float heightPercent) {
+        this.mHeightPercent = heightPercent;
+    }
+
+    /**
+     * get referenceIds
+     *
+     * @return referenceIds
+     */
+    public String[] getReferenceIds() {
+        return mReferenceIds;
+    }
+
+    /**
+     * set referenceIds
+     *
+     * @param referenceIds
+     */
+    public void setReferenceIds(String[] referenceIds) {
+        mReferenceIds = referenceIds;
+    }
+
+    /**
+     * is constrainedWidth
+     *
+     * @return true if width constrained
+     */
+    public boolean isConstrainedWidth() {
+        return mConstrainedWidth;
+    }
+
+    /**
+     * set constrainedWidth
+     *
+     * @param constrainedWidth
+     */
+    public void setConstrainedWidth(boolean constrainedWidth) {
+        this.mConstrainedWidth = constrainedWidth;
+    }
+
+    /**
+     * is constrainedHeight
+     *
+     * @return true if height constrained
+     */
+    public boolean isConstrainedHeight() {
+        return mConstrainedHeight;
+    }
+
+    /**
+     * set constrainedHeight
+     *
+     * @param constrainedHeight
+     */
+    public void setConstrainedHeight(boolean constrainedHeight) {
+        this.mConstrainedHeight = constrainedHeight;
+    }
+
+    /**
+     * get width
+     * @return width
+     */
+    public int getWidth() {
+        return mWidth;
+    }
+
+    /**
+     * set width
+     *
+     * @param width
+     */
+    public void setWidth(int width) {
+        mWidth = width;
+    }
+
+    /**
+     * get height
+     * @return height
+     */
+    public int getHeight() {
+        return mHeight;
+    }
+
+    /**
+     * set height
+     *
+     * @param height
+     */
+    public void setHeight(int height) {
+        mHeight = height;
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToTop(VAnchor anchor) {
+        linkToTop(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToLeft(HAnchor anchor) {
+        linkToLeft(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToRight(HAnchor anchor) {
+        linkToRight(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToStart(HAnchor anchor) {
+        linkToStart(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToEnd(HAnchor anchor) {
+        linkToEnd(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToBottom(VAnchor anchor) {
+        linkToBottom(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToBaseline(VAnchor anchor) {
+        linkToBaseline(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToTop(VAnchor anchor, int margin) {
+        linkToTop(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToLeft(HAnchor anchor, int margin) {
+        linkToLeft(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToRight(HAnchor anchor, int margin) {
+        linkToRight(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToStart(HAnchor anchor, int margin) {
+        linkToStart(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToEnd(HAnchor anchor, int margin) {
+        linkToEnd(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToBottom(VAnchor anchor, int margin) {
+        linkToBottom(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToBaseline(VAnchor anchor, int margin) {
+        linkToBaseline(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToTop(VAnchor anchor, int margin, int goneMargin) {
+        mTop.mConnection = anchor;
+        mTop.mMargin = margin;
+        mTop.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToLeft(HAnchor anchor, int margin, int goneMargin) {
+        mLeft.mConnection = anchor;
+        mLeft.mMargin = margin;
+        mLeft.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToRight(HAnchor anchor, int margin, int goneMargin) {
+        mRight.mConnection = anchor;
+        mRight.mMargin = margin;
+        mRight.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToStart(HAnchor anchor, int margin, int goneMargin) {
+        mStart.mConnection = anchor;
+        mStart.mMargin = margin;
+        mStart.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToEnd(HAnchor anchor, int margin, int goneMargin) {
+        mEnd.mConnection = anchor;
+        mEnd.mMargin = margin;
+        mEnd.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToBottom(VAnchor anchor, int margin, int goneMargin) {
+        mBottom.mConnection = anchor;
+        mBottom.mMargin = margin;
+        mBottom.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToBaseline(VAnchor anchor, int margin, int goneMargin) {
+        mBaseline.mConnection = anchor;
+        mBaseline.mMargin = margin;
+        mBaseline.mGoneMargin = goneMargin;
+    }
+
+    /**
+     * convert a String array into a String representation
+     *
+     * @param str String array to be converted
+     * @return a String representation of the input array.
+     */
+    public String convertStringArrayToString(String[] str) {
+        StringBuilder ret = new StringBuilder("[");
+        for (int i = 0; i < str.length; i++) {
+
+            ret.append((i == 0) ? "'" : ",'");
+
+            ret.append(str[i]);
+            ret.append("'");
+
+        }
+        ret.append("]");
+        return ret.toString();
+    }
+
+    protected void append(StringBuilder builder, String name, float value) {
+        if (Float.isNaN(value)) {
+            return;
+        }
+        builder.append(name);
+        builder.append(":").append(value).append(",\n");
+
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder(mId + ":{\n");
+        mLeft.build(ret);
+        mRight.build(ret);
+        mTop.build(ret);
+        mBottom.build(ret);
+        mStart.build(ret);
+        mEnd.build(ret);
+        mBaseline.build(ret);
+
+        if (mWidth != UNSET) {
+            ret.append("width:").append(mWidth).append(",\n");
+        }
+        if (mHeight != UNSET) {
+            ret.append("height:").append(mHeight).append(",\n");
+        }
+        append(ret, "horizontalBias", mHorizontalBias);
+        append(ret, "verticalBias", mVerticalBias);
+        if (mDimensionRatio != null) {
+            ret.append("dimensionRatio:'").append(mDimensionRatio).append("',\n");
+        }
+        if (mCircleConstraint != null) {
+            if (!Float.isNaN(mCircleAngle) || mCircleRadius != Integer.MIN_VALUE) {
+                ret.append("circular:['").append(mCircleConstraint).append("'");
+                if (!Float.isNaN(mCircleAngle)) {
+                    ret.append(",").append(mCircleAngle);
+                }
+                if (mCircleRadius != Integer.MIN_VALUE) {
+                    if (Float.isNaN(mCircleAngle)) {
+                        ret.append(",0,").append(mCircleRadius);
+                    } else {
+                        ret.append(",").append(mCircleRadius);
+                    }
+                }
+                ret.append("],\n");
+            }
+        }
+        append(ret, "verticalWeight", mVerticalWeight);
+        append(ret, "horizontalWeight", mHorizontalWeight);
+        if (mHorizontalChainStyle != null) {
+            ret.append("horizontalChainStyle:'").append(chainModeMap.get(mHorizontalChainStyle))
+                    .append("',\n");
+        }
+        if (mVerticalChainStyle != null) {
+            ret.append("verticalChainStyle:'").append(chainModeMap.get(mVerticalChainStyle))
+                    .append("',\n");
+        }
+        if (mWidthDefault != null) {
+            if (mWidthMax == UNSET && mWidthMin == UNSET) {
+                ret.append("width:'").append(mWidthDefault.toString().toLowerCase())
+                        .append("',\n");
+            } else {
+                ret.append("width:{value:'").append(mWidthDefault.toString().toLowerCase())
+                        .append("'");
+                if (mWidthMax != UNSET) {
+                    ret.append(",max:").append(mWidthMax);
+                }
+                if (mWidthMin != UNSET) {
+                    ret.append(",min:").append(mWidthMin);
+                }
+                ret.append("},\n");
+            }
+        }
+        if (mHeightDefault != null) {
+            if (mHeightMax == UNSET && mHeightMin == UNSET) {
+                ret.append("height:'").append(mHeightDefault.toString().toLowerCase())
+                        .append("',\n");
+            } else {
+                ret.append("height:{value:'").append(mHeightDefault.toString().toLowerCase())
+                        .append("'");
+                if (mHeightMax != UNSET) {
+                    ret.append(",max:").append(mHeightMax);
+                }
+                if (mHeightMin != UNSET) {
+                    ret.append(",min:").append(mHeightMin);
+                }
+                ret.append("},\n");
+            }
+        }
+        if (!Double.isNaN(mWidthPercent)) {
+            ret.append("width:'").append((int) mWidthPercent).append("%',\n");
+        }
+        if (!Double.isNaN(mHeightPercent)) {
+            ret.append("height:'").append((int) mHeightPercent).append("%',\n");
+        }
+        if (mReferenceIds != null) {
+            ret.append("referenceIds:")
+                    .append(convertStringArrayToString(mReferenceIds))
+                    .append(",\n");
+        }
+        if (mConstrainedWidth) {
+            ret.append("constrainedWidth:").append(mConstrainedWidth).append(",\n");
+        }
+        if (mConstrainedHeight) {
+            ret.append("constrainedHeight:").append(mConstrainedHeight).append(",\n");
+        }
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/ConstraintSet.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/ConstraintSet.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+
+/**
+ * Provides the API for creating a ConstraintSet Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ */
+public class ConstraintSet {
+    private final String mName;
+    ArrayList<Constraint> mConstraints = new ArrayList<>();
+    ArrayList<Helper> mHelpers = new ArrayList<>();
+
+    public ConstraintSet(String name) {
+        mName = name;
+    }
+
+    public void add(Constraint c) {
+        mConstraints.add(c);
+    }
+
+    public void add(Helper h) {
+        mHelpers.add(h);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder(mName + ":{\n");
+        if (!mConstraints.isEmpty()) {
+            for (Constraint cs: mConstraints) {
+                ret.append(cs.toString());
+            }
+        }
+
+        if (!mHelpers.isEmpty()) {
+            for (Helper h: mHelpers) {
+                ret.append(h.toString());
+            }
+        }
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Guideline.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Guideline.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+public abstract class Guideline extends Helper {
+    private int mStart = Integer.MIN_VALUE;
+    private int mEnd = Integer.MIN_VALUE;
+    private float mPercent = Float.NaN;
+
+    Guideline(String name) {
+        super(name, new HelperType(""));
+    }
+
+    /**
+     * Get the start position
+     *
+     * @return start position
+     */
+    public int getStart() {
+        return mStart;
+    }
+
+    /**
+     * Set the start position
+     *
+     * @param start the start position
+     */
+    public void setStart(int start) {
+        mStart = start;
+        configMap.put("start", String.valueOf(mStart));
+    }
+
+    /**
+     * Get the end position
+     *
+     * @return end position
+     */
+    public int getEnd() {
+        return mEnd;
+    }
+
+    /**
+     * Set the end position
+     *
+     * @param end the end position
+     */
+    public void setEnd(int end) {
+        mEnd = end;
+        configMap.put("end", String.valueOf(mEnd));
+    }
+
+    /**
+     * Get the position in percent
+     *
+     * @return position in percent
+     */
+    public float getPercent() {
+        return mPercent;
+    }
+
+    /**
+     * Set the position in percent
+     *
+     * @param percent the position in percent
+     */
+    public void setPercent(float percent) {
+        mPercent = percent;
+        configMap.put("percent", String.valueOf(mPercent));
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/HChain.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/HChain.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+public class HChain extends Chain {
+    public class HAnchor extends Anchor {
+        HAnchor(Constraint.HSide side) {
+            super(Constraint.Side.valueOf(side.name()));
+        }
+    }
+
+    private HAnchor mLeft = new HAnchor(Constraint.HSide.LEFT);
+    private HAnchor mRight = new HAnchor(Constraint.HSide.RIGHT);
+    private HAnchor mStart = new HAnchor(Constraint.HSide.START);
+    private HAnchor mEnd = new HAnchor(Constraint.HSide.END);
+
+    public HChain(String name) {
+        super(name);
+        type = new HelperType(typeMap.get(Type.HORIZONTAL_CHAIN));
+    }
+
+    public HChain(String name, String config) {
+        super(name);
+        this.config = config;
+        type = new HelperType(typeMap.get(Type.HORIZONTAL_CHAIN));
+        configMap = convertConfigToMap();
+        if (configMap.containsKey("contains")) {
+            Ref.addStringToReferences(configMap.get("contains"), references);
+        }
+    }
+
+    /**
+     * Get the left anchor
+     *
+     * @return the left anchor
+     */
+    public HAnchor getLeft() {
+        return mLeft;
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToLeft(Constraint.HAnchor anchor) {
+        linkToLeft(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToLeft(Constraint.HAnchor anchor, int margin) {
+        linkToLeft(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Left
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToLeft(Constraint.HAnchor anchor, int margin, int goneMargin) {
+        mLeft.mConnection = anchor;
+        mLeft.mMargin = margin;
+        mLeft.mGoneMargin = goneMargin;
+        configMap.put("left", mLeft.toString());
+    }
+
+    /**
+     * Get the right anchor
+     *
+     * @return the right anchor
+     */
+    public HAnchor getRight() {
+        return mRight;
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToRight(Constraint.HAnchor anchor) {
+        linkToRight(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToRight(Constraint.HAnchor anchor, int margin) {
+        linkToRight(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Right
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToRight(Constraint.HAnchor anchor, int margin, int goneMargin) {
+        mRight.mConnection = anchor;
+        mRight.mMargin = margin;
+        mRight.mGoneMargin = goneMargin;
+        configMap.put("right", mRight.toString());
+    }
+
+    /**
+     * Get the start anchor
+     *
+     * @return the start anchor
+     */
+    public HAnchor getStart() {
+        return mStart;
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToStart(Constraint.HAnchor anchor) {
+        linkToStart(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToStart(Constraint.HAnchor anchor, int margin) {
+        linkToStart(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Start
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToStart(Constraint.HAnchor anchor, int margin, int goneMargin) {
+        mStart.mConnection = anchor;
+        mStart.mMargin = margin;
+        mStart.mGoneMargin = goneMargin;
+        configMap.put("start", mStart.toString());
+    }
+
+    /**
+     * Get the end anchor
+     *
+     * @return the end anchor
+     */
+    public HAnchor getEnd() {
+        return mEnd;
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToEnd(Constraint.HAnchor anchor) {
+        linkToEnd(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToEnd(Constraint.HAnchor anchor, int margin) {
+        linkToEnd(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to End
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToEnd(Constraint.HAnchor anchor, int margin, int goneMargin) {
+        mEnd.mConnection = anchor;
+        mEnd.mMargin = margin;
+        mEnd.mGoneMargin = goneMargin;
+        configMap.put("end", mEnd.toString());
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/HGuideline.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/HGuideline.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+class HGuideline extends Guideline {
+    public HGuideline(String name) {
+        super(name);
+        type = new HelperType(typeMap.get(Type.HORIZONTAL_GUIDELINE));
+    }
+
+    public HGuideline(String name, String config) {
+        super(name);
+        this.config = config;
+        type = new HelperType(typeMap.get(Type.HORIZONTAL_GUIDELINE));
+        configMap = convertConfigToMap();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Helper.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Helper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Helper {
+    public enum Type {
+        VERTICAL_GUIDELINE,
+        HORIZONTAL_GUIDELINE,
+        VERTICAL_CHAIN,
+        HORIZONTAL_CHAIN,
+        BARRIER
+    }
+
+    protected final String name;
+    protected HelperType type = null;
+    protected String config;
+    protected Map<String, String> configMap = new HashMap<>();
+    final static protected Map<Constraint.Side, String> sideMap = new HashMap<>();
+    static {
+        sideMap.put(Constraint.Side.LEFT, "'left'");
+        sideMap.put(Constraint.Side.RIGHT, "'right'");
+        sideMap.put(Constraint.Side.TOP, "'top'");
+        sideMap.put(Constraint.Side.BOTTOM, "'bottom'");
+        sideMap.put(Constraint.Side.START, "'start'");
+        sideMap.put(Constraint.Side.END, "'end'");
+        sideMap.put(Constraint.Side.BASELINE, "'baseline'");
+    }
+
+    final static protected Map<Helper.Type, String> typeMap = new HashMap<>();
+    static {
+        typeMap.put(Type.VERTICAL_GUIDELINE, "vGuideline");
+        typeMap.put(Type.HORIZONTAL_GUIDELINE, "hGuideline");
+        typeMap.put(Type.VERTICAL_CHAIN, "vChain");
+        typeMap.put(Type.HORIZONTAL_CHAIN, "hChain");
+        typeMap.put(Type.BARRIER, "barrier");
+    }
+
+    public Helper(String name, HelperType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public Helper(String name, HelperType type, String config) {
+        this.name = name;
+        this.type = type;
+        this.config = config;
+        configMap = convertConfigToMap();
+    }
+
+    public String getId() {
+        return name;
+    }
+
+    public HelperType getType() {
+        return type;
+    }
+
+    public String getConfig() {
+        return config;
+    }
+
+    public Map<String, String> convertConfigToMap() {
+        if (config == null || config.length() == 0) {
+            return null;
+        }
+
+        Map<String, String> map = new HashMap<>();
+        StringBuilder builder = new StringBuilder();
+        String key = "";
+        String value = "";
+        int squareBrackets = 0;
+        int curlyBrackets = 0;
+        char ch;
+        for (int i = 0; i < config.length(); i++) {
+            ch = config.charAt(i);
+            if (ch == ':') {
+                key = builder.toString();
+                builder.setLength(0);
+            } else if (ch == ',' && squareBrackets == 0 && curlyBrackets == 0) {
+                value = builder.toString();
+                map.put(key, value);
+                key = value = "";
+                builder.setLength(0);
+            } else if (ch != ' ') {
+                switch (ch) {
+                    case '[':
+                        squareBrackets++;
+                        break;
+                    case '{':
+                        curlyBrackets++;
+                        break;
+                    case ']':
+                        squareBrackets--;
+                        break;
+                    case '}':
+                        curlyBrackets--;
+                        break;
+                }
+
+                builder.append(ch);
+            }
+        }
+
+        map.put(key, builder.toString());
+        return map;
+    }
+
+    public void append(Map<String, String> map, StringBuilder ret) {
+        if (map.isEmpty()) {
+            return;
+        }
+        for (String key : map.keySet()) {
+            ret.append(key).append(":").append(map.get(key)).append(",\n");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder(name + ":{\n");
+
+        if (type != null) {
+            ret.append("type:'").append(type.toString()).append("',\n");
+        }
+
+        if (configMap != null) {
+            append(configMap, ret);
+        }
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+
+    public static void main(String[] args) {
+        Barrier b = new Barrier("abc", "['a1', 'b2']");
+        System.out.println(b.toString());
+    }
+
+    public static final class HelperType {
+        final String mName;
+
+        public HelperType(String str) {
+            mName = str;
+        }
+
+        @Override
+        public String toString() { return mName; }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyAttribute.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyAttribute.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+/**
+ * Provides the API for creating a KeyAttribute Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ */
+public class KeyAttribute extends Keys {
+    protected String TYPE = "KeyAttributes";
+    private String mTarget = null;
+    private int mFrame = 0;
+    private String mTransitionEasing;
+    private Fit mCurveFit = null;
+    private Visibility mVisibility = null;
+    private float mAlpha = Float.NaN;
+    private float mRotation = Float.NaN;
+    private float mRotationX = Float.NaN;
+    private float mRotationY = Float.NaN;
+    private float mPivotX = Float.NaN;
+    private float mPivotY = Float.NaN;
+    private float mTransitionPathRotate = Float.NaN;
+    private float mScaleX = Float.NaN;
+    private float mScaleY = Float.NaN;
+    private float mTranslationX = Float.NaN;
+    private float mTranslationY = Float.NaN;
+    private float mTranslationZ = Float.NaN;
+
+    public KeyAttribute(int frame, String target) {
+        mTarget = target;
+        mFrame = frame;
+    }
+
+    public enum Fit {
+        SPLINE,
+        LINEAR,
+    }
+
+    public enum Visibility {
+        VISIBLE,
+        INVISIBLE,
+        GONE
+    }
+
+    public String getTarget() {
+        return mTarget;
+    }
+
+    public void setTarget(String target) {
+        mTarget = target;
+    }
+
+    public String getTransitionEasing() {
+        return mTransitionEasing;
+    }
+
+    public void setTransitionEasing(String transitionEasing) {
+        mTransitionEasing = transitionEasing;
+    }
+
+    public Fit getCurveFit() {
+        return mCurveFit;
+    }
+
+    public void setCurveFit(Fit curveFit) {
+        mCurveFit = curveFit;
+    }
+
+    public Visibility getVisibility() {
+        return mVisibility;
+    }
+
+    public void setVisibility(Visibility visibility) {
+        mVisibility = visibility;
+    }
+
+    public float getAlpha() {
+        return mAlpha;
+    }
+
+    public void setAlpha(float alpha) {
+        mAlpha = alpha;
+    }
+
+    public float getRotation() {
+        return mRotation;
+    }
+
+    public void setRotation(float rotation) {
+        mRotation = rotation;
+    }
+
+    public float getRotationX() {
+        return mRotationX;
+    }
+
+    public void setRotationX(float rotationX) {
+        mRotationX = rotationX;
+    }
+
+    public float getRotationY() {
+        return mRotationY;
+    }
+
+    public void setRotationY(float rotationY) {
+        mRotationY = rotationY;
+    }
+
+    public float getPivotX() {
+        return mPivotX;
+    }
+
+    public void setPivotX(float pivotX) {
+        mPivotX = pivotX;
+    }
+
+    public float getPivotY() {
+        return mPivotY;
+    }
+
+    public void setPivotY(float pivotY) {
+        mPivotY = pivotY;
+    }
+
+    public float getTransitionPathRotate() {
+        return mTransitionPathRotate;
+    }
+
+    public void setTransitionPathRotate(float transitionPathRotate) {
+        mTransitionPathRotate = transitionPathRotate;
+    }
+
+    public float getScaleX() {
+        return mScaleX;
+    }
+
+    public void setScaleX(float scaleX) {
+        mScaleX = scaleX;
+    }
+
+    public float getScaleY() {
+        return mScaleY;
+    }
+
+    public void setScaleY(float scaleY) {
+        mScaleY = scaleY;
+    }
+
+    public float getTranslationX() {
+        return mTranslationX;
+    }
+
+    public void setTranslationX(float translationX) {
+        mTranslationX = translationX;
+    }
+
+    public float getTranslationY() {
+        return mTranslationY;
+    }
+
+    public void setTranslationY(float translationY) {
+        mTranslationY = translationY;
+    }
+
+    public float getTranslationZ() {
+        return mTranslationZ;
+    }
+
+    public void setTranslationZ(float translationZ) {
+        mTranslationZ = translationZ;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append(TYPE);
+        ret.append(":{\n");
+        attributesToString(ret);
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+
+    protected void attributesToString(StringBuilder builder) {
+        append(builder, "target", mTarget);
+        builder.append("frame:").append(mFrame).append(",\n");
+
+        append(builder, "easing", mTransitionEasing);
+        if (mCurveFit != null) {
+            builder.append("fit:'").append(mCurveFit).append("',\n");
+        }
+        if (mVisibility != null) {
+            builder.append("visibility:'").append(mVisibility).append("',\n");
+        }
+        append(builder, "alpha", mAlpha);
+        append(builder, "rotationX", mRotationX);
+        append(builder, "rotationY", mRotationY);
+        append(builder, "rotationZ", mRotation);
+
+        append(builder, "pivotX", mPivotX);
+        append(builder, "pivotY", mPivotY);
+        append(builder, "pathRotate", mTransitionPathRotate);
+        append(builder, "scaleX", mScaleX);
+        append(builder, "scaleY", mScaleY);
+        append(builder, "translationX", mTranslationX);
+        append(builder, "translationY", mTranslationY);
+        append(builder, "translationZ", mTranslationZ);
+
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyAttributes.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyAttributes.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.Arrays;
+
+/**
+ * Provides the API for creating a KeyAttribute Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ * This allows multiple KeyAttribute positions to defined in one object.
+ */
+public class KeyAttributes extends Keys {
+    protected String TYPE = "KeyAttributes";
+    private String[] mTarget = null;
+    private String mTransitionEasing;
+    private Fit mCurveFit = null;
+    private int[] mFrames = null;
+
+    private Visibility[] mVisibility = null;
+    private float[] mAlpha = null;
+    private float[] mRotation = null;
+    private float[] mRotationX = null;
+    private float[] mRotationY = null;
+    private float[] mPivotX = null;
+    private float[] mPivotY = null;
+    private float[] mTransitionPathRotate = null;
+    private float[] mScaleX = null;
+    private float[] mScaleY = null;
+    private float[] mTranslationX = null;
+    private float[] mTranslationY = null;
+    private float[] mTranslationZ = null;
+
+    public enum Fit {
+        SPLINE,
+        LINEAR,
+    }
+
+    public enum Visibility {
+        VISIBLE,
+        INVISIBLE,
+        GONE
+    }
+
+    KeyAttributes(int numOfFrames, String... targets) {
+        mTarget = targets;
+        mFrames = new int[numOfFrames];
+        // the default is evenly spaced  1 at 50, 2 at 33 & 66, 3 at 25,50,75
+        float gap = 100f / (mFrames.length + 1);
+        for (int i = 0; i < mFrames.length; i++) {
+            mFrames[i] = (int) (i * gap + gap);
+        }
+    }
+
+    public String[] getTarget() {
+        return mTarget;
+    }
+
+    public void setTarget(String[] target) {
+        mTarget = target;
+    }
+
+    public String getTransitionEasing() {
+        return mTransitionEasing;
+    }
+
+    public void setTransitionEasing(String transitionEasing) {
+        mTransitionEasing = transitionEasing;
+    }
+
+    public Fit getCurveFit() {
+        return mCurveFit;
+    }
+
+    public void setCurveFit(Fit curveFit) {
+        mCurveFit = curveFit;
+    }
+
+    public Visibility[] getVisibility() {
+        return mVisibility;
+    }
+
+    public void setVisibility(Visibility... visibility) {
+        mVisibility = visibility;
+    }
+
+    public float[] getAlpha() {
+        return mAlpha;
+    }
+
+    public void setAlpha(float... alpha) {
+        mAlpha = alpha;
+    }
+
+    public float[] getRotation() {
+        return mRotation;
+    }
+
+    public void setRotation(float... rotation) {
+        mRotation = rotation;
+    }
+
+    public float[] getRotationX() {
+        return mRotationX;
+    }
+
+    public void setRotationX(float... rotationX) {
+        mRotationX = rotationX;
+    }
+
+    public float[] getRotationY() {
+        return mRotationY;
+    }
+
+    public void setRotationY(float... rotationY) {
+        mRotationY = rotationY;
+    }
+
+    public float[] getPivotX() {
+        return mPivotX;
+    }
+
+    public void setPivotX(float... pivotX) {
+        mPivotX = pivotX;
+    }
+
+    public float[] getPivotY() {
+        return mPivotY;
+    }
+
+    public void setPivotY(float... pivotY) {
+        mPivotY = pivotY;
+    }
+
+    public float[] getTransitionPathRotate() {
+        return mTransitionPathRotate;
+    }
+
+    public void setTransitionPathRotate(float... transitionPathRotate) {
+        mTransitionPathRotate = transitionPathRotate;
+    }
+
+    public float[] getScaleX() {
+        return mScaleX;
+    }
+
+    public void setScaleX(float[] scaleX) {
+        mScaleX = scaleX;
+    }
+
+    public float[] getScaleY() {
+        return mScaleY;
+    }
+
+    public void setScaleY(float[] scaleY) {
+        mScaleY = scaleY;
+    }
+
+    public float[] getTranslationX() {
+        return mTranslationX;
+    }
+
+    public void setTranslationX(float[] translationX) {
+        mTranslationX = translationX;
+    }
+
+    public float[] getTranslationY() {
+        return mTranslationY;
+    }
+
+    public void setTranslationY(float[] translationY) {
+        mTranslationY = translationY;
+    }
+
+    public float[] getTranslationZ() {
+        return mTranslationZ;
+    }
+
+    public void setTranslationZ(float[] translationZ) {
+        mTranslationZ = translationZ;
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append(TYPE);
+        ret.append(":{\n");
+        attributesToString(ret);
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+
+    protected void attributesToString(StringBuilder builder) {
+        append(builder, "target", mTarget);
+        builder.append("frame:").append(Arrays.toString(mFrames)).append(",\n");
+
+        append(builder, "easing", mTransitionEasing);
+        if (mCurveFit != null) {
+            builder.append("fit:'").append(mCurveFit).append("',\n");
+        }
+        if (mVisibility != null) {
+            builder.append("visibility:'").append(Arrays.toString(mVisibility)).append("',\n");
+        }
+        append(builder, "alpha", mAlpha);
+        append(builder, "rotationX", mRotationX);
+        append(builder, "rotationY", mRotationY);
+        append(builder, "rotationZ", mRotation);
+
+        append(builder, "pivotX", mPivotX);
+        append(builder, "pivotY", mPivotY);
+        append(builder, "pathRotate", mTransitionPathRotate);
+        append(builder, "scaleX", mScaleX);
+        append(builder, "scaleY", mScaleY);
+        append(builder, "translationX", mTranslationX);
+        append(builder, "translationY", mTranslationY);
+        append(builder, "translationZ", mTranslationZ);
+
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyCycle.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyCycle.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+public class KeyCycle extends KeyAttribute {
+    private static final String TAG = "KeyCycle";
+    private Wave mWaveShape = null;
+    private float mWavePeriod = Float.NaN;
+    private float mWaveOffset = Float.NaN;
+    private float mWavePhase = Float.NaN;
+
+    KeyCycle(int frame, String target) {
+        super(frame, target);
+        TYPE = "KeyCycle";
+    }
+
+    public enum Wave {
+        SIN,
+        SQUARE,
+        TRIANGLE,
+        SAW,
+        REVERSE_SAW,
+        COS
+    }
+
+    public Wave getShape() {
+        return mWaveShape;
+    }
+
+    public void setShape(Wave waveShape) {
+        mWaveShape = waveShape;
+    }
+
+    public float getPeriod() {
+        return mWavePeriod;
+    }
+
+    public void setPeriod(float wavePeriod) {
+        mWavePeriod = wavePeriod;
+    }
+
+    public float getOffset() {
+        return mWaveOffset;
+    }
+
+    public void setOffset(float waveOffset) {
+        mWaveOffset = waveOffset;
+    }
+
+    public float getPhase() {
+        return mWavePhase;
+    }
+
+    public void setPhase(float wavePhase) {
+        mWavePhase = wavePhase;
+    }
+
+    @Override
+    protected void attributesToString(StringBuilder builder) {
+        super.attributesToString(builder);
+
+        if (mWaveShape != null) {
+            builder.append("shape:'").append(mWaveShape).append("',\n");
+        }
+        append(builder, "period", mWavePeriod);
+        append(builder, "offset", mWaveOffset);
+        append(builder, "phase", mWavePhase);
+
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyCycles.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyCycles.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+/**
+ * Provides the API for creating a KeyCycle Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ * This allows multiple KeyCycle positions to defined in one object.
+ */
+public class KeyCycles extends KeyAttributes {
+
+
+    public enum Wave {
+        SIN,
+        SQUARE,
+        TRIANGLE,
+        SAW,
+        REVERSE_SAW,
+        COS
+    }
+
+    private KeyCycles.Wave mWaveShape = null;
+    private float[] mWavePeriod = null;
+    private float[] mWaveOffset = null;
+    private float[] mWavePhase = null;
+
+    KeyCycles(int numOfFrames, String... targets) {
+        super(numOfFrames, targets);
+        TYPE = "KeyCycle";
+    }
+
+    public KeyCycles.Wave getWaveShape() {
+        return mWaveShape;
+    }
+
+    public void setWaveShape(KeyCycles.Wave waveShape) {
+        mWaveShape = waveShape;
+    }
+
+    public float[] getWavePeriod() {
+        return mWavePeriod;
+    }
+
+    public void setWavePeriod(float... wavePeriod) {
+        mWavePeriod = wavePeriod;
+    }
+
+    public float[] getWaveOffset() {
+        return mWaveOffset;
+    }
+
+    public void setWaveOffset(float... waveOffset) {
+        mWaveOffset = waveOffset;
+    }
+
+    public float[] getWavePhase() {
+        return mWavePhase;
+    }
+
+    public void setWavePhase(float... wavePhase) {
+        mWavePhase = wavePhase;
+    }
+
+    @Override
+    protected void attributesToString(StringBuilder builder) {
+        super.attributesToString(builder);
+
+        if (mWaveShape != null) {
+            builder.append("shape:'").append(mWaveShape).append("',\n");
+        }
+        append(builder, "period", mWavePeriod);
+        append(builder, "offset", mWaveOffset);
+        append(builder, "phase", mWavePhase);
+
+    }
+
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyFrames.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyFrames.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+
+/**
+ * Provides the API for creating a KeyFrames Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ * KeyFrames is a container for KeyAttribute,KeyCycle,KeyPosition etc.
+ */
+
+public class KeyFrames {
+    ArrayList<Keys> mKeys = new ArrayList<>();
+
+    public void add(@SuppressWarnings("HiddenTypeParameter") Keys keyFrame) {
+        mKeys.add(keyFrame);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        if (!mKeys.isEmpty()) {
+            ret.append("keyFrames:{\n");
+            for (Keys key : mKeys) {
+                ret.append(key.toString());
+            }
+            ret.append("},\n");
+        }
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyPosition.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyPosition.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+/**
+ * Provides the API for creating a KeyPosition Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ */
+public class KeyPosition extends Keys {
+
+    private String mTarget = null;
+    private String mTransitionEasing = null;
+    private int mFrame = 0;
+    private float mPercentWidth = Float.NaN;
+    private float mPercentHeight = Float.NaN;
+    private float mPercentX = Float.NaN;
+    private float mPercentY = Float.NaN;
+    private Type mPositionType = Type.CARTESIAN;
+
+    public enum Type {
+        CARTESIAN,
+        SCREEN,
+        PATH
+    }
+
+    public KeyPosition(String firstTarget, int frame) {
+
+        mTarget = firstTarget;
+        mFrame = frame;
+    }
+
+    public String getTransitionEasing() {
+        return mTransitionEasing;
+    }
+
+    public void setTransitionEasing(String transitionEasing) {
+        mTransitionEasing = transitionEasing;
+    }
+
+    public int getFrames() {
+        return mFrame;
+    }
+
+    public void setFrames(int frames) {
+        mFrame = frames;
+    }
+
+    public float getPercentWidth() {
+        return mPercentWidth;
+    }
+
+    public void setPercentWidth(float percentWidth) {
+        mPercentWidth = percentWidth;
+    }
+
+    public float getPercentHeight() {
+        return mPercentHeight;
+    }
+
+    public void setPercentHeight(float percentHeight) {
+        mPercentHeight = percentHeight;
+    }
+
+    public float getPercentX() {
+        return mPercentX;
+    }
+
+    public void setPercentX(float percentX) {
+        mPercentX = percentX;
+    }
+
+    public float getPercentY() {
+        return mPercentY;
+    }
+
+    public void setPercentY(float percentY) {
+        mPercentY = percentY;
+    }
+
+    public Type getPositionType() {
+        return mPositionType;
+    }
+
+    public void setPositionType(Type positionType) {
+        mPositionType = positionType;
+    }
+
+    public String getTarget() {
+        return mTarget;
+    }
+
+    public void setTarget(String target) {
+        mTarget = target;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("KeyPositions:{\n");
+
+        append(ret, "target", mTarget);
+        ret.append("frame:").append(mFrame).append(",\n");
+
+        if (mPositionType != null) {
+            ret.append("type:'").append(mPositionType).append("',\n");
+        }
+
+        append(ret, "easing", mTransitionEasing);
+        append(ret, "percentX", mPercentX);
+        append(ret, "percentY", mPercentY);
+        append(ret, "percentWidth", mPercentWidth);
+        append(ret, "percentHeight", mPercentHeight);
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyPositions.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/KeyPositions.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.Arrays;
+
+/**
+ * Provides the API for creating a KeyPosition Object for use in the Core
+ * ConstraintLayout & MotionLayout system
+ * This allows multiple KeyPosition positions to defined in one object.
+ */
+public class KeyPositions extends Keys {
+
+    private String[] mTarget = null;
+    private String mTransitionEasing = null;
+    private Type mPositionType = null;
+
+    private int[] mFrames = null;
+    private float[] mPercentWidth = null;
+    private float[] mPercentHeight = null;
+    private float[] mPercentX = null;
+    private float[] mPercentY = null;
+
+    public enum Type {
+        CARTESIAN,
+        SCREEN,
+        PATH
+    }
+
+    public KeyPositions(int numOfFrames, String... targets) {
+        mTarget = targets;
+        mFrames = new int[numOfFrames];
+        // the default is evenly spaced  1 at 50, 2 at 33 & 66, 3 at 25,50,75
+        float gap = 100f / (mFrames.length + 1);
+        for (int i = 0; i < mFrames.length; i++) {
+            mFrames[i] = (int) (i * gap + gap);
+        }
+    }
+
+    public String getTransitionEasing() {
+        return mTransitionEasing;
+    }
+
+    public void setTransitionEasing(String transitionEasing) {
+        mTransitionEasing = transitionEasing;
+    }
+
+    public int[] getFrames() {
+        return mFrames;
+    }
+
+    public void setFrames(int... frames) {
+        mFrames = frames;
+    }
+
+    public float[] getPercentWidth() {
+        return mPercentWidth;
+    }
+
+    public void setPercentWidth(float... percentWidth) {
+        mPercentWidth = percentWidth;
+    }
+
+    public float[] getPercentHeight() {
+        return mPercentHeight;
+    }
+
+    public void setPercentHeight(float... percentHeight) {
+        mPercentHeight = percentHeight;
+    }
+
+    public float[] getPercentX() {
+        return mPercentX;
+    }
+
+    public void setPercentX(float... percentX) {
+        mPercentX = percentX;
+    }
+
+    public float[] getPercentY() {
+        return mPercentY;
+    }
+
+    public void setPercentY(float... percentY) {
+        mPercentY = percentY;
+    }
+
+    public Type getPositionType() {
+        return mPositionType;
+    }
+
+    public void setPositionType(Type positionType) {
+        mPositionType = positionType;
+    }
+
+    public String[] getTarget() {
+        return mTarget;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("KeyPositions:{\n");
+
+        append(ret, "target", mTarget);
+
+        ret.append("frame:").append(Arrays.toString(mFrames)).append(",\n");
+
+        if (mPositionType != null) {
+            ret.append("type:'").append(mPositionType).append("',\n");
+        }
+
+        append(ret, "easing", mTransitionEasing);
+        append(ret, "percentX", mPercentX);
+        append(ret, "percentX", mPercentY);
+        append(ret, "percentWidth", mPercentWidth);
+        append(ret, "percentHeight", mPercentHeight);
+
+        ret.append("},\n");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Keys.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Keys.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.Arrays;
+
+/**
+ * This is the base Key for all the key (KeyCycle, KeyPosition, etc.) Objects
+ */
+public class Keys {
+
+    protected String unpack(String[] str) {
+        StringBuilder ret = new StringBuilder("[");
+        for (int i = 0; i < str.length; i++) {
+
+            ret.append((i == 0) ? "'" : ",'");
+
+            ret.append(str[i]);
+            ret.append("'");
+
+        }
+        ret.append("]");
+        return ret.toString();
+    }
+
+    protected void append(StringBuilder builder, String name, int value) {
+        if (value != Integer.MIN_VALUE) {
+            builder.append(name);
+            builder.append(":'").append(value).append("',\n");
+        }
+    }
+
+    protected void append(StringBuilder builder, String name, String value) {
+        if (value != null) {
+            builder.append(name);
+            builder.append(":'").append(value).append("',\n");
+        }
+    }
+
+    protected void append(StringBuilder builder, String name, float value) {
+        if (Float.isNaN(value)) {
+            return;
+        }
+        builder.append(name);
+        builder.append(":").append(value).append(",\n");
+
+    }
+
+    protected void append(StringBuilder builder, String name, String[] array) {
+        if (array != null) {
+            builder.append(name);
+            builder.append(":").append(unpack(array)).append(",\n");
+        }
+    }
+
+    protected void append(StringBuilder builder, String name, float[] array) {
+        if (array != null) {
+            builder.append(name);
+            builder.append("percentWidth:").append(Arrays.toString(array)).append(",\n");
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/MotionScene.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/MotionScene.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+
+/**
+ * This defines to MotionScene container
+ * It contains ConstraintSet and Transitions
+ */
+public class MotionScene {
+    ArrayList<Transition> mTransitions = new ArrayList<>();
+    ArrayList<ConstraintSet> mConstraintSets = new ArrayList<>();
+
+    // todo add support for variables, generate and helpers
+    public void addTransition(Transition transition) {
+        mTransitions.add(transition);
+    }
+
+    public void addConstraintSet(ConstraintSet constraintSet) {
+        mConstraintSets.add(constraintSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder("{\n");
+        if (!mTransitions.isEmpty()) {
+            ret.append("Transitions:{\n");
+            for (Transition transition : mTransitions) {
+                ret.append(transition.toString());
+            }
+            ret.append("},\n");
+        }
+        if (!mConstraintSets.isEmpty()) {
+            ret.append("ConstraintSets:{\n");
+            for (ConstraintSet constraintSet : mConstraintSets) {
+                ret.append(constraintSet.toString());
+            }
+            ret.append("},\n");
+        }
+
+        ret.append("}\n");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/OnSwipe.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/OnSwipe.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+/**
+ * Create automatic swipe handling object
+ */
+public class OnSwipe {
+
+    private Drag mDragDirection = null;
+    private Side mTouchAnchorSide = null;
+
+    private String mTouchAnchorId = null;
+    private String mLimitBoundsTo = null;
+    private TouchUp mOnTouchUp = null;
+    private String mRotationCenterId = null;
+    private float mMaxVelocity = Float.NaN;
+    private float mMaxAcceleration = Float.NaN;
+    private float mDragScale = Float.NaN;
+
+    private float mDragThreshold = Float.NaN;
+    private float mSpringDamping = Float.NaN;
+    private float mSpringMass = Float.NaN;
+    private float mSpringStiffness = Float.NaN;
+    private float mSpringStopThreshold = Float.NaN;
+    private Boundary mSpringBoundary = null;
+    private Mode mAutoCompleteMode = null;
+
+    public OnSwipe() {
+    }
+
+    public OnSwipe(String anchor, Side side, Drag dragDirection) {
+        mTouchAnchorId = anchor;
+        mTouchAnchorSide = side;
+        mDragDirection = dragDirection;
+    }
+
+    public enum Mode {
+        VELOCITY,
+        SPRING
+    }
+
+    public enum Boundary {
+        OVERSHOOT,
+        BOUNCE_START,
+        BOUNCE_END,
+        BOUNCE_BOTH,
+    }
+
+
+    public enum Drag {
+        UP,
+        DOWN,
+        LEFT,
+        RIGHT,
+        START,
+        END,
+        CLOCKWISE,
+        ANTICLOCKWISE
+    }
+
+    public static final int FLAG_DISABLE_POST_SCROLL = 1;
+    public static final int FLAG_DISABLE_SCROLL = 2;
+
+    public enum Side {
+        TOP,
+        LEFT,
+        RIGHT,
+        BOTTOM,
+        MIDDLE,
+        START,
+        END,
+    }
+
+    public enum TouchUp {
+        AUTOCOMPLETE,
+        TO_START,
+        NEVER_COMPLETE_END,
+        TO_END,
+        STOP,
+        DECELERATE,
+        DECELERATE_COMPLETE,
+        NEVER_COMPLETE_START
+    }
+
+    /**
+     * The id of the view who's movement is matched to your drag
+     * If not specified it will map to a linear movement across the width of the motionLayout
+     */
+    public OnSwipe setTouchAnchorId(String id) {
+        mTouchAnchorId = id;
+        return this;
+    }
+
+    public String getTouchAnchorId() {
+        return mTouchAnchorId;
+    }
+
+    /**
+     * This side of the view that matches the drag movement.
+     * Only meaning full if the object changes size during the movement.
+     * (rotation is not considered)
+     */
+    public OnSwipe setTouchAnchorSide(Side side) {
+        mTouchAnchorSide = side;
+        return this;
+    }
+
+    public Side getTouchAnchorSide() {
+        return mTouchAnchorSide;
+    }
+
+    /**
+     * The direction of the drag.
+     */
+    public OnSwipe setDragDirection(Drag dragDirection) {
+        mDragDirection = dragDirection;
+        return this;
+    }
+
+    public Drag getDragDirection() {
+        return mDragDirection;
+    }
+
+    /**
+     * The maximum velocity (Change in progress per second) animation can achieve
+     */
+    public OnSwipe setMaxVelocity(int maxVelocity) {
+        mMaxVelocity = maxVelocity;
+        return this;
+    }
+
+    public float getMaxVelocity() {
+        return mMaxVelocity;
+    }
+
+    /**
+     * The maximum acceleration and deceleration of the animation
+     * (Change in Change in progress per second)
+     * Faster makes the object seem lighter and quicker
+     */
+    public OnSwipe setMaxAcceleration(int maxAcceleration) {
+        mMaxAcceleration = maxAcceleration;
+        return this;
+    }
+
+    public float getMaxAcceleration() {
+        return mMaxAcceleration;
+    }
+
+
+    /**
+     * Normally 1 this can be tweaked to make the acceleration faster
+     */
+    public OnSwipe setDragScale(int dragScale) {
+        mDragScale = dragScale;
+        return this;
+    }
+
+    public float getDragScale() {
+        return mDragScale;
+    }
+
+    /**
+     * This sets the threshold before the animation is kicked off.
+     * It is important when have multi state animations the have some play before the
+     * System decides which animation to jump on.
+     */
+    public OnSwipe setDragThreshold(int dragThreshold) {
+        mDragThreshold = dragThreshold;
+        return this;
+    }
+
+    public float getDragThreshold() {
+        return mDragThreshold;
+    }
+
+
+    /**
+     * Configures what happens when the user releases on mouse up.
+     * One of: ON_UP_AUTOCOMPLETE, ON_UP_AUTOCOMPLETE_TO_START, ON_UP_AUTOCOMPLETE_TO_END,
+     * ON_UP_STOP, ON_UP_DECELERATE, ON_UP_DECELERATE_AND_COMPLETE
+     *
+     * @param mode default = ON_UP_AUTOCOMPLETE
+     */
+    public OnSwipe setOnTouchUp(TouchUp mode) {
+        mOnTouchUp = mode;
+        return this;
+    }
+
+    public TouchUp getOnTouchUp() {
+        return mOnTouchUp;
+    }
+
+    /**
+     * Only allow touch actions to be initiated within this region
+     */
+    public OnSwipe setLimitBoundsTo(String id) {
+        mLimitBoundsTo = id;
+        return this;
+    }
+
+    public String getLimitBoundsTo() {
+        return mLimitBoundsTo;
+    }
+
+    /**
+     * The view to center the rotation about
+     *
+     * @return this
+     */
+    public OnSwipe setRotateCenter(String rotationCenterId) {
+        mRotationCenterId = rotationCenterId;
+        return this;
+    }
+
+    public String getRotationCenterId() {
+        return mRotationCenterId;
+    }
+
+
+    public float getSpringDamping() {
+        return mSpringDamping;
+    }
+
+    /**
+     * Set the damping of the spring if using spring.
+     * c in "a = (-k*x-c*v)/m" equation for the acceleration of a spring
+     *
+     * @return this
+     */
+    public OnSwipe setSpringDamping(float springDamping) {
+        mSpringDamping = springDamping;
+        return this;
+    }
+
+    /**
+     * Get the mass of the spring.
+     * the m in "a = (-k*x-c*v)/m" equation for the acceleration of a spring
+     */
+    public float getSpringMass() {
+        return mSpringMass;
+    }
+
+    /**
+     * Set the Mass of the spring if using spring.
+     * m in "a = (-k*x-c*v)/m" equation for the acceleration of a spring
+     *
+     * @return this
+     */
+    public OnSwipe setSpringMass(float springMass) {
+        mSpringMass = springMass;
+        return this;
+    }
+
+    /**
+     * get the stiffness of the spring
+     *
+     * @return NaN if not set
+     */
+    public float getSpringStiffness() {
+        return mSpringStiffness;
+    }
+
+    /**
+     * set the stiffness of the spring if using spring.
+     * If this is set the swipe will use a spring return system.
+     * If set to NaN it will revert to the norm system.
+     * K in "a = (-k*x-c*v)/m" equation for the acceleration of a spring
+     */
+    public OnSwipe setSpringStiffness(float springStiffness) {
+        mSpringStiffness = springStiffness;
+        return this;
+    }
+
+    /**
+     * The threshold for spring motion to stop.
+     */
+    public float getSpringStopThreshold() {
+        return mSpringStopThreshold;
+    }
+
+    /**
+     * set the threshold for spring motion to stop.
+     * This is in change in progress / second
+     * If the spring will never go above that threshold again it will stop.
+     *
+     * @param springStopThreshold when to stop.
+     */
+    public OnSwipe setSpringStopThreshold(float springStopThreshold) {
+        mSpringStopThreshold = springStopThreshold;
+        return this;
+    }
+
+    /**
+     * The behaviour at the boundaries 0 and 1
+     */
+    public Boundary getSpringBoundary() {
+        return mSpringBoundary;
+    }
+
+    /**
+     * The behaviour at the boundaries 0 and 1.
+     *
+     * @param springBoundary behaviour at the boundaries
+     */
+    public OnSwipe setSpringBoundary(Boundary springBoundary) {
+        mSpringBoundary = springBoundary;
+        return this;
+    }
+
+    public Mode getAutoCompleteMode() {
+        return mAutoCompleteMode;
+    }
+
+
+    /**
+     * sets the behaviour at the boundaries 0 and 1
+     * COMPLETE_MODE_CONTINUOUS_VELOCITY = 0;
+     * COMPLETE_MODE_SPRING = 1;
+     */
+    public void setAutoCompleteMode(Mode autoCompleteMode) {
+        mAutoCompleteMode = autoCompleteMode;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("OnSwipe:{\n");
+        if (mTouchAnchorId != null) {
+            ret.append("anchor:'").append(mTouchAnchorId).append("',\n");
+        }
+        if (mDragDirection != null) {
+            ret.append("direction:'").append(mDragDirection.toString().toLowerCase()).append(
+                    "',\n");
+        }
+        if (mTouchAnchorSide != null) {
+            ret.append("side:'").append(mTouchAnchorSide.toString().toLowerCase()).append("',\n");
+        }
+        if (!Float.isNaN(mDragScale)) {
+            ret.append("scale:'").append(mDragScale).append("',\n");
+        }
+        if (!Float.isNaN(mDragThreshold)) {
+            ret.append("threshold:'").append(mDragThreshold).append("',\n");
+        }
+        if (!Float.isNaN(mMaxVelocity)) {
+            ret.append("maxVelocity:'").append(mMaxVelocity).append("',\n");
+        }
+        if (!Float.isNaN(mMaxAcceleration)) {
+            ret.append("maxAccel:'").append(mMaxAcceleration).append("',\n");
+        }
+        if (mLimitBoundsTo != null) {
+            ret.append("limitBounds:'").append(mLimitBoundsTo).append("',\n");
+        }
+        if (mAutoCompleteMode != null) {
+            ret.append("mode:'").append(mAutoCompleteMode.toString().toLowerCase()).append("',\n");
+        }
+        if (mOnTouchUp != null) {
+            ret.append("touchUp:'").append(mOnTouchUp.toString().toLowerCase()).append("',\n");
+        }
+        if (!Float.isNaN(mSpringMass)) {
+            ret.append("springMass:'").append(mSpringMass).append("',\n");
+        }
+
+        if (!Float.isNaN(mSpringStiffness)) {
+            ret.append("springStiffness:'").append(mSpringStiffness).append("',\n");
+        }
+        if (!Float.isNaN(mSpringDamping)) {
+            ret.append("springDamping:'").append(mSpringDamping).append("',\n");
+        }
+        if (!Float.isNaN(mSpringStopThreshold)) {
+            ret.append("stopThreshold:'").append(mSpringStopThreshold).append("',\n");
+        }
+        if (mSpringBoundary != null) {
+            ret.append("springBoundary:'").append(mSpringBoundary).append("',\n");
+        }
+        if (mRotationCenterId != null) {
+            ret.append("around:'").append(mRotationCenterId).append("',\n");
+        }
+
+        ret.append("},\n");
+
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Ref.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Ref.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Ref {
+    private String mId;
+    private float mWeight = Float.NaN;
+    private float mPreMargin = Float.NaN;
+    private float mPostMargin = Float.NaN;
+
+    Ref(String id) {
+        mId = id;
+    }
+
+    Ref(String id, float weight) {
+        mId = id;
+        mWeight = weight;
+    }
+
+    Ref(String id, float weight, float preMargin) {
+        mId = id;
+        mWeight = weight;
+        mPreMargin = preMargin;
+    }
+
+    Ref(String id, float weight, float preMargin, float postMargin) {
+        mId = id;
+        mWeight = weight;
+        mPreMargin = preMargin;
+        mPostMargin = postMargin;
+    }
+
+    /**
+     * Get the Id of the reference
+     *
+     * @return the Id of the reference
+     */
+    public String getId() {
+        return mId;
+    }
+
+    /**
+     * Set the Id of the reference
+     *
+     * @param id
+     */
+    public void setId(String id) {
+        mId = id;
+    }
+
+    /**
+     * Get the weight of the reference
+     *
+     * @return the weight of the reference
+     */
+    public float getWeight() {
+        return mWeight;
+    }
+
+    /**
+     * Set the weight of the reference
+     *
+     * @param weight
+     */
+    public void setWeight(float weight) {
+        mWeight = weight;
+    }
+
+    /**
+     * Get the preMargin of the reference
+     *
+     * @return the preMargin of the reference
+     */
+    public float getPreMargin() {
+        return mPreMargin;
+    }
+
+    /**
+     * Set the preMargin of the reference
+     *
+     * @param preMargin
+     */
+    public void setPreMargin(float preMargin) {
+        mPreMargin = preMargin;
+    }
+
+    /**
+     * Get the postMargin of the reference
+     *
+     * @return the preMargin of the reference
+     */
+    public float getPostMargin() {
+        return mPostMargin;
+    }
+
+    /**
+     * Set the postMargin of the reference
+     *
+     * @param postMargin
+     */
+    public void setPostMargin(float postMargin) {
+        mPostMargin = postMargin;
+    }
+
+    /**
+     * Try to parse an object into a float number
+     *
+     * @param obj object to be parsed
+     * @return a number
+     */
+    static public float parseFloat(Object obj) {
+        float val = Float.NaN;
+        try {
+            val = Float.parseFloat(obj.toString());
+        } catch (Exception e) {
+            // ignore
+        }
+        return val;
+    }
+
+    static public Ref parseStringToRef(String str) {
+        String[] values = str.replaceAll("[\\[\\]\\']", "").split(",");
+        if (values.length == 0) {
+            return null;
+        }
+        Object[] arr = new Object[4];
+        for (int i = 0; i < values.length; i++) {
+            if (i >= 4) {
+                break;
+            }
+            arr[i] = values[i];
+        }
+        return new Ref(arr[0].toString().replace("'", ""), parseFloat(arr[1]),
+                parseFloat(arr[2]), parseFloat(arr[3]));
+    }
+
+    /**
+     * Add references in a String representation to a Ref ArrayList
+     * Used to add the Ref(s) property in the Config to references
+     *
+     * @param str references in a String representation
+     * @param refs  a Ref ArrayList
+     */
+    static public void addStringToReferences(String str, ArrayList<Ref> refs) {
+        if (str == null || str.length() == 0) {
+            return;
+        }
+
+        Object[] arr = new Object[4];
+        StringBuilder builder = new StringBuilder();
+        int squareBrackets = 0;
+        int varCount = 0;
+        char ch;
+
+        for (int i = 0; i < str.length(); i++) {
+            ch = str.charAt(i);
+            switch (ch) {
+                case '[':
+                    squareBrackets++;
+                    break;
+                case ']':
+                    if (squareBrackets > 0) {
+                        squareBrackets--;
+                        arr[varCount] = builder.toString();
+                        builder.setLength(0);
+                        if (arr[0] != null) {
+                            refs.add(new Ref(arr[0].toString(), parseFloat(arr[1]),
+                                    parseFloat(arr[2]), parseFloat(arr[3])));
+                            varCount = 0;
+                            Arrays.fill(arr, null);
+                        }
+                    }
+                    break;
+                case ',':
+                    // deal with the first 3 values in the nested array,
+                    // the fourth value (postMargin) would be handled at case ']'
+                    if (varCount < 3) {
+                        arr[varCount++] = builder.toString();
+                        builder.setLength(0);
+                    }
+                    // squareBrackets == 1 indicate the value is not in a nested array.
+                    if (squareBrackets == 1 && arr[0] != null) {
+                        refs.add(new Ref(arr[0].toString()));
+                        varCount = 0;
+                        arr[0] = null;
+                    }
+                    break;
+                case ' ':
+                case '\'':
+                    break;
+                default:
+                    builder.append(ch);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (mId == null || mId.length() == 0) {
+            return "";
+        }
+
+        StringBuilder ret = new StringBuilder();
+        boolean isArray = false;
+        if (!Float.isNaN(mWeight) || !Float.isNaN(mPreMargin)
+                || !Float.isNaN(mPostMargin)) {
+            isArray = true;
+        }
+        if (isArray) {
+            ret.append("[");
+        }
+        ret.append("'").append(mId).append("'");
+
+        if (!Float.isNaN(mPostMargin)) {
+            ret.append(",").append(!Float.isNaN(mWeight) ? mWeight : 0).append(",");
+            ret.append(!Float.isNaN(mPreMargin) ? mPreMargin : 0).append(",");
+            ret.append(mPostMargin);
+        } else if (!Float.isNaN(mPreMargin)) {
+            ret.append(",").append(!Float.isNaN(mWeight) ? mWeight : 0).append(",");
+            ret.append(mPreMargin);
+        } else if (!Float.isNaN(mWeight)) {
+            ret.append(",").append(mWeight);
+        }
+
+        if(isArray) {
+            ret.append("]");
+        }
+        ret.append(",");
+        return ret.toString();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Transition.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/Transition.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+/**
+ * Create a Transition Object.
+ * Transition objects reference the start and end Constraints
+ */
+public class Transition {
+    private OnSwipe mOnSwipe = null;
+    final int UNSET = -1;
+    private final int DEFAULT_DURATION = 400;
+    private final float DEFAULT_STAGGER = 0;
+    private String mId = null;
+    private String mConstraintSetEnd = null;
+    private String mConstraintSetStart = null;
+    @SuppressWarnings("unused") private int mDefaultInterpolator = 0;
+    @SuppressWarnings("unused") private String mDefaultInterpolatorString = null;
+    @SuppressWarnings("unused") private int mDefaultInterpolatorID = -1;
+    private int mDuration = DEFAULT_DURATION;
+    private float mStagger = DEFAULT_STAGGER;
+
+    private KeyFrames mKeyFrames = new KeyFrames();
+
+    public void setOnSwipe(OnSwipe onSwipe) {
+        mOnSwipe = onSwipe;
+    }
+
+    public void setKeyFrames(@SuppressWarnings("HiddenTypeParameter") Keys keyFrames) {
+        mKeyFrames.add(keyFrames);
+    }
+
+    public Transition(String from, String to) {
+        mId = "default";
+        mConstraintSetStart = from;
+        mConstraintSetEnd = to;
+    }
+
+    public Transition(String id, String from, String to) {
+        mId = id;
+        mConstraintSetStart = from;
+        mConstraintSetEnd = to;
+    }
+
+    String toJson() {
+        return toString();
+    }
+
+    public void setId(String id) {
+        mId = id;
+    }
+
+    public void setTo(String constraintSetEnd) {
+        mConstraintSetEnd = constraintSetEnd;
+    }
+
+    public void setFrom(String constraintSetStart) {
+        mConstraintSetStart = constraintSetStart;
+    }
+
+    public void setDuration(int duration) {
+        mDuration = duration;
+    }
+
+    public void setStagger(float stagger) {
+        mStagger = stagger;
+    }
+
+    @Override
+    public String toString() {
+        String ret = mId + ":{\n"
+                + "from:'" + mConstraintSetStart + "',\n"
+                + "to:'" + mConstraintSetEnd + "',\n";
+        if (mDuration != DEFAULT_DURATION) {
+            ret += "duration:" + mDuration + ",\n";
+        }
+        if (mStagger != DEFAULT_STAGGER) {
+            ret += "stagger:" + mStagger + ",\n";
+        }
+        if (mOnSwipe != null) {
+            ret += mOnSwipe.toString();
+        }
+
+        ret += mKeyFrames.toString();
+
+
+        ret += "},\n";
+
+        return ret;
+    }
+
+    public String getId() {
+        return mId;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/VChain.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/VChain.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+public class VChain extends Chain {
+
+    public class VAnchor extends Anchor {
+        VAnchor(Constraint.VSide side) {
+            super(Constraint.Side.valueOf(side.name()));
+        }
+    }
+
+    private VAnchor mTop = new VAnchor(Constraint.VSide.TOP);
+    private VAnchor mBottom = new VAnchor(Constraint.VSide.BOTTOM);
+    private VAnchor mBaseline = new VAnchor(Constraint.VSide.BASELINE);
+
+    public VChain(String name) {
+        super(name);
+        type = new HelperType(typeMap.get(Type.VERTICAL_CHAIN));
+    }
+
+    public VChain(String name, String config) {
+        super(name);
+        this.config = config;
+        type = new HelperType(typeMap.get(Type.VERTICAL_CHAIN));
+        configMap = convertConfigToMap();
+        if (configMap.containsKey("contains")) {
+            Ref.addStringToReferences(configMap.get("contains"), references);
+        }
+    }
+
+    /**
+     * Get the top anchor
+     *
+     * @return the top anchor
+     */
+    public VAnchor getTop() {
+        return mTop;
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToTop(Constraint.VAnchor anchor) {
+        linkToTop(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToTop(Constraint.VAnchor anchor, int margin) {
+        linkToTop(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Top
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToTop(Constraint.VAnchor anchor, int margin, int goneMargin) {
+        mTop.mConnection = anchor;
+        mTop.mMargin = margin;
+        mTop.mGoneMargin = goneMargin;
+        configMap.put("top", mTop.toString());
+    }
+
+    /**
+     * Get the bottom anchor
+     *
+     * @return the bottom anchor
+     */
+    public VAnchor getBottom() {
+        return mBottom;
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToBottom(Constraint.VAnchor anchor) {
+        linkToBottom(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToBottom(Constraint.VAnchor anchor, int margin) {
+        linkToBottom(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Bottom
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToBottom(Constraint.VAnchor anchor, int margin, int goneMargin) {
+        mBottom.mConnection = anchor;
+        mBottom.mMargin = margin;
+        mBottom.mGoneMargin = goneMargin;
+        configMap.put("bottom", mBottom.toString());
+    }
+
+    /**
+     * Get the baseline anchor
+     *
+     * @return the baseline anchor
+     */
+    public VAnchor getBaseline() {
+        return mBaseline;
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     */
+    public void linkToBaseline(Constraint.VAnchor anchor) {
+        linkToBaseline(anchor, 0);
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     */
+    public void linkToBaseline(Constraint.VAnchor anchor, int margin) {
+        linkToBaseline(anchor, margin, Integer.MIN_VALUE);
+    }
+
+    /**
+     * Connect anchor to Baseline
+     *
+     * @param anchor anchor to be connected
+     * @param margin value of the margin
+     * @param goneMargin value of the goneMargin
+     */
+    public void linkToBaseline(Constraint.VAnchor anchor, int margin, int goneMargin) {
+        mBaseline.mConnection = anchor;
+        mBaseline.mMargin = margin;
+        mBaseline.mGoneMargin = goneMargin;
+        configMap.put("baseline", mBaseline.toString());
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/dsl/VGuideline.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/dsl/VGuideline.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.dsl;
+
+public class VGuideline extends Guideline {
+    public VGuideline(String name) {
+        super(name);
+        type = new HelperType(typeMap.get(Type.VERTICAL_GUIDELINE));
+    }
+
+    public VGuideline(String name, String config) {
+        super(name);
+        this.config = config;
+        type = new HelperType(typeMap.get(Type.VERTICAL_GUIDELINE));
+        configMap = convertConfigToMap();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/CustomAttribute.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/CustomAttribute.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion;
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Defines non standard Attributes
+ *
+ *
+ */
+public class CustomAttribute {
+    private static final String TAG = "TransitionLayout";
+    @SuppressWarnings("unused") private boolean mMethod = false;
+    String mName;
+    private AttributeType mType;
+    private int mIntegerValue;
+    private float mFloatValue;
+    @SuppressWarnings("unused") private String mStringValue;
+    boolean mBooleanValue;
+    private int mColorValue;
+
+    public enum AttributeType {
+        INT_TYPE,
+        FLOAT_TYPE,
+        COLOR_TYPE,
+        COLOR_DRAWABLE_TYPE,
+        STRING_TYPE,
+        BOOLEAN_TYPE,
+        DIMENSION_TYPE,
+        REFERENCE_TYPE
+    }
+
+    public AttributeType getType() {
+        return mType;
+    }
+
+    /**
+     * Continuous types are interpolated they are fired only at
+     */
+    public boolean isContinuous() {
+        switch (mType) {
+            case REFERENCE_TYPE:
+            case BOOLEAN_TYPE:
+            case STRING_TYPE:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    public void setFloatValue(float value) {
+        mFloatValue = value;
+    }
+
+    public void setColorValue(int value) {
+        mColorValue = value;
+    }
+
+    public void setIntValue(int value) {
+        mIntegerValue = value;
+    }
+
+    public void setStringValue(String value) {
+        mStringValue = value;
+    }
+
+    /**
+     * The number of interpolation values that need to be interpolated
+     * Typically 1 but 3 for colors.
+     *
+     * @return Typically 1 but 3 for colors.
+     */
+    public int numberOfInterpolatedValues() {
+        switch (mType) {
+            case COLOR_TYPE:
+            case COLOR_DRAWABLE_TYPE:
+                return 4;
+            default:
+                return 1;
+        }
+    }
+
+    /**
+     * Transforms value to a float for the purpose of interpolation
+     *
+     * @return interpolation value
+     */
+    public float getValueToInterpolate() {
+        switch (mType) {
+            case INT_TYPE:
+                return mIntegerValue;
+            case FLOAT_TYPE:
+                return mFloatValue;
+            case COLOR_TYPE:
+            case COLOR_DRAWABLE_TYPE:
+                throw new RuntimeException("Color does not have a single color to interpolate");
+            case STRING_TYPE:
+                throw new RuntimeException("Cannot interpolate String");
+            case BOOLEAN_TYPE:
+                return mBooleanValue ? 1 : 0;
+            case DIMENSION_TYPE:
+                return mFloatValue;
+            default:
+                return Float.NaN;
+        }
+    }
+
+    // @TODO: add description
+    public void getValuesToInterpolate(float[] ret) {
+        switch (mType) {
+            case INT_TYPE:
+                ret[0] = mIntegerValue;
+                break;
+            case FLOAT_TYPE:
+                ret[0] = mFloatValue;
+                break;
+            case COLOR_DRAWABLE_TYPE:
+            case COLOR_TYPE:
+                int a = 0xFF & (mColorValue >> 24);
+                int r = 0xFF & (mColorValue >> 16);
+                int g = 0xFF & (mColorValue >> 8);
+                int b = 0xFF & mColorValue;
+                float f_r = (float) Math.pow(r / 255.0f, 2.2);
+                float f_g = (float) Math.pow(g / 255.0f, 2.2);
+                float f_b = (float) Math.pow(b / 255.0f, 2.2);
+                ret[0] = f_r;
+                ret[1] = f_g;
+                ret[2] = f_b;
+                ret[3] = a / 255f;
+                break;
+            case STRING_TYPE:
+                throw new RuntimeException("Color does not have a single color to interpolate");
+            case BOOLEAN_TYPE:
+                ret[0] = mBooleanValue ? 1 : 0;
+                break;
+            case DIMENSION_TYPE:
+                ret[0] = mFloatValue;
+                break;
+            default:
+                break;
+        }
+    }
+
+    // @TODO: add description
+    public void setValue(float[] value) {
+        switch (mType) {
+            case REFERENCE_TYPE:
+            case INT_TYPE:
+                mIntegerValue = (int) value[0];
+                break;
+            case FLOAT_TYPE:
+                mFloatValue = value[0];
+                break;
+            case COLOR_DRAWABLE_TYPE:
+            case COLOR_TYPE:
+                mColorValue = hsvToRgb(value[0], value[1], value[2]);
+                mColorValue = (mColorValue & 0xFFFFFF) | (clamp((int) (0xFF * value[3])) << 24);
+                break;
+            case STRING_TYPE:
+                throw new RuntimeException("Color does not have a single color to interpolate");
+            case BOOLEAN_TYPE:
+                mBooleanValue = value[0] > 0.5;
+                break;
+            case DIMENSION_TYPE:
+                mFloatValue = value[0];
+                break;
+            default:
+                break;
+        }
+    }
+
+    // @TODO: add description
+    public static int hsvToRgb(float hue, float saturation, float value) {
+        int h = (int) (hue * 6);
+        float f = hue * 6 - h;
+        int p = (int) (0.5f + 255 * value * (1 - saturation));
+        int q = (int) (0.5f + 255 * value * (1 - f * saturation));
+        int t = (int) (0.5f + 255 * value * (1 - (1 - f) * saturation));
+        int v = (int) (0.5f + 255 * value);
+        switch (h) {
+            case 0:
+                return 0XFF000000 | (v << 16) + (t << 8) + p;
+            case 1:
+                return 0XFF000000 | (q << 16) + (v << 8) + p;
+            case 2:
+                return 0XFF000000 | (p << 16) + (v << 8) + t;
+            case 3:
+                return 0XFF000000 | (p << 16) + (q << 8) + v;
+            case 4:
+                return 0XFF000000 | (t << 16) + (p << 8) + v;
+            case 5:
+                return 0XFF000000 | (v << 16) + (p << 8) + q;
+            default:
+                return 0;
+        }
+    }
+
+    /**
+     * test if the two attributes are different
+     */
+    public boolean diff(CustomAttribute customAttribute) {
+        if (customAttribute == null || mType != customAttribute.mType) {
+            return false;
+        }
+        switch (mType) {
+            case INT_TYPE:
+            case REFERENCE_TYPE:
+                return mIntegerValue == customAttribute.mIntegerValue;
+            case FLOAT_TYPE:
+                return mFloatValue == customAttribute.mFloatValue;
+            case COLOR_TYPE:
+            case COLOR_DRAWABLE_TYPE:
+                return mColorValue == customAttribute.mColorValue;
+            case STRING_TYPE:
+                return mIntegerValue == customAttribute.mIntegerValue;
+            case BOOLEAN_TYPE:
+                return mBooleanValue == customAttribute.mBooleanValue;
+            case DIMENSION_TYPE:
+                return mFloatValue == customAttribute.mFloatValue;
+            default:
+                return false;
+        }
+    }
+
+    public CustomAttribute(String name, AttributeType attributeType) {
+        mName = name;
+        mType = attributeType;
+    }
+
+    public CustomAttribute(String name, AttributeType attributeType, Object value, boolean method) {
+        mName = name;
+        mType = attributeType;
+        mMethod = method;
+        setValue(value);
+    }
+
+    public CustomAttribute(CustomAttribute source, Object value) {
+        mName = source.mName;
+        mType = source.mType;
+        setValue(value);
+
+    }
+
+    // @TODO: add description
+    public void setValue(Object value) {
+        switch (mType) {
+            case REFERENCE_TYPE:
+            case INT_TYPE:
+                mIntegerValue = (Integer) value;
+                break;
+            case FLOAT_TYPE:
+                mFloatValue = (Float) value;
+                break;
+            case COLOR_TYPE:
+            case COLOR_DRAWABLE_TYPE:
+                mColorValue = (Integer) value;
+                break;
+            case STRING_TYPE:
+                mStringValue = (String) value;
+                break;
+            case BOOLEAN_TYPE:
+                mBooleanValue = (Boolean) value;
+                break;
+            case DIMENSION_TYPE:
+                mFloatValue = (Float) value;
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static int clamp(int c) {
+        int n = 255;
+        c &= ~(c >> 31);
+        c -= n;
+        c &= (c >> 31);
+        c += n;
+        return c;
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/CustomVariable.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/CustomVariable.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion;
+
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+
+/**
+ * Defines non standard Attributes
+ */
+public class CustomVariable {
+    private static final String TAG = "TransitionLayout";
+    String mName;
+    private int mType;
+    private int mIntegerValue = Integer.MIN_VALUE;
+    private float mFloatValue = Float.NaN;
+    private String mStringValue = null;
+    boolean mBooleanValue;
+
+    // @TODO: add description
+    public CustomVariable copy() {
+        return new CustomVariable(this);
+    }
+
+    public CustomVariable(CustomVariable c) {
+        mName = c.mName;
+        mType = c.mType;
+        mIntegerValue = c.mIntegerValue;
+        mFloatValue = c.mFloatValue;
+        mStringValue = c.mStringValue;
+        mBooleanValue = c.mBooleanValue;
+    }
+
+    public CustomVariable(String name, int type, String value) {
+        mName = name;
+        mType = type;
+        mStringValue = value;
+    }
+
+    public CustomVariable(String name, int type, int value) {
+        mName = name;
+        mType = type;
+        if (type == TypedValues.Custom.TYPE_FLOAT) { // catch int ment for float
+            mFloatValue = value;
+        } else {
+            mIntegerValue = value;
+        }
+    }
+
+    public CustomVariable(String name, int type, float value) {
+        mName = name;
+        mType = type;
+        mFloatValue = value;
+    }
+
+    public CustomVariable(String name, int type, boolean value) {
+        mName = name;
+        mType = type;
+        mBooleanValue = value;
+    }
+
+    // @TODO: add description
+    public static String colorString(int v) {
+        String str = "00000000" + Integer.toHexString(v);
+        return "#" + str.substring(str.length() - 8);
+    }
+
+    @Override
+    public String toString() {
+        String str = mName + ':';
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+                return str + mIntegerValue;
+            case TypedValues.Custom.TYPE_FLOAT:
+                return str + mFloatValue;
+            case TypedValues.Custom.TYPE_COLOR:
+                return str + colorString(mIntegerValue);
+            case TypedValues.Custom.TYPE_STRING:
+                return str + mStringValue;
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                return str + (Boolean) mBooleanValue;
+            case TypedValues.Custom.TYPE_DIMENSION:
+                return str + mFloatValue;
+        }
+        return str + "????";
+    }
+
+    public int getType() {
+        return mType;
+    }
+
+    public boolean getBooleanValue() {
+        return mBooleanValue;
+    }
+
+    public float getFloatValue() {
+        return mFloatValue;
+    }
+
+    public int getColorValue() {
+        return mIntegerValue;
+    }
+
+    public int getIntegerValue() {
+        return mIntegerValue;
+    }
+
+    public String getStringValue() {
+        return mStringValue;
+    }
+
+    /**
+     * Continuous types are interpolated they are fired only at
+     */
+    public boolean isContinuous() {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_REFERENCE:
+            case TypedValues.Custom.TYPE_BOOLEAN:
+            case TypedValues.Custom.TYPE_STRING:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    public void setFloatValue(float value) {
+        mFloatValue = value;
+    }
+
+    public void setBooleanValue(boolean value) {
+        mBooleanValue = value;
+    }
+
+    public void setIntValue(int value) {
+        mIntegerValue = value;
+    }
+
+    public void setStringValue(String value) {
+        mStringValue = value;
+    }
+
+    /**
+     * The number of interpolation values that need to be interpolated
+     * Typically 1 but 3 for colors.
+     *
+     * @return Typically 1 but 3 for colors.
+     */
+    public int numberOfInterpolatedValues() {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_COLOR:
+                return 4;
+            default:
+                return 1;
+        }
+    }
+
+    /**
+     * Transforms value to a float for the purpose of interpolation
+     *
+     * @return interpolation value
+     */
+    public float getValueToInterpolate() {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+                return mIntegerValue;
+            case TypedValues.Custom.TYPE_FLOAT:
+                return mFloatValue;
+            case TypedValues.Custom.TYPE_COLOR:
+                throw new RuntimeException("Color does not have a single color to interpolate");
+            case TypedValues.Custom.TYPE_STRING:
+                throw new RuntimeException("Cannot interpolate String");
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                return mBooleanValue ? 1 : 0;
+            case TypedValues.Custom.TYPE_DIMENSION:
+                return mFloatValue;
+        }
+        return Float.NaN;
+    }
+
+    // @TODO: add description
+    public void getValuesToInterpolate(float[] ret) {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+                ret[0] = mIntegerValue;
+                break;
+            case TypedValues.Custom.TYPE_FLOAT:
+                ret[0] = mFloatValue;
+                break;
+            case TypedValues.Custom.TYPE_COLOR:
+                int a = 0xFF & (mIntegerValue >> 24);
+                int r = 0xFF & (mIntegerValue >> 16);
+                int g = 0xFF & (mIntegerValue >> 8);
+                int b = 0xFF & mIntegerValue;
+                float f_r = (float) Math.pow(r / 255.0f, 2.2);
+                float f_g = (float) Math.pow(g / 255.0f, 2.2);
+                float f_b = (float) Math.pow(b / 255.0f, 2.2);
+                ret[0] = f_r;
+                ret[1] = f_g;
+                ret[2] = f_b;
+                ret[3] = a / 255f;
+                break;
+            case TypedValues.Custom.TYPE_STRING:
+                throw new RuntimeException("Cannot interpolate String");
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                ret[0] = mBooleanValue ? 1 : 0;
+                break;
+            case TypedValues.Custom.TYPE_DIMENSION:
+                ret[0] = mFloatValue;
+                break;
+        }
+    }
+
+    // @TODO: add description
+    public void setValue(float[] value) {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_REFERENCE:
+            case TypedValues.Custom.TYPE_INT:
+                mIntegerValue = (int) value[0];
+                break;
+            case TypedValues.Custom.TYPE_FLOAT:
+            case TypedValues.Custom.TYPE_DIMENSION:
+                mFloatValue = value[0];
+                break;
+            case TypedValues.Custom.TYPE_COLOR:
+                float f_r = value[0];
+                float f_g = value[1];
+                float f_b = value[2];
+                int r = 0xFF & Math.round((float) Math.pow(f_r, 1.0 / 2.0) * 255.0f);
+                int g = 0xFF & Math.round((float) Math.pow(f_g, 1.0 / 2.0) * 255.0f);
+                int b = 0xFF & Math.round((float) Math.pow(f_b, 1.0 / 2.0) * 255.0f);
+                int a = 0xFF & Math.round(value[3] * 255.0f);
+                mIntegerValue = a << 24 | r << 16 | g << 8 | b;
+                break;
+            case TypedValues.Custom.TYPE_STRING:
+                throw new RuntimeException("Cannot interpolate String");
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                mBooleanValue = value[0] > 0.5;
+                break;
+        }
+    }
+
+    // @TODO: add description
+    public static int hsvToRgb(float hue, float saturation, float value) {
+        int h = (int) (hue * 6);
+        float f = hue * 6 - h;
+        int p = (int) (0.5f + 255 * value * (1 - saturation));
+        int q = (int) (0.5f + 255 * value * (1 - f * saturation));
+        int t = (int) (0.5f + 255 * value * (1 - (1 - f) * saturation));
+        int v = (int) (0.5f + 255 * value);
+        switch (h) {
+            case 0:
+                return 0XFF000000 | (v << 16) + (t << 8) + p;
+            case 1:
+                return 0XFF000000 | (q << 16) + (v << 8) + p;
+            case 2:
+                return 0XFF000000 | (p << 16) + (v << 8) + t;
+            case 3:
+                return 0XFF000000 | (p << 16) + (q << 8) + v;
+            case 4:
+                return 0XFF000000 | (t << 16) + (p << 8) + v;
+            case 5:
+                return 0XFF000000 | (v << 16) + (p << 8) + q;
+
+        }
+        return 0;
+    }
+
+    /**
+     * test if the two attributes are different
+     */
+    public boolean diff(CustomVariable customAttribute) {
+        if (customAttribute == null || mType != customAttribute.mType) {
+            return false;
+        }
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+            case TypedValues.Custom.TYPE_REFERENCE:
+                return mIntegerValue == customAttribute.mIntegerValue;
+            case TypedValues.Custom.TYPE_FLOAT:
+                return mFloatValue == customAttribute.mFloatValue;
+            case TypedValues.Custom.TYPE_COLOR:
+                return mIntegerValue == customAttribute.mIntegerValue;
+            case TypedValues.Custom.TYPE_STRING:
+                return mIntegerValue == customAttribute.mIntegerValue;
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                return mBooleanValue == customAttribute.mBooleanValue;
+            case TypedValues.Custom.TYPE_DIMENSION:
+                return mFloatValue == customAttribute.mFloatValue;
+        }
+        return false;
+    }
+
+    public CustomVariable(String name, int attributeType) {
+        mName = name;
+        mType = attributeType;
+    }
+
+    public CustomVariable(String name, int attributeType, Object value) {
+        mName = name;
+        mType = attributeType;
+        setValue(value);
+    }
+
+    public CustomVariable(CustomVariable source, Object value) {
+        mName = source.mName;
+        mType = source.mType;
+        setValue(value);
+
+    }
+
+    // @TODO: add description
+    public void setValue(Object value) {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_REFERENCE:
+            case TypedValues.Custom.TYPE_INT:
+                mIntegerValue = (Integer) value;
+                break;
+            case TypedValues.Custom.TYPE_FLOAT:
+                mFloatValue = (Float) value;
+                break;
+            case TypedValues.Custom.TYPE_COLOR:
+                mIntegerValue = (Integer) value;
+                break;
+            case TypedValues.Custom.TYPE_STRING:
+                mStringValue = (String) value;
+                break;
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                mBooleanValue = (Boolean) value;
+                break;
+            case TypedValues.Custom.TYPE_DIMENSION:
+                mFloatValue = (Float) value;
+                break;
+        }
+    }
+
+    private static int clamp(int c) {
+        int n = 255;
+        c &= ~(c >> 31);
+        c -= n;
+        c &= (c >> 31);
+        c += n;
+        return c;
+    }
+
+    // @TODO: add description
+    public int getInterpolatedColor(float[] value) {
+        int r = clamp((int) ((float) Math.pow(value[0], 1.0 / 2.2) * 255.0f));
+        int g = clamp((int) ((float) Math.pow(value[1], 1.0 / 2.2) * 255.0f));
+        int b = clamp((int) ((float) Math.pow(value[2], 1.0 / 2.2) * 255.0f));
+        int a = clamp((int) (value[3] * 255.0f));
+        int color = (a << 24) | (r << 16) | (g << 8) | b;
+        return color;
+    }
+
+    // @TODO: add description
+    public void setInterpolatedValue(MotionWidget view, float[] value) {
+
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+                view.setCustomAttribute(mName, mType, (int) value[0]);
+                break;
+            case TypedValues.Custom.TYPE_COLOR:
+                int r = clamp((int) ((float) Math.pow(value[0], 1.0 / 2.2) * 255.0f));
+                int g = clamp((int) ((float) Math.pow(value[1], 1.0 / 2.2) * 255.0f));
+                int b = clamp((int) ((float) Math.pow(value[2], 1.0 / 2.2) * 255.0f));
+                int a = clamp((int) (value[3] * 255.0f));
+                int color = (a << 24) | (r << 16) | (g << 8) | b;
+                view.setCustomAttribute(mName, mType, color);
+                break;
+            case TypedValues.Custom.TYPE_REFERENCE:
+            case TypedValues.Custom.TYPE_STRING:
+                throw new RuntimeException("unable to interpolate " + mName);
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                view.setCustomAttribute(mName, mType, value[0] > 0.5f);
+                break;
+            case TypedValues.Custom.TYPE_DIMENSION:
+            case TypedValues.Custom.TYPE_FLOAT:
+                view.setCustomAttribute(mName, mType, value[0]);
+                break;
+        }
+    }
+
+    // @TODO: add description
+    public static int rgbaTocColor(float r, float g, float b, float a) {
+        int ir = clamp((int) (r * 255f));
+        int ig = clamp((int) (g * 255f));
+        int ib = clamp((int) (b * 255f));
+        int ia = clamp((int) (a * 255f));
+        int color = (ia << 24) | (ir << 16) | (ig << 8) | ib;
+        return color;
+    }
+
+    // @TODO: add description
+    public void applyToWidget(MotionWidget view) {
+        switch (mType) {
+            case TypedValues.Custom.TYPE_INT:
+            case TypedValues.Custom.TYPE_COLOR:
+            case TypedValues.Custom.TYPE_REFERENCE:
+                view.setCustomAttribute(mName, mType, mIntegerValue);
+                break;
+            case TypedValues.Custom.TYPE_STRING:
+                view.setCustomAttribute(mName, mType, mStringValue);
+                break;
+            case TypedValues.Custom.TYPE_BOOLEAN:
+                view.setCustomAttribute(mName, mType, mBooleanValue);
+                break;
+            case TypedValues.Custom.TYPE_DIMENSION:
+            case TypedValues.Custom.TYPE_FLOAT:
+                view.setCustomAttribute(mName, mType, mFloatValue);
+                break;
+        }
+    }
+
+    public String getName() {
+        return mName;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/Motion.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/Motion.java
@@ -1,0 +1,1774 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion;
+
+import static androidx.constraintlayout.core.motion.MotionWidget.UNSET;
+
+import androidx.constraintlayout.core.motion.key.MotionConstraintSet;
+import androidx.constraintlayout.core.motion.key.MotionKey;
+import androidx.constraintlayout.core.motion.key.MotionKeyAttributes;
+import androidx.constraintlayout.core.motion.key.MotionKeyCycle;
+import androidx.constraintlayout.core.motion.key.MotionKeyPosition;
+import androidx.constraintlayout.core.motion.key.MotionKeyTimeCycle;
+import androidx.constraintlayout.core.motion.key.MotionKeyTrigger;
+import androidx.constraintlayout.core.motion.utils.CurveFit;
+import androidx.constraintlayout.core.motion.utils.DifferentialInterpolator;
+import androidx.constraintlayout.core.motion.utils.Easing;
+import androidx.constraintlayout.core.motion.utils.FloatRect;
+import androidx.constraintlayout.core.motion.utils.KeyCache;
+import androidx.constraintlayout.core.motion.utils.KeyCycleOscillator;
+import androidx.constraintlayout.core.motion.utils.KeyFrameArray;
+import androidx.constraintlayout.core.motion.utils.Rect;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TimeCycleSplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.motion.utils.Utils;
+import androidx.constraintlayout.core.motion.utils.VelocityMatrix;
+import androidx.constraintlayout.core.motion.utils.ViewState;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Contains the picture of a view through a transition and is used to interpolate it.
+ * During a transition every view has a MotionController which drives its position.
+ * <p>
+ * All parameter which affect a views motion are added to MotionController and then setup()
+ * builds out the splines that control the view.
+ *
+ *
+ */
+public class Motion implements TypedValues {
+    public static final int PATH_PERCENT = 0;
+    public static final int PATH_PERPENDICULAR = 1;
+    public static final int HORIZONTAL_PATH_X = 2;
+    public static final int HORIZONTAL_PATH_Y = 3;
+    public static final int VERTICAL_PATH_X = 4;
+    public static final int VERTICAL_PATH_Y = 5;
+    public static final int DRAW_PATH_NONE = 0;
+    public static final int DRAW_PATH_BASIC = 1;
+    public static final int DRAW_PATH_RELATIVE = 2;
+    public static final int DRAW_PATH_CARTESIAN = 3;
+    public static final int DRAW_PATH_AS_CONFIGURED = 4;
+    public static final int DRAW_PATH_RECTANGLE = 5;
+    public static final int DRAW_PATH_SCREEN = 6;
+
+    public static final int ROTATION_RIGHT = 1;
+    public static final int ROTATION_LEFT = 2;
+    Rect mTempRect = new Rect(); // for efficiency
+
+    private static final String TAG = "MotionController";
+    private static final boolean DEBUG = false;
+    private static final boolean FAVOR_FIXED_SIZE_VIEWS = false;
+    MotionWidget mView;
+    public String mId;
+    String mConstraintTag;
+    private int mCurveFitType = CurveFit.SPLINE;
+    private MotionPaths mStartMotionPath = new MotionPaths();
+    private MotionPaths mEndMotionPath = new MotionPaths();
+
+    private MotionConstrainedPoint mStartPoint = new MotionConstrainedPoint();
+    private MotionConstrainedPoint mEndPoint = new MotionConstrainedPoint();
+
+    // spline 0 is the generic one that process all the standard attributes
+    private CurveFit[] mSpline;
+    private CurveFit mArcSpline;
+    float mMotionStagger = Float.NaN;
+    float mStaggerOffset = 0;
+    float mStaggerScale = 1.0f;
+    float mCurrentCenterX, mCurrentCenterY;
+    private int[] mInterpolateVariables;
+    private double[] mInterpolateData; // scratch data created during setup
+    private double[] mInterpolateVelocity; // scratch data created during setup
+
+    private String[] mAttributeNames;  // the names of the custom attributes
+    private int[] mAttributeInterpolatorCount; // how many interpolators for each custom attribute
+    private int mMaxDimension = 4;
+    private float[] mValuesBuff = new float[mMaxDimension];
+    private ArrayList<MotionPaths> mMotionPaths = new ArrayList<>();
+    private float[] mVelocity = new float[1]; // used as a temp buffer to return values
+
+    private ArrayList<MotionKey> mKeyList = new ArrayList<>(); // List of key frame items
+
+    // splines to calculate for use TimeCycles
+    private HashMap<String, TimeCycleSplineSet> mTimeCycleAttributesMap;
+    private HashMap<String, SplineSet> mAttributesMap; // splines to calculate values of attributes
+
+    // splines to calculate values of attributes
+    private HashMap<String, KeyCycleOscillator> mCycleMap;
+    private MotionKeyTrigger[] mKeyTriggers; // splines to calculate values of attributes
+    private int mPathMotionArc = UNSET;
+
+    // if set, pivot point is maintained as the other object
+    private int mTransformPivotTarget = UNSET;
+
+    // if set, pivot point is maintained as the other object
+    private MotionWidget mTransformPivotView = null;
+    private int mQuantizeMotionSteps = UNSET;
+    private float mQuantizeMotionPhase = Float.NaN;
+    private DifferentialInterpolator mQuantizeMotionInterpolator = null;
+    private boolean mNoMovement = false;
+    Motion mRelativeMotion;
+    /**
+     * Get the view to pivot around
+     *
+     * @return id of view or UNSET if not set
+     */
+    public int getTransformPivotTarget() {
+        return mTransformPivotTarget;
+    }
+
+    /**
+     * Set a view to pivot around
+     *
+     * @param transformPivotTarget id of view
+     */
+    public void setTransformPivotTarget(int transformPivotTarget) {
+        mTransformPivotTarget = transformPivotTarget;
+        mTransformPivotView = null;
+    }
+
+    /**
+     * provides access to MotionPath objects
+     */
+    public MotionPaths getKeyFrame(int i) {
+        return mMotionPaths.get(i);
+    }
+
+    public Motion(MotionWidget view) {
+        setView(view);
+    }
+
+    /**
+     * get the left most position of the widget at the start of the movement.
+     *
+     * @return the left most position
+     */
+    public float getStartX() {
+        return mStartMotionPath.mX;
+    }
+
+    /**
+     * get the top most position of the widget at the start of the movement.
+     * Positive is down.
+     *
+     * @return the top most position
+     */
+    public float getStartY() {
+        return mStartMotionPath.mY;
+    }
+
+    /**
+     * get the left most position of the widget at the end of the movement.
+     *
+     * @return the left most position
+     */
+    public float getFinalX() {
+        return mEndMotionPath.mX;
+    }
+
+    /**
+     * get the top most position of the widget at the end of the movement.
+     * Positive is down.
+     *
+     * @return the top most position
+     */
+    public float getFinalY() {
+        return mEndMotionPath.mY;
+    }
+
+    /**
+     * get the width of the widget at the start of the movement.
+     *
+     * @return the width at the start
+     */
+    public float getStartWidth() {
+        return mStartMotionPath.mWidth;
+    }
+
+    /**
+     * get the width of the widget at the start of the movement.
+     *
+     * @return the height at the start
+     */
+    public float getStartHeight() {
+        return mStartMotionPath.mHeight;
+    }
+
+    /**
+     * get the width of the widget at the end of the movement.
+     *
+     * @return the width at the end
+     */
+    public float getFinalWidth() {
+        return mEndMotionPath.mWidth;
+    }
+
+    /**
+     * get the width of the widget at the end of the movement.
+     *
+     * @return the height at the end
+     */
+    public float getFinalHeight() {
+        return mEndMotionPath.mHeight;
+    }
+
+    /**
+     * Returns the id of the view to move relative to.
+     * The position at the start and then end will be viewed relative to this view
+     * -1 is the return value if NOT in polar mode
+     *
+     * @return the view id of the view this is in polar mode to or -1 if not in polar
+     */
+    public String getAnimateRelativeTo() {
+        return mStartMotionPath.mAnimateRelativeTo;
+    }
+
+    /**
+     * set up the motion to be relative to this other motionController
+     */
+    public void setupRelative(Motion motionController) {
+        mRelativeMotion = motionController;
+    }
+
+    private void setupRelative() {
+        if (mRelativeMotion == null) {
+            return;
+        }
+        mStartMotionPath.setupRelative(mRelativeMotion, mRelativeMotion.mStartMotionPath);
+        mEndMotionPath.setupRelative(mRelativeMotion, mRelativeMotion.mEndMotionPath);
+    }
+
+    public float getCenterX() {
+        return mCurrentCenterX;
+    }
+
+    public float getCenterY() {
+        return mCurrentCenterY;
+    }
+
+    // @TODO: add description
+    public void getCenter(double p, float[] pos, float[] vel) {
+        double[] position = new double[4];
+        double[] velocity = new double[4];
+        mSpline[0].getPos(p, position);
+        mSpline[0].getSlope(p, velocity);
+        Arrays.fill(vel, 0);
+        mStartMotionPath.getCenter(p, mInterpolateVariables, position, pos, velocity, vel);
+    }
+
+    /**
+     * Fills the array point with the center coordinates.
+     * point[0] is filled with the
+     * x coordinate of "time" 0.0 mPoints[point.length-1] is filled with the y coordinate of "time"
+     * 1.0
+     *
+     * @param points     array to fill (should be 2x pointCount)
+     * @param pointCount truncate mPoints to this length. Must be > 1 and <= mPoints.length
+     */
+    public void buildPath(float[] points, int pointCount) {
+        float mils = 1.0f / (pointCount - 1);
+        SplineSet trans_x =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_X);
+        SplineSet trans_y =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_Y);
+        KeyCycleOscillator osc_x =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_X);
+        KeyCycleOscillator osc_y =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_Y);
+
+        for (int i = 0; i < pointCount; i++) {
+            float position = i * mils;
+            if (mStaggerScale != 1.0f) {
+                if (position < mStaggerOffset) {
+                    position = 0;
+                }
+                if (position > mStaggerOffset && position < 1.0) {
+                    position -= mStaggerOffset;
+                    position *= mStaggerScale;
+                    position = Math.min(position, 1.0f);
+                }
+            }
+            double p = position;
+
+            Easing easing = mStartMotionPath.mKeyFrameEasing;
+            float start = 0;
+            float end = Float.NaN;
+            for (MotionPaths frame : mMotionPaths) {
+                if (frame.mKeyFrameEasing != null) { // this frame has an easing
+                    if (frame.mTime < position) {  // frame with easing is before the current pos
+                        easing = frame.mKeyFrameEasing; // this is the candidate
+                        start = frame.mTime; // this is also the starting time
+                    } else { // frame with easing is past the pos
+                        if (Float.isNaN(end)) { // we never ended the time line
+                            end = frame.mTime;
+                        }
+                    }
+                }
+            }
+
+            if (easing != null) {
+                if (Float.isNaN(end)) {
+                    end = 1.0f;
+                }
+                float offset = (position - start) / (end - start);
+                offset = (float) easing.get(offset);
+                p = offset * (end - start) + start;
+
+            }
+
+            mSpline[0].getPos(p, mInterpolateData);
+            if (mArcSpline != null) {
+                if (mInterpolateData.length > 0) {
+                    mArcSpline.getPos(p, mInterpolateData);
+                }
+            }
+            mStartMotionPath.getCenter(p, mInterpolateVariables, mInterpolateData, points, i * 2);
+
+            if (osc_x != null) {
+                points[i * 2] += osc_x.get(position);
+            } else if (trans_x != null) {
+                points[i * 2] += trans_x.get(position);
+            }
+            if (osc_y != null) {
+                points[i * 2 + 1] += osc_y.get(position);
+            } else if (trans_y != null) {
+                points[i * 2 + 1] += trans_y.get(position);
+            }
+        }
+    }
+
+    double[] getPos(double position) {
+        mSpline[0].getPos(position, mInterpolateData);
+        if (mArcSpline != null) {
+            if (mInterpolateData.length > 0) {
+                mArcSpline.getPos(position, mInterpolateData);
+            }
+        }
+        return mInterpolateData;
+    }
+
+    /**
+     * Fills the array point with the center coordinates.
+     * point[0] is filled with the
+     * x coordinate of "time" 0.0 mPoints[point.length-1] is filled with the y coordinate of "time"
+     * 1.0
+     *
+     * @param bounds array to fill (should be 2x the number of mPoints
+     * @return number of key frames
+     */
+    void buildBounds(float[] bounds, int pointCount) {
+        float mils = 1.0f / (pointCount - 1);
+        @SuppressWarnings("unused") SplineSet trans_x =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_X);
+        @SuppressWarnings("unused") SplineSet trans_y =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_Y);
+        @SuppressWarnings("unused") KeyCycleOscillator osc_x =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_X);
+        @SuppressWarnings("unused") KeyCycleOscillator osc_y =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_Y);
+
+        for (int i = 0; i < pointCount; i++) {
+            float position = i * mils;
+            if (mStaggerScale != 1.0f) {
+                if (position < mStaggerOffset) {
+                    position = 0;
+                }
+                if (position > mStaggerOffset && position < 1.0) {
+                    position -= mStaggerOffset;
+                    position *= mStaggerScale;
+                    position = Math.min(position, 1.0f);
+                }
+            }
+            double p = position;
+
+            Easing easing = mStartMotionPath.mKeyFrameEasing;
+            float start = 0;
+            float end = Float.NaN;
+            for (MotionPaths frame : mMotionPaths) {
+                if (frame.mKeyFrameEasing != null) { // this frame has an easing
+                    if (frame.mTime < position) {  // frame with easing is before the current pos
+                        easing = frame.mKeyFrameEasing; // this is the candidate
+                        start = frame.mTime; // this is also the starting time
+                    } else { // frame with easing is past the pos
+                        if (Float.isNaN(end)) { // we never ended the time line
+                            end = frame.mTime;
+                        }
+                    }
+                }
+            }
+
+            if (easing != null) {
+                if (Float.isNaN(end)) {
+                    end = 1.0f;
+                }
+                float offset = (position - start) / (end - start);
+                offset = (float) easing.get(offset);
+                p = offset * (end - start) + start;
+
+            }
+
+            mSpline[0].getPos(p, mInterpolateData);
+            if (mArcSpline != null) {
+                if (mInterpolateData.length > 0) {
+                    mArcSpline.getPos(p, mInterpolateData);
+                }
+            }
+            mStartMotionPath.getBounds(mInterpolateVariables, mInterpolateData, bounds, i * 2);
+        }
+    }
+
+    private float getPreCycleDistance() {
+        int pointCount = 100;
+        float[] points = new float[2];
+        float sum = 0;
+        float mils = 1.0f / (pointCount - 1);
+        double x = 0, y = 0;
+        for (int i = 0; i < pointCount; i++) {
+            float position = i * mils;
+
+            double p = position;
+
+            Easing easing = mStartMotionPath.mKeyFrameEasing;
+            float start = 0;
+            float end = Float.NaN;
+            for (MotionPaths frame : mMotionPaths) {
+                if (frame.mKeyFrameEasing != null) { // this frame has an easing
+                    if (frame.mTime < position) {  // frame with easing is before the current pos
+                        easing = frame.mKeyFrameEasing; // this is the candidate
+                        start = frame.mTime; // this is also the starting time
+                    } else { // frame with easing is past the pos
+                        if (Float.isNaN(end)) { // we never ended the time line
+                            end = frame.mTime;
+                        }
+                    }
+                }
+            }
+
+            if (easing != null) {
+                if (Float.isNaN(end)) {
+                    end = 1.0f;
+                }
+                float offset = (position - start) / (end - start);
+                offset = (float) easing.get(offset);
+                p = offset * (end - start) + start;
+
+            }
+
+            mSpline[0].getPos(p, mInterpolateData);
+            mStartMotionPath.getCenter(p, mInterpolateVariables, mInterpolateData, points, 0);
+            if (i > 0) {
+                sum += (float) Math.hypot(y - points[1], x - points[0]);
+            }
+            x = points[0];
+            y = points[1];
+        }
+        return sum;
+    }
+
+    MotionKeyPosition getPositionKeyframe(int layoutWidth, int layoutHeight, float x, float y) {
+        FloatRect start = new FloatRect();
+        start.left = mStartMotionPath.mX;
+        start.top = mStartMotionPath.mY;
+        start.right = start.left + mStartMotionPath.mWidth;
+        start.bottom = start.top + mStartMotionPath.mHeight;
+        FloatRect end = new FloatRect();
+        end.left = mEndMotionPath.mX;
+        end.top = mEndMotionPath.mY;
+        end.right = end.left + mEndMotionPath.mWidth;
+        end.bottom = end.top + mEndMotionPath.mHeight;
+        for (MotionKey key : mKeyList) {
+            if (key instanceof MotionKeyPosition) {
+                if (((MotionKeyPosition) key).intersects(layoutWidth,
+                        layoutHeight, start, end, x, y)) {
+                    return (MotionKeyPosition) key;
+                }
+            }
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public int buildKeyFrames(float[] keyFrames, int[] mode, int[] pos) {
+        if (keyFrames != null) {
+            int count = 0;
+            double[] time = mSpline[0].getTimePoints();
+            if (mode != null) {
+                for (MotionPaths keyFrame : mMotionPaths) {
+                    mode[count++] = keyFrame.mMode;
+                }
+                count = 0;
+            }
+            if (pos != null) {
+                for (MotionPaths keyFrame : mMotionPaths) {
+                    pos[count++] = (int) (100 * keyFrame.mPosition);
+                }
+                count = 0;
+            }
+            for (int i = 0; i < time.length; i++) {
+                mSpline[0].getPos(time[i], mInterpolateData);
+                mStartMotionPath.getCenter(time[i],
+                        mInterpolateVariables, mInterpolateData, keyFrames, count);
+                count += 2;
+            }
+            return count / 2;
+        }
+        return 0;
+    }
+
+    int buildKeyBounds(float[] keyBounds, int[] mode) {
+        if (keyBounds != null) {
+            int count = 0;
+            double[] time = mSpline[0].getTimePoints();
+            if (mode != null) {
+                for (MotionPaths keyFrame : mMotionPaths) {
+                    mode[count++] = keyFrame.mMode;
+                }
+                count = 0;
+            }
+
+            for (int i = 0; i < time.length; i++) {
+                mSpline[0].getPos(time[i], mInterpolateData);
+                mStartMotionPath.getBounds(mInterpolateVariables,
+                        mInterpolateData, keyBounds, count);
+                count += 2;
+            }
+            return count / 2;
+        }
+        return 0;
+    }
+
+    String[] mAttributeTable;
+
+    int getAttributeValues(String attributeType, float[] points, int pointCount) {
+        @SuppressWarnings("unused") float mils = 1.0f / (pointCount - 1);
+        SplineSet spline = mAttributesMap.get(attributeType);
+        if (spline == null) {
+            return -1;
+        }
+        for (int j = 0; j < points.length; j++) {
+            points[j] = spline.get(j / (points.length - 1));
+        }
+        return points.length;
+    }
+
+    // @TODO: add description
+    public void buildRect(float p, float[] path, int offset) {
+        p = getAdjustedPosition(p, null);
+        mSpline[0].getPos(p, mInterpolateData);
+        mStartMotionPath.getRect(mInterpolateVariables, mInterpolateData, path, offset);
+    }
+
+    void buildRectangles(float[] path, int pointCount) {
+        float mils = 1.0f / (pointCount - 1);
+        for (int i = 0; i < pointCount; i++) {
+            float position = i * mils;
+            position = getAdjustedPosition(position, null);
+            mSpline[0].getPos(position, mInterpolateData);
+            mStartMotionPath.getRect(mInterpolateVariables, mInterpolateData, path, i * 8);
+        }
+    }
+
+    float getKeyFrameParameter(int type, float x, float y) {
+
+        float dx = mEndMotionPath.mX - mStartMotionPath.mX;
+        float dy = mEndMotionPath.mY - mStartMotionPath.mY;
+        float startCenterX = mStartMotionPath.mX + mStartMotionPath.mWidth / 2;
+        float startCenterY = mStartMotionPath.mY + mStartMotionPath.mHeight / 2;
+        float hypotenuse = (float) Math.hypot(dx, dy);
+        if (hypotenuse < 0.0000001) {
+            return Float.NaN;
+        }
+
+        float vx = x - startCenterX;
+        float vy = y - startCenterY;
+        float distFromStart = (float) Math.hypot(vx, vy);
+        if (distFromStart == 0) {
+            return 0;
+        }
+        float pathDistance = (vx * dx + vy * dy);
+
+        switch (type) {
+            case PATH_PERCENT:
+                return pathDistance / hypotenuse;
+            case PATH_PERPENDICULAR:
+                return (float) Math.sqrt(hypotenuse * hypotenuse - pathDistance * pathDistance);
+            case HORIZONTAL_PATH_X:
+                return vx / dx;
+            case HORIZONTAL_PATH_Y:
+                return vy / dx;
+            case VERTICAL_PATH_X:
+                return vx / dy;
+            case VERTICAL_PATH_Y:
+                return vy / dy;
+        }
+        return 0;
+    }
+
+    private void insertKey(MotionPaths point) {
+        MotionPaths redundant = null;
+        for (MotionPaths p : mMotionPaths) {
+            if (point.mPosition == p.mPosition) {
+                redundant = p;
+            }
+        }
+        if (redundant != null) {
+            mMotionPaths.remove(redundant);
+        }
+        int pos = Collections.binarySearch(mMotionPaths, point);
+        if (pos == 0) {
+            Utils.loge(TAG, " KeyPath position \"" + point.mPosition + "\" outside of range");
+        }
+        mMotionPaths.add(-pos - 1, point);
+    }
+
+    void addKeys(ArrayList<MotionKey> list) {
+        mKeyList.addAll(list);
+        if (DEBUG) {
+            for (MotionKey key : mKeyList) {
+                Utils.log(TAG, " ################ set = " + key.getClass().getSimpleName());
+            }
+        }
+    }
+
+    // @TODO: add description
+    public void addKey(MotionKey key) {
+        mKeyList.add(key);
+        if (DEBUG) {
+            Utils.log(TAG, " ################ addKey = " + key.getClass().getSimpleName());
+        }
+    }
+
+    public void setPathMotionArc(int arc) {
+        mPathMotionArc = arc;
+    }
+
+    /**
+     * Called after all TimePoints & Cycles have been added;
+     * Spines are evaluated
+     */
+    public void setup(int parentWidth,
+            int parentHeight,
+            float transitionDuration,
+            long currentTime) {
+        @SuppressWarnings({"unused", "ModifiedButNotUsed"})
+        HashSet<String> springAttributes = new HashSet<>();
+        // attributes we need to interpolate
+        HashSet<String> timeCycleAttributes = new HashSet<>(); // attributes we need to interpolate
+        HashSet<String> splineAttributes = new HashSet<>(); // attributes we need to interpolate
+        HashSet<String> cycleAttributes = new HashSet<>(); // attributes we need to oscillate
+        HashMap<String, Integer> interpolation = new HashMap<>();
+        ArrayList<MotionKeyTrigger> triggerList = null;
+
+        setupRelative();
+        if (DEBUG) {
+            if (mKeyList == null) {
+                Utils.log(TAG, ">>>>>>>>>>>>>>> mKeyList==null");
+
+            } else {
+                Utils.log(TAG, ">>>>>>>>>>>>>>> mKeyList for " + mView.getName());
+
+            }
+        }
+
+        if (mPathMotionArc != UNSET && mStartMotionPath.mPathMotionArc == UNSET) {
+            mStartMotionPath.mPathMotionArc = mPathMotionArc;
+        }
+
+        mStartPoint.different(mEndPoint, splineAttributes);
+        if (DEBUG) {
+            HashSet<String> attr = new HashSet<>();
+            mStartPoint.different(mEndPoint, attr);
+            Utils.log(TAG, ">>>>>>>>>>>>>>> MotionConstrainedPoint found "
+                    + Arrays.toString(attr.toArray()));
+        }
+        if (mKeyList != null) {
+            for (MotionKey key : mKeyList) {
+                if (key instanceof MotionKeyPosition) {
+                    MotionKeyPosition keyPath = (MotionKeyPosition) key;
+                    insertKey(new MotionPaths(parentWidth, parentHeight,
+                            keyPath, mStartMotionPath, mEndMotionPath));
+                    if (keyPath.mCurveFit != UNSET) {
+                        mCurveFitType = keyPath.mCurveFit;
+                    }
+                } else if (key instanceof MotionKeyCycle) {
+                    key.getAttributeNames(cycleAttributes);
+                } else if (key instanceof MotionKeyTimeCycle) {
+                    key.getAttributeNames(timeCycleAttributes);
+                } else if (key instanceof MotionKeyTrigger) {
+                    if (triggerList == null) {
+                        triggerList = new ArrayList<>();
+                    }
+                    triggerList.add((MotionKeyTrigger) key);
+                } else {
+                    key.setInterpolation(interpolation);
+                    key.getAttributeNames(splineAttributes);
+                }
+            }
+        }
+
+        //--------------------------- trigger support --------------------
+
+        if (triggerList != null) {
+            mKeyTriggers = triggerList.toArray(new MotionKeyTrigger[0]);
+        }
+
+        //--------------------------- splines support --------------------
+        if (!splineAttributes.isEmpty()) {
+            mAttributesMap = new HashMap<>();
+            for (String attribute : splineAttributes) {
+                SplineSet splineSets;
+                if (attribute.startsWith("CUSTOM,")) {
+                    KeyFrameArray.CustomVar attrList = new KeyFrameArray.CustomVar();
+                    String customAttributeName = attribute.split(",")[1];
+                    for (MotionKey key : mKeyList) {
+                        if (key.mCustom == null) {
+                            continue;
+                        }
+                        CustomVariable customAttribute = key.mCustom.get(customAttributeName);
+                        if (customAttribute != null) {
+                            attrList.append(key.mFramePosition, customAttribute);
+                        }
+                    }
+                    splineSets = SplineSet.makeCustomSplineSet(attribute, attrList);
+                } else {
+                    splineSets = SplineSet.makeSpline(attribute, currentTime);
+                }
+                if (splineSets == null) {
+                    continue;
+                }
+                splineSets.setType(attribute);
+                mAttributesMap.put(attribute, splineSets);
+            }
+            if (mKeyList != null) {
+                for (MotionKey key : mKeyList) {
+                    if ((key instanceof MotionKeyAttributes)) {
+                        key.addValues(mAttributesMap);
+                    }
+                }
+            }
+            mStartPoint.addValues(mAttributesMap, 0);
+            mEndPoint.addValues(mAttributesMap, 100);
+
+            for (String spline : mAttributesMap.keySet()) {
+                int curve = CurveFit.SPLINE; // default is SPLINE
+                if (interpolation.containsKey(spline)) {
+                    Integer boxedCurve = interpolation.get(spline);
+                    if (boxedCurve != null) {
+                        curve = boxedCurve;
+                    }
+                }
+                SplineSet splineSet = mAttributesMap.get(spline);
+                if (splineSet != null) {
+                    splineSet.setup(curve);
+                }
+            }
+        }
+
+        //--------------------------- timeCycle support --------------------
+        if (!timeCycleAttributes.isEmpty()) {
+            if (mTimeCycleAttributesMap == null) {
+                mTimeCycleAttributesMap = new HashMap<>();
+            }
+            for (String attribute : timeCycleAttributes) {
+                if (mTimeCycleAttributesMap.containsKey(attribute)) {
+                    continue;
+                }
+
+                SplineSet splineSets = null;
+                if (attribute.startsWith("CUSTOM,")) {
+                    KeyFrameArray.CustomVar attrList = new KeyFrameArray.CustomVar();
+                    String customAttributeName = attribute.split(",")[1];
+                    for (MotionKey key : mKeyList) {
+                        if (key.mCustom == null) {
+                            continue;
+                        }
+                        CustomVariable customAttribute = key.mCustom.get(customAttributeName);
+                        if (customAttribute != null) {
+                            attrList.append(key.mFramePosition, customAttribute);
+                        }
+                    }
+                    splineSets = SplineSet.makeCustomSplineSet(attribute, attrList);
+                } else {
+                    splineSets = SplineSet.makeSpline(attribute, currentTime);
+                }
+                if (splineSets == null) {
+                    continue;
+                }
+                splineSets.setType(attribute);
+//                mTimeCycleAttributesMap.put(attribute, splineSets);
+            }
+
+            if (mKeyList != null) {
+                for (MotionKey key : mKeyList) {
+                    if (key instanceof MotionKeyTimeCycle) {
+                        ((MotionKeyTimeCycle) key).addTimeValues(mTimeCycleAttributesMap);
+                    }
+                }
+            }
+
+            for (String spline : mTimeCycleAttributesMap.keySet()) {
+                int curve = CurveFit.SPLINE; // default is SPLINE
+                if (interpolation.containsKey(spline)) {
+                    curve = interpolation.get(spline);
+                }
+                mTimeCycleAttributesMap.get(spline).setup(curve);
+            }
+        }
+
+        //--------------------------------- end new key frame 2
+
+        MotionPaths[] points = new MotionPaths[2 + mMotionPaths.size()];
+        int count = 1;
+        points[0] = mStartMotionPath;
+        points[points.length - 1] = mEndMotionPath;
+        if (mMotionPaths.size() > 0 && mCurveFitType == MotionKey.UNSET) {
+            mCurveFitType = CurveFit.SPLINE;
+        }
+        for (MotionPaths point : mMotionPaths) {
+            points[count++] = point;
+        }
+
+        // -----  setup custom attributes which must be in the start and end constraint sets
+        int variables = 18;
+        HashSet<String> attributeNameSet = new HashSet<>();
+        for (String s : mEndMotionPath.mCustomAttributes.keySet()) {
+            if (mStartMotionPath.mCustomAttributes.containsKey(s)) {
+                if (!splineAttributes.contains("CUSTOM," + s)) {
+                    attributeNameSet.add(s);
+                }
+            }
+        }
+
+        mAttributeNames = attributeNameSet.toArray(new String[0]);
+        mAttributeInterpolatorCount = new int[mAttributeNames.length];
+        for (int i = 0; i < mAttributeNames.length; i++) {
+            String attributeName = mAttributeNames[i];
+            mAttributeInterpolatorCount[i] = 0;
+            for (int j = 0; j < points.length; j++) {
+                if (points[j].mCustomAttributes.containsKey(attributeName)) {
+                    CustomVariable attribute = points[j].mCustomAttributes.get(attributeName);
+                    if (attribute != null) {
+                        mAttributeInterpolatorCount[i] += attribute.numberOfInterpolatedValues();
+                        break;
+                    }
+                }
+            }
+        }
+        boolean arcMode = points[0].mPathMotionArc != UNSET;
+        boolean[] mask = new boolean[variables + mAttributeNames.length]; // defaults to false
+        for (int i = 1; i < points.length; i++) {
+            points[i].different(points[i - 1], mask, mAttributeNames, arcMode);
+        }
+
+        count = 0;
+        for (int i = 1; i < mask.length; i++) {
+            if (mask[i]) {
+                count++;
+            }
+        }
+
+        mInterpolateVariables = new int[count];
+        int varLen = Math.max(2, count);
+        mInterpolateData = new double[varLen];
+        mInterpolateVelocity = new double[varLen];
+
+        count = 0;
+        for (int i = 1; i < mask.length; i++) {
+            if (mask[i]) {
+                mInterpolateVariables[count++] = i;
+            }
+        }
+
+        double[][] splineData = new double[points.length][mInterpolateVariables.length];
+        double[] timePoint = new double[points.length];
+
+        for (int i = 0; i < points.length; i++) {
+            points[i].fillStandard(splineData[i], mInterpolateVariables);
+            timePoint[i] = points[i].mTime;
+        }
+
+        for (int j = 0; j < mInterpolateVariables.length; j++) {
+            int interpolateVariable = mInterpolateVariables[j];
+            if (interpolateVariable < MotionPaths.sNames.length) {
+                @SuppressWarnings("unused") String s =
+                        MotionPaths.sNames[mInterpolateVariables[j]] + " [";
+                for (int i = 0; i < points.length; i++) {
+                    s += splineData[i][j];
+                }
+            }
+        }
+        mSpline = new CurveFit[1 + mAttributeNames.length];
+
+        for (int i = 0; i < mAttributeNames.length; i++) {
+            int pointCount = 0;
+            double[][] splinePoints = null;
+            double[] timePoints = null;
+            String name = mAttributeNames[i];
+
+            for (int j = 0; j < points.length; j++) {
+                if (points[j].hasCustomData(name)) {
+                    if (splinePoints == null) {
+                        timePoints = new double[points.length];
+                        splinePoints =
+                                new double[points.length][points[j].getCustomDataCount(name)];
+                    }
+                    timePoints[pointCount] = points[j].mTime;
+                    points[j].getCustomData(name, splinePoints[pointCount], 0);
+                    pointCount++;
+                }
+            }
+            timePoints = Arrays.copyOf(timePoints, pointCount);
+            splinePoints = Arrays.copyOf(splinePoints, pointCount);
+            mSpline[i + 1] = CurveFit.get(mCurveFitType, timePoints, splinePoints);
+        }
+
+        // Spline for positions
+        mSpline[0] = CurveFit.get(mCurveFitType, timePoint, splineData);
+        // --------------------------- SUPPORT ARC MODE --------------
+        if (points[0].mPathMotionArc != UNSET) {
+            int size = points.length;
+            int[] mode = new int[size];
+            double[] time = new double[size];
+            double[][] values = new double[size][2];
+            for (int i = 0; i < size; i++) {
+                mode[i] = points[i].mPathMotionArc;
+                time[i] = points[i].mTime;
+                values[i][0] = points[i].mX;
+                values[i][1] = points[i].mY;
+            }
+
+            mArcSpline = CurveFit.getArc(mode, time, values);
+        }
+
+        //--------------------------- Cycle support --------------------
+        float distance = Float.NaN;
+        mCycleMap = new HashMap<>();
+        if (mKeyList != null) {
+            for (String attribute : cycleAttributes) {
+                KeyCycleOscillator cycle = KeyCycleOscillator.makeWidgetCycle(attribute);
+                if (cycle == null) {
+                    continue;
+                }
+
+                if (cycle.variesByPath()) {
+                    if (Float.isNaN(distance)) {
+                        distance = getPreCycleDistance();
+                    }
+                }
+                cycle.setType(attribute);
+                mCycleMap.put(attribute, cycle);
+            }
+            for (MotionKey key : mKeyList) {
+                if (key instanceof MotionKeyCycle) {
+                    ((MotionKeyCycle) key).addCycleValues(mCycleMap);
+                }
+            }
+            for (KeyCycleOscillator cycle : mCycleMap.values()) {
+                cycle.setup(distance);
+            }
+        }
+
+        if (DEBUG) {
+            Utils.log(TAG, "Animation of splineAttributes "
+                    + Arrays.toString(splineAttributes.toArray()));
+            Utils.log(TAG, "Animation of cycle " + Arrays.toString(mCycleMap.keySet().toArray()));
+            if (mAttributesMap != null) {
+                Utils.log(TAG, " splines = " + Arrays.toString(mAttributesMap.keySet().toArray()));
+                for (String s : mAttributesMap.keySet()) {
+                    Utils.log(TAG, s + " = " + mAttributesMap.get(s));
+                }
+            }
+            Utils.log(TAG, " ---------------------------------------- ");
+        }
+
+        //--------------------------- end cycle support ----------------
+    }
+
+    /**
+     * Debug string
+     */
+    @Override
+    public String toString() {
+        return " start: x: " + mStartMotionPath.mX + " y: " + mStartMotionPath.mY
+                + " end: x: " + mEndMotionPath.mX + " y: " + mEndMotionPath.mY;
+    }
+
+    private void readView(MotionPaths motionPaths) {
+        motionPaths.setBounds((int) mView.getX(), (int) mView.getY(),
+                mView.getWidth(), mView.getHeight());
+    }
+
+    public void setView(MotionWidget view) {
+        mView = view;
+    }
+
+    public MotionWidget getView() {
+        return mView;
+    }
+
+    // @TODO: add description
+    public void setStart(MotionWidget mw) {
+        mStartMotionPath.mTime = 0;
+        mStartMotionPath.mPosition = 0;
+        mStartMotionPath.setBounds(mw.getX(), mw.getY(), mw.getWidth(), mw.getHeight());
+        mStartMotionPath.applyParameters(mw);
+        mStartPoint.setState(mw);
+        TypedBundle p = mw.getWidgetFrame().getMotionProperties();
+        if (p != null) {
+            p.applyDelta(this);
+        }
+    }
+
+    // @TODO: add description
+    public void setEnd(MotionWidget mw) {
+        mEndMotionPath.mTime = 1;
+        mEndMotionPath.mPosition = 1;
+        readView(mEndMotionPath);
+        mEndMotionPath.setBounds(mw.getLeft(), mw.getTop(), mw.getWidth(), mw.getHeight());
+        mEndMotionPath.applyParameters(mw);
+        mEndPoint.setState(mw);
+    }
+
+    // @TODO: add description
+    public void setStartState(ViewState rect,
+            MotionWidget v,
+            int rotation,
+            int preWidth,
+            int preHeight) {
+        mStartMotionPath.mTime = 0;
+        mStartMotionPath.mPosition = 0;
+        int cx, cy;
+        Rect r = new Rect();
+        switch (rotation) {
+            case 2:
+                cx = rect.left + rect.right;
+                cy = rect.top + rect.bottom;
+                r.left = preHeight - (cy + rect.width()) / 2;
+                r.top = (cx - rect.height()) / 2;
+                r.right = r.left + rect.width();
+                r.bottom = r.top + rect.height();
+                break;
+            case 1:
+                cx = rect.left + rect.right;
+                cy = rect.top + rect.bottom;
+                r.left = (cy - rect.width()) / 2;
+                r.top = preWidth - (cx + rect.height()) / 2;
+                r.right = r.left + rect.width();
+                r.bottom = r.top + rect.height();
+                break;
+        }
+        mStartMotionPath.setBounds(r.left, r.top, r.width(), r.height());
+        mStartPoint.setState(r, v, rotation, rect.rotation);
+    }
+
+    void rotate(Rect rect, Rect out, int rotation, int preHeight, int preWidth) {
+        int cx, cy;
+        switch (rotation) {
+
+            case MotionConstraintSet.ROTATE_PORTRATE_OF_LEFT:
+                cx = rect.left + rect.right;
+                cy = rect.top + rect.bottom;
+                out.left = preHeight - (cy + rect.width()) / 2;
+                out.top = (cx - rect.height()) / 2;
+                out.right = out.left + rect.width();
+                out.bottom = out.top + rect.height();
+                break;
+            case MotionConstraintSet.ROTATE_PORTRATE_OF_RIGHT:
+                cx = rect.left + rect.right;
+                cy = rect.top + rect.bottom;
+                out.left = (cy - rect.width()) / 2;
+                out.top = preWidth - (cx + rect.height()) / 2;
+                out.right = out.left + rect.width();
+                out.bottom = out.top + rect.height();
+                break;
+            case MotionConstraintSet.ROTATE_LEFT_OF_PORTRATE:
+                cx = rect.left + rect.right;
+                cy = rect.bottom + rect.top;
+                out.left = preHeight - (cy + rect.width()) / 2;
+                out.top = (cx - rect.height()) / 2;
+                out.right = out.left + rect.width();
+                out.bottom = out.top + rect.height();
+                break;
+            case MotionConstraintSet.ROTATE_RIGHT_OF_PORTRATE:
+                cx = rect.left + rect.right;
+                cy = rect.top + rect.bottom;
+                out.left = rect.height() / 2 + rect.top - cx / 2;
+                out.top = preWidth - (cx + rect.height()) / 2;
+                out.right = out.left + rect.width();
+                out.bottom = out.top + rect.height();
+                break;
+        }
+    }
+
+    // Todo : Implement  QuantizeMotion scene rotate
+    //    void setStartState(Rect cw, ConstraintSet constraintSet,
+    //                      int parentWidth, int parentHeight) {
+    //        int rotate = constraintSet.mRotate; // for rotated frames
+    //        if (rotate != 0) {
+    //            rotate(cw, mTempRect, rotate, parentWidth, parentHeight);
+    //        }
+    //        mStartMotionPath.time = 0;
+    //        mStartMotionPath.position = 0;
+    //        readView(mStartMotionPath);
+    //        mStartMotionPath.setBounds(cw.left, cw.top, cw.width(), cw.height());
+    //        ConstraintSet.Constraint constraint = constraintSet.getParameters(mId);
+    //        mStartMotionPath.applyParameters(constraint);
+    //        mMotionStagger = constraint.motion.mMotionStagger;
+    //        mStartPoint.setState(cw, constraintSet, rotate, mId);
+    //        mTransformPivotTarget = constraint.transform.transformPivotTarget;
+    //        mQuantizeMotionSteps = constraint.motion.mQuantizeMotionSteps;
+    //        mQuantizeMotionPhase = constraint.motion.mQuantizeMotionPhase;
+    //        mQuantizeMotionInterpolator = getInterpolator(mView.getContext(),
+    //                constraint.motion.mQuantizeInterpolatorType,
+    //                constraint.motion.mQuantizeInterpolatorString,
+    //                constraint.motion.mQuantizeInterpolatorID
+    //        );
+    //    }
+
+    static final int EASE_IN_OUT = 0;
+    static final int EASE_IN = 1;
+    static final int EASE_OUT = 2;
+    static final int LINEAR = 3;
+    static final int BOUNCE = 4;
+    static final int OVERSHOOT = 5;
+    private static final int SPLINE_STRING = -1;
+    @SuppressWarnings("unused") private static final int INTERPOLATOR_REFERENCE_ID = -2;
+    @SuppressWarnings("unused") private static final int INTERPOLATOR_UNDEFINED = -3;
+
+    private static DifferentialInterpolator getInterpolator(int type,
+            String interpolatorString,
+            @SuppressWarnings("unused") int id) {
+        switch (type) {
+            case SPLINE_STRING:
+                final Easing easing = Easing.getInterpolator(interpolatorString);
+                return new DifferentialInterpolator() {
+                    float mX;
+
+                    @Override
+                    public float getInterpolation(float x) {
+                        mX = x;
+                        return (float) easing.get(x);
+                    }
+
+                    @Override
+                    public float getVelocity() {
+                        return (float) easing.getDiff(mX);
+                    }
+                };
+
+        }
+        return null;
+    }
+
+//    void setEndState(Rect cw, ConstraintSet constraintSet, int parentWidth, int parentHeight) {
+//        int rotate = constraintSet.mRotate; // for rotated frames
+//        if (rotate != 0) {
+//            rotate(cw, mTempRect, rotate, parentWidth, parentHeight);
+//            cw = mTempRect;
+//        }
+//        mEndMotionPath.time = 1;
+//        mEndMotionPath.position = 1;
+//        readView(mEndMotionPath);
+//        mEndMotionPath.setBounds(cw.left, cw.top, cw.width(), cw.height());
+//        mEndMotionPath.applyParameters(constraintSet.getParameters(mId));
+//        mEndPoint.setState(cw, constraintSet, rotate, mId);
+//    }
+
+    void setBothStates(MotionWidget v) {
+        mStartMotionPath.mTime = 0;
+        mStartMotionPath.mPosition = 0;
+        mNoMovement = true;
+        mStartMotionPath.setBounds(v.getX(), v.getY(), v.getWidth(), v.getHeight());
+        mEndMotionPath.setBounds(v.getX(), v.getY(), v.getWidth(), v.getHeight());
+        mStartPoint.setState(v);
+        mEndPoint.setState(v);
+    }
+
+    /**
+     * Calculates the adjusted position (and optional velocity).
+     * Note if requesting velocity staggering is not considered
+     *
+     * @param position position pre stagger
+     * @param velocity return velocity
+     * @return actual position accounting for easing and staggering
+     */
+    private float getAdjustedPosition(float position, float[] velocity) {
+        if (velocity != null) {
+            velocity[0] = 1;
+        } else if (mStaggerScale != 1.0) {
+            if (position < mStaggerOffset) {
+                position = 0;
+            }
+            if (position > mStaggerOffset && position < 1.0) {
+                position -= mStaggerOffset;
+                position *= mStaggerScale;
+                position = Math.min(position, 1.0f);
+            }
+        }
+
+        // adjust the position based on the easing curve
+        float adjusted = position;
+        Easing easing = mStartMotionPath.mKeyFrameEasing;
+        float start = 0;
+        float end = Float.NaN;
+        for (MotionPaths frame : mMotionPaths) {
+            if (frame.mKeyFrameEasing != null) { // this frame has an easing
+                if (frame.mTime < position) {  // frame with easing is before the current pos
+                    easing = frame.mKeyFrameEasing; // this is the candidate
+                    start = frame.mTime; // this is also the starting time
+                } else { // frame with easing is past the pos
+                    if (Float.isNaN(end)) { // we never ended the time line
+                        end = frame.mTime;
+                    }
+                }
+            }
+        }
+
+        if (easing != null) {
+            if (Float.isNaN(end)) {
+                end = 1.0f;
+            }
+            float offset = (position - start) / (end - start);
+            float new_offset = (float) easing.get(offset);
+            adjusted = new_offset * (end - start) + start;
+            if (velocity != null) {
+                velocity[0] = (float) easing.getDiff(offset);
+            }
+        }
+        return adjusted;
+    }
+
+    void endTrigger(boolean start) {
+//        if ("button".equals(Debug.getName(mView)))
+//            if (mKeyTriggers != null) {
+//                for (int i = 0; i < mKeyTriggers.length; i++) {
+//                    mKeyTriggers[i].conditionallyFire(start ? -100 : 100, mView);
+//                }
+//            }
+    }
+    //##############################################################################################
+    //$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%
+    //$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%
+    //$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%
+    //$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%$%
+    //##############################################################################################
+
+    /**
+     * The main driver of interpolation
+     *
+     * @return do you need to keep animating
+     */
+    public boolean interpolate(MotionWidget child,
+            float globalPosition,
+            long time,
+            KeyCache keyCache) {
+        @SuppressWarnings("unused")  boolean timeAnimation = false;
+        float position = getAdjustedPosition(globalPosition, null);
+        // This quantize the position into steps e.g. 4 steps = 0-0.25,0.25-0.50 etc
+        if (mQuantizeMotionSteps != UNSET) {
+            @SuppressWarnings("unused") float pin = position;
+            float steps = 1.0f / mQuantizeMotionSteps; // the length of a step
+            float jump = (float) Math.floor(position / steps) * steps; // step jumps
+            float section = (position % steps) / steps; // float from 0 to 1 in a step
+
+            if (!Float.isNaN(mQuantizeMotionPhase)) {
+                section = (section + mQuantizeMotionPhase) % 1;
+            }
+            if (mQuantizeMotionInterpolator != null) {
+                section = mQuantizeMotionInterpolator.getInterpolation(section);
+            } else {
+                section = section > 0.5 ? 1 : 0;
+            }
+            position = section * steps + jump;
+        }
+        // MotionKeyTimeCycle.PathRotate timePathRotate = null;
+        if (mAttributesMap != null) {
+            for (SplineSet aSpline : mAttributesMap.values()) {
+                aSpline.setProperty(child, position);
+            }
+        }
+
+        //       TODO add KeyTimeCycle
+        //        if (mTimeCycleAttributesMap != null) {
+        //            for (ViewTimeCycle aSpline : mTimeCycleAttributesMap.values()) {
+        //                if (aSpline instanceof ViewTimeCycle.PathRotate) {
+        //                    timePathRotate = (ViewTimeCycle.PathRotate) aSpline;
+        //                    continue;
+        //                }
+        //                timeAnimation |= aSpline.setProperty(child, position, time, keyCache);
+        //            }
+        //        }
+
+        if (mSpline != null) {
+            mSpline[0].getPos(position, mInterpolateData);
+            mSpline[0].getSlope(position, mInterpolateVelocity);
+            if (mArcSpline != null) {
+                if (mInterpolateData.length > 0) {
+                    mArcSpline.getPos(position, mInterpolateData);
+                    mArcSpline.getSlope(position, mInterpolateVelocity);
+                }
+            }
+
+            if (!mNoMovement) {
+                mStartMotionPath.setView(position, child,
+                        mInterpolateVariables, mInterpolateData, mInterpolateVelocity, null);
+            }
+            if (mTransformPivotTarget != UNSET) {
+                if (mTransformPivotView == null) {
+                    MotionWidget layout = (MotionWidget) child.getParent();
+                    mTransformPivotView = layout.findViewById(mTransformPivotTarget);
+                }
+                if (mTransformPivotView != null) {
+                    float cy =
+                            (mTransformPivotView.getTop() + mTransformPivotView.getBottom()) / 2.0f;
+                    float cx =
+                            (mTransformPivotView.getLeft() + mTransformPivotView.getRight()) / 2.0f;
+                    if (child.getRight() - child.getLeft() > 0
+                            && child.getBottom() - child.getTop() > 0) {
+                        float px = (cx - child.getLeft());
+                        float py = (cy - child.getTop());
+                        child.setPivotX(px);
+                        child.setPivotY(py);
+                    }
+                }
+            }
+
+            //       TODO add support for path rotate
+            //            if (mAttributesMap != null) {
+            //                for (SplineSet aSpline : mAttributesMap.values()) {
+            //                    if (aSpline instanceof ViewSpline.PathRotate
+            //                          && mInterpolateVelocity.length > 1)
+            //                        ((ViewSpline.PathRotate) aSpline).setPathRotate(child,
+            //                        position, mInterpolateVelocity[0], mInterpolateVelocity[1]);
+            //                }
+            //
+            //            }
+            //            if (timePathRotate != null) {
+            //                timeAnimation |= timePathRotate.setPathRotate(child, keyCache,
+            //                  position, time, mInterpolateVelocity[0], mInterpolateVelocity[1]);
+            //            }
+
+            for (int i = 1; i < mSpline.length; i++) {
+                CurveFit spline = mSpline[i];
+                spline.getPos(position, mValuesBuff);
+                //interpolated here
+                mStartMotionPath.mCustomAttributes
+                        .get(mAttributeNames[i - 1])
+                        .setInterpolatedValue(child, mValuesBuff);
+            }
+            if (mStartPoint.mVisibilityMode == MotionWidget.VISIBILITY_MODE_NORMAL) {
+                if (position <= 0.0f) {
+                    child.setVisibility(mStartPoint.mVisibility);
+                } else if (position >= 1.0f) {
+                    child.setVisibility(mEndPoint.mVisibility);
+                } else if (mEndPoint.mVisibility != mStartPoint.mVisibility) {
+                    child.setVisibility(MotionWidget.VISIBLE);
+                }
+            }
+
+            if (mKeyTriggers != null) {
+                for (int i = 0; i < mKeyTriggers.length; i++) {
+                    mKeyTriggers[i].conditionallyFire(position, child);
+                }
+            }
+        } else {
+            // do the interpolation
+
+            float float_l =
+                    (mStartMotionPath.mX + (mEndMotionPath.mX - mStartMotionPath.mX) * position);
+            float float_t =
+                    (mStartMotionPath.mY + (mEndMotionPath.mY - mStartMotionPath.mY) * position);
+            float float_width = (mStartMotionPath.mWidth
+                    + (mEndMotionPath.mWidth - mStartMotionPath.mWidth) * position);
+            float float_height = (mStartMotionPath.mHeight
+                    + (mEndMotionPath.mHeight - mStartMotionPath.mHeight) * position);
+            int l = (int) (0.5f + float_l);
+            int t = (int) (0.5f + float_t);
+            int r = (int) (0.5f + float_l + float_width);
+            int b = (int) (0.5f + float_t + float_height);
+            int width = r - l;
+            int height = b - t;
+
+            if (FAVOR_FIXED_SIZE_VIEWS) {
+                l = (int) (mStartMotionPath.mX
+                        + (mEndMotionPath.mX - mStartMotionPath.mX) * position);
+                t = (int) (mStartMotionPath.mY
+                        + (mEndMotionPath.mY - mStartMotionPath.mY) * position);
+                width = (int) (mStartMotionPath.mWidth
+                        + (mEndMotionPath.mWidth - mStartMotionPath.mWidth) * position);
+                height = (int) (mStartMotionPath.mHeight
+                        + (mEndMotionPath.mHeight - mStartMotionPath.mHeight) * position);
+                r = l + width;
+                b = t + height;
+            }
+            // widget is responsible to call measure
+            child.layout(l, t, r, b);
+        }
+
+        // TODO add pathRotate KeyCycles
+        if (mCycleMap != null) {
+            for (KeyCycleOscillator osc : mCycleMap.values()) {
+                if (osc instanceof KeyCycleOscillator.PathRotateSet) {
+                    ((KeyCycleOscillator.PathRotateSet) osc).setPathRotate(child, position,
+                            mInterpolateVelocity[0], mInterpolateVelocity[1]);
+                } else {
+                    osc.setProperty(child, position);
+                }
+            }
+        }
+        //   When we support TimeCycle return true if repaint is needed
+        //        return timeAnimation;
+        return false;
+    }
+
+    /**
+     * This returns the differential with respect to the animation layout position (Progress)
+     * of a point on the view (post layout effects are not computed)
+     *
+     * @param position    position in time
+     * @param locationX   the x location on the view (0 = left edge, 1 = right edge)
+     * @param locationY   the y location on the view (0 = top, 1 = bottom)
+     * @param mAnchorDpDt returns the differential of the motion with respect to the position
+     */
+    public void getDpDt(float position, float locationX, float locationY, float[] mAnchorDpDt) {
+        position = getAdjustedPosition(position, mVelocity);
+
+        if (mSpline != null) {
+            mSpline[0].getSlope(position, mInterpolateVelocity);
+            mSpline[0].getPos(position, mInterpolateData);
+            float v = mVelocity[0];
+            for (int i = 0; i < mInterpolateVelocity.length; i++) {
+                mInterpolateVelocity[i] *= v;
+            }
+
+            if (mArcSpline != null) {
+                if (mInterpolateData.length > 0) {
+                    mArcSpline.getPos(position, mInterpolateData);
+                    mArcSpline.getSlope(position, mInterpolateVelocity);
+                    mStartMotionPath.setDpDt(locationX, locationY, mAnchorDpDt,
+                            mInterpolateVariables, mInterpolateVelocity, mInterpolateData);
+                }
+                return;
+            }
+            mStartMotionPath.setDpDt(locationX, locationY, mAnchorDpDt,
+                    mInterpolateVariables, mInterpolateVelocity, mInterpolateData);
+            return;
+        }
+        // do the interpolation
+        float dleft = (mEndMotionPath.mX - mStartMotionPath.mX);
+        float dTop = (mEndMotionPath.mY - mStartMotionPath.mY);
+        float dWidth = (mEndMotionPath.mWidth - mStartMotionPath.mWidth);
+        float dHeight = (mEndMotionPath.mHeight - mStartMotionPath.mHeight);
+        float dRight = dleft + dWidth;
+        float dBottom = dTop + dHeight;
+        mAnchorDpDt[0] = dleft * (1 - locationX) + dRight * locationX;
+        mAnchorDpDt[1] = dTop * (1 - locationY) + dBottom * locationY;
+    }
+
+    /**
+     * This returns the differential with respect to the animation post layout transform
+     * of a point on the view
+     *
+     * @param position    position in time
+     * @param width       width of the view
+     * @param height      height of the view
+     * @param locationX   the x location on the view (0 = left edge, 1 = right edge)
+     * @param locationY   the y location on the view (0 = top, 1 = bottom)
+     * @param mAnchorDpDt returns the differential of the motion with respect to the position
+     */
+    void getPostLayoutDvDp(float position,
+            int width,
+            int height,
+            float locationX,
+            float locationY,
+            float[] mAnchorDpDt) {
+        if (DEBUG) {
+            Utils.log(TAG, " position= " + position
+                    + " location= " + locationX + " , " + locationY);
+        }
+        position = getAdjustedPosition(position, mVelocity);
+
+        SplineSet trans_x =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_X);
+        SplineSet trans_y =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.TRANSLATION_Y);
+        SplineSet rotation =
+                (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.ROTATION);
+        SplineSet scale_x = (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.SCALE_X);
+        SplineSet scale_y = (mAttributesMap == null) ? null : mAttributesMap.get(MotionKey.SCALE_Y);
+
+        KeyCycleOscillator osc_x =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_X);
+        KeyCycleOscillator osc_y =
+                (mCycleMap == null) ? null : mCycleMap.get(MotionKey.TRANSLATION_Y);
+        KeyCycleOscillator osc_r = (mCycleMap == null) ? null : mCycleMap.get(MotionKey.ROTATION);
+        KeyCycleOscillator osc_sx = (mCycleMap == null) ? null : mCycleMap.get(MotionKey.SCALE_X);
+        KeyCycleOscillator osc_sy = (mCycleMap == null) ? null : mCycleMap.get(MotionKey.SCALE_Y);
+
+        VelocityMatrix vmat = new VelocityMatrix();
+        vmat.clear();
+        vmat.setRotationVelocity(rotation, position);
+        vmat.setTranslationVelocity(trans_x, trans_y, position);
+        vmat.setScaleVelocity(scale_x, scale_y, position);
+        vmat.setRotationVelocity(osc_r, position);
+        vmat.setTranslationVelocity(osc_x, osc_y, position);
+        vmat.setScaleVelocity(osc_sx, osc_sy, position);
+        if (mArcSpline != null) {
+            if (mInterpolateData.length > 0) {
+                mArcSpline.getPos(position, mInterpolateData);
+                mArcSpline.getSlope(position, mInterpolateVelocity);
+                mStartMotionPath.setDpDt(locationX, locationY, mAnchorDpDt,
+                        mInterpolateVariables, mInterpolateVelocity, mInterpolateData);
+            }
+            vmat.applyTransform(locationX, locationY, width, height, mAnchorDpDt);
+            return;
+        }
+        if (mSpline != null) {
+            position = getAdjustedPosition(position, mVelocity);
+            mSpline[0].getSlope(position, mInterpolateVelocity);
+            mSpline[0].getPos(position, mInterpolateData);
+            float v = mVelocity[0];
+            for (int i = 0; i < mInterpolateVelocity.length; i++) {
+                mInterpolateVelocity[i] *= v;
+            }
+            mStartMotionPath.setDpDt(locationX, locationY, mAnchorDpDt,
+                    mInterpolateVariables, mInterpolateVelocity, mInterpolateData);
+            vmat.applyTransform(locationX, locationY, width, height, mAnchorDpDt);
+            return;
+        }
+
+        // do the interpolation
+        float dleft = (mEndMotionPath.mX - mStartMotionPath.mX);
+        float dTop = (mEndMotionPath.mY - mStartMotionPath.mY);
+        float dWidth = (mEndMotionPath.mWidth - mStartMotionPath.mWidth);
+        float dHeight = (mEndMotionPath.mHeight - mStartMotionPath.mHeight);
+        float dRight = dleft + dWidth;
+        float dBottom = dTop + dHeight;
+        mAnchorDpDt[0] = dleft * (1 - locationX) + dRight * locationX;
+        mAnchorDpDt[1] = dTop * (1 - locationY) + dBottom * locationY;
+
+        vmat.clear();
+        vmat.setRotationVelocity(rotation, position);
+        vmat.setTranslationVelocity(trans_x, trans_y, position);
+        vmat.setScaleVelocity(scale_x, scale_y, position);
+        vmat.setRotationVelocity(osc_r, position);
+        vmat.setTranslationVelocity(osc_x, osc_y, position);
+        vmat.setScaleVelocity(osc_sx, osc_sy, position);
+        vmat.applyTransform(locationX, locationY, width, height, mAnchorDpDt);
+    }
+
+    // @TODO: add description
+    public int getDrawPath() {
+        int mode = mStartMotionPath.mDrawPath;
+        for (MotionPaths keyFrame : mMotionPaths) {
+            mode = Math.max(mode, keyFrame.mDrawPath);
+        }
+        mode = Math.max(mode, mEndMotionPath.mDrawPath);
+        return mode;
+    }
+
+    public void setDrawPath(int debugMode) {
+        mStartMotionPath.mDrawPath = debugMode;
+    }
+
+    String name() {
+
+        return mView.getName();
+    }
+
+    void positionKeyframe(MotionWidget view,
+            MotionKeyPosition key,
+            float x,
+            float y,
+            String[] attribute,
+            float[] value) {
+        FloatRect start = new FloatRect();
+        start.left = mStartMotionPath.mX;
+        start.top = mStartMotionPath.mY;
+        start.right = start.left + mStartMotionPath.mWidth;
+        start.bottom = start.top + mStartMotionPath.mHeight;
+        FloatRect end = new FloatRect();
+        end.left = mEndMotionPath.mX;
+        end.top = mEndMotionPath.mY;
+        end.right = end.left + mEndMotionPath.mWidth;
+        end.bottom = end.top + mEndMotionPath.mHeight;
+        key.positionAttributes(view, start, end, x, y, attribute, value);
+    }
+
+    /**
+     * Get the keyFrames for the view controlled by this MotionController
+     *
+     * @param type is position(0-100) + 1000
+     *             * mType(1=Attributes, 2=Position, 3=TimeCycle 4=Cycle 5=Trigger
+     * @param pos  the x&y position of the keyFrame along the path
+     * @return Number of keyFrames found
+     */
+    public int getKeyFramePositions(int[] type, float[] pos) {
+        int i = 0;
+        int count = 0;
+        for (MotionKey key : mKeyList) {
+            type[i++] = key.mFramePosition + 1000 * key.mType;
+            float time = key.mFramePosition / 100.0f;
+            mSpline[0].getPos(time, mInterpolateData);
+            mStartMotionPath.getCenter(time, mInterpolateVariables, mInterpolateData, pos, count);
+            count += 2;
+        }
+
+        return i;
+    }
+
+    /**
+     * Gets the keyFrames for the view controlled by this MotionController.
+     * The info data structure is of the form
+     * 0 length if your are at index i the [i+len+1] is the next entry
+     * 1 type  1=Attributes, 2=Position, 3=TimeCycle 4=Cycle 5=Trigger
+     * 2 position
+     * 3 x location
+     * 4 y location
+     * 5
+     * ...
+     * length
+     *
+     * @param type if type is -1, skip all keyframes with type != -1
+     * @param info is a data structure array of int that holds info on each keyframe
+     * @return Number of keyFrames found
+     */
+    public int getKeyFrameInfo(int type, int[] info) {
+        int count = 0;
+        int cursor = 0;
+        float[] pos = new float[2];
+        int len;
+        for (MotionKey key : mKeyList) {
+            if (key.mType != type && type == -1) {
+                continue;
+            }
+            len = cursor;
+            info[cursor] = 0;
+
+            info[++cursor] = key.mType;
+            info[++cursor] = key.mFramePosition;
+
+            float time = key.mFramePosition / 100.0f;
+            mSpline[0].getPos(time, mInterpolateData);
+            mStartMotionPath.getCenter(time, mInterpolateVariables, mInterpolateData, pos, 0);
+            info[++cursor] = Float.floatToIntBits(pos[0]);
+            info[++cursor] = Float.floatToIntBits(pos[1]);
+            if (key instanceof MotionKeyPosition) {
+                MotionKeyPosition kp = (MotionKeyPosition) key;
+                info[++cursor] = kp.mPositionType;
+
+                info[++cursor] = Float.floatToIntBits(kp.mPercentX);
+                info[++cursor] = Float.floatToIntBits(kp.mPercentY);
+            }
+            cursor++;
+            info[len] = cursor - len;
+            count++;
+        }
+
+        return count;
+    }
+
+    @Override
+    public boolean setValue(int id, int value) {
+        switch (id) {
+            case TypedValues.PositionType.TYPE_PATH_MOTION_ARC:
+                setPathMotionArc(value);
+                return true;
+            case TypedValues.MotionType.TYPE_QUANTIZE_MOTIONSTEPS:
+                mQuantizeMotionSteps = value;
+                return true;
+            case TypedValues.TransitionType.TYPE_AUTO_TRANSITION:
+                // TODO add support for auto transitions mAutoTransition = value;
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, float value) {
+        if (MotionType.TYPE_QUANTIZE_MOTION_PHASE == id) {
+            mQuantizeMotionPhase = value;
+            return true;
+        }
+        if (MotionType.TYPE_STAGGER == id) {
+            mMotionStagger = value;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, String value) {
+        if (TransitionType.TYPE_INTERPOLATOR == id
+                || MotionType.TYPE_QUANTIZE_INTERPOLATOR_TYPE == id) {
+            mQuantizeMotionInterpolator = getInterpolator(SPLINE_STRING, value, 0);
+            return true;
+        }
+        if (MotionType.TYPE_ANIMATE_RELATIVE_TO == id) {
+            mStartMotionPath.mAnimateRelativeTo = value;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, boolean value) {
+        return false;
+    }
+
+    @Override
+    public int getId(String name) {
+        return 0;
+    }
+
+    /**
+     * Set stagger scale
+     */
+    public void setStaggerScale(float staggerScale) {
+        mStaggerScale = staggerScale;
+    }
+
+    /**
+     * set the offset used in calculating stagger launches
+     *
+     * @param staggerOffset fraction of progress before this controller runs
+     */
+    public void setStaggerOffset(float staggerOffset) {
+        mStaggerOffset = staggerOffset;
+    }
+
+    /**
+     * The values set in
+     * motion: {
+     * stagger: '2'
+     * }
+     *
+     * @return value from motion: { stagger: ? } or NaN if not set
+     */
+    public float getMotionStagger() {
+        return mMotionStagger;
+    }
+
+    public void setIdString(String stringId) {
+        mId = stringId;
+        mStartMotionPath.mId = mId;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionConstrainedPoint.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionConstrainedPoint.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion;
+
+import androidx.constraintlayout.core.motion.utils.Easing;
+import androidx.constraintlayout.core.motion.utils.Rect;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.motion.utils.Utils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Set;
+
+/**
+ * All the parameter it extracts from a ConstraintSet/View
+ *
+ *
+ */
+class MotionConstrainedPoint implements Comparable<MotionConstrainedPoint> {
+    public static final String TAG = "MotionPaths";
+    public static final boolean DEBUG = false;
+
+    private float mAlpha = 1;
+    int mVisibilityMode = MotionWidget.VISIBILITY_MODE_NORMAL;
+    int mVisibility;
+    @SuppressWarnings("unused") private boolean mApplyElevation = false;
+    private float mElevation = 0;
+    private float mRotation = 0;
+    private float mRotationX = 0;
+    public float rotationY = 0;
+    private float mScaleX = 1;
+    private float mScaleY = 1;
+    private float mPivotX = Float.NaN;
+    private float mPivotY = Float.NaN;
+    private float mTranslationX = 0;
+    private float mTranslationY = 0;
+    private float mTranslationZ = 0;
+    @SuppressWarnings("unused") private Easing mKeyFrameEasing;
+    @SuppressWarnings("unused") private int mDrawPath = 0;
+    private float mPosition;
+    private float mX;
+    private float mY;
+    private float mWidth;
+    private float mHeight;
+    private float mPathRotate = Float.NaN;
+    private float mProgress = Float.NaN;
+    @SuppressWarnings("unused") private int mAnimateRelativeTo = -1;
+
+    static final int PERPENDICULAR = 1;
+    static final int CARTESIAN = 2;
+    static String[] sNames = {"position", "x", "y", "width", "height", "pathRotate"};
+
+    LinkedHashMap<String, CustomVariable> mCustomVariable = new LinkedHashMap<>();
+    int mMode = 0; // how was this point computed 1=perpendicular 2=deltaRelative
+
+    MotionConstrainedPoint() {
+
+    }
+
+    private boolean diff(float a, float b) {
+        if (Float.isNaN(a) || Float.isNaN(b)) {
+            return Float.isNaN(a) != Float.isNaN(b);
+        }
+        return Math.abs(a - b) > 0.000001f;
+    }
+
+    /**
+     * Given the start and end points define Keys that need to be built
+     */
+    void different(MotionConstrainedPoint points, HashSet<String> keySet) {
+        if (diff(mAlpha, points.mAlpha)) {
+            keySet.add(TypedValues.AttributesType.S_ALPHA);
+        }
+        if (diff(mElevation, points.mElevation)) {
+            keySet.add(TypedValues.AttributesType.S_TRANSLATION_Z);
+        }
+        if (mVisibility != points.mVisibility
+                && mVisibilityMode == MotionWidget.VISIBILITY_MODE_NORMAL
+                && (mVisibility == MotionWidget.VISIBLE
+                || points.mVisibility == MotionWidget.VISIBLE)) {
+            keySet.add(TypedValues.AttributesType.S_ALPHA);
+        }
+        if (diff(mRotation, points.mRotation)) {
+            keySet.add(TypedValues.AttributesType.S_ROTATION_Z);
+        }
+        if (!(Float.isNaN(mPathRotate) && Float.isNaN(points.mPathRotate))) {
+            keySet.add(TypedValues.AttributesType.S_PATH_ROTATE);
+        }
+        if (!(Float.isNaN(mProgress) && Float.isNaN(points.mProgress))) {
+            keySet.add(TypedValues.AttributesType.S_PROGRESS);
+        }
+        if (diff(mRotationX, points.mRotationX)) {
+            keySet.add(TypedValues.AttributesType.S_ROTATION_X);
+        }
+        if (diff(rotationY, points.rotationY)) {
+            keySet.add(TypedValues.AttributesType.S_ROTATION_Y);
+        }
+        if (diff(mPivotX, points.mPivotX)) {
+            keySet.add(TypedValues.AttributesType.S_PIVOT_X);
+        }
+        if (diff(mPivotY, points.mPivotY)) {
+            keySet.add(TypedValues.AttributesType.S_PIVOT_Y);
+        }
+        if (diff(mScaleX, points.mScaleX)) {
+            keySet.add(TypedValues.AttributesType.S_SCALE_X);
+        }
+        if (diff(mScaleY, points.mScaleY)) {
+            keySet.add(TypedValues.AttributesType.S_SCALE_Y);
+        }
+        if (diff(mTranslationX, points.mTranslationX)) {
+            keySet.add(TypedValues.AttributesType.S_TRANSLATION_X);
+        }
+        if (diff(mTranslationY, points.mTranslationY)) {
+            keySet.add(TypedValues.AttributesType.S_TRANSLATION_Y);
+        }
+        if (diff(mTranslationZ, points.mTranslationZ)) {
+            keySet.add(TypedValues.AttributesType.S_TRANSLATION_Z);
+        }
+        if (diff(mElevation, points.mElevation)) {
+            keySet.add(TypedValues.AttributesType.S_ELEVATION);
+        }
+    }
+
+    void different(MotionConstrainedPoint points, boolean[] mask, String[] custom) {
+        int c = 0;
+        mask[c++] |= diff(mPosition, points.mPosition);
+        mask[c++] |= diff(mX, points.mX);
+        mask[c++] |= diff(mY, points.mY);
+        mask[c++] |= diff(mWidth, points.mWidth);
+        mask[c++] |= diff(mHeight, points.mHeight);
+    }
+
+    double[] mTempValue = new double[18];
+    double[] mTempDelta = new double[18];
+
+    void fillStandard(double[] data, int[] toUse) {
+        float[] set = {mPosition, mX, mY, mWidth, mHeight, mAlpha, mElevation,
+                mRotation, mRotationX, rotationY, mScaleX, mScaleY, mPivotX,
+                mPivotY, mTranslationX, mTranslationY, mTranslationZ, mPathRotate};
+        int c = 0;
+        for (int i = 0; i < toUse.length; i++) {
+            if (toUse[i] < set.length) {
+                data[c++] = set[toUse[i]];
+            }
+        }
+    }
+
+    boolean hasCustomData(String name) {
+        return mCustomVariable.containsKey(name);
+    }
+
+    int getCustomDataCount(String name) {
+        return mCustomVariable.get(name).numberOfInterpolatedValues();
+    }
+
+    int getCustomData(String name, double[] value, int offset) {
+        CustomVariable a = mCustomVariable.get(name);
+        if (a.numberOfInterpolatedValues() == 1) {
+            value[offset] = a.getValueToInterpolate();
+            return 1;
+        } else {
+            int n = a.numberOfInterpolatedValues();
+            float[] f = new float[n];
+            a.getValuesToInterpolate(f);
+            for (int i = 0; i < n; i++) {
+                value[offset++] = f[i];
+            }
+            return n;
+        }
+    }
+
+    void setBounds(float x, float y, float w, float h) {
+        this.mX = x;
+        this.mY = y;
+        mWidth = w;
+        mHeight = h;
+    }
+
+    @Override
+    public int compareTo(MotionConstrainedPoint o) {
+        return Float.compare(mPosition, o.mPosition);
+    }
+
+    public void applyParameters(MotionWidget view) {
+
+        this.mVisibility = view.getVisibility();
+        this.mAlpha = (view.getVisibility() != MotionWidget.VISIBLE) ? 0.0f : view.getAlpha();
+        this.mApplyElevation = false; // TODO figure a way to cache parameters
+
+        this.mRotation = view.getRotationZ();
+        this.mRotationX = view.getRotationX();
+        this.rotationY = view.getRotationY();
+        this.mScaleX = view.getScaleX();
+        this.mScaleY = view.getScaleY();
+        this.mPivotX = view.getPivotX();
+        this.mPivotY = view.getPivotY();
+        this.mTranslationX = view.getTranslationX();
+        this.mTranslationY = view.getTranslationY();
+        this.mTranslationZ = view.getTranslationZ();
+        Set<String> at = view.getCustomAttributeNames();
+        for (String s : at) {
+            CustomVariable attr = view.getCustomAttribute(s);
+            if (attr != null && attr.isContinuous()) {
+                this.mCustomVariable.put(s, attr);
+            }
+        }
+
+
+    }
+
+    public void addValues(HashMap<String, SplineSet> splines, int mFramePosition) {
+        for (String s : splines.keySet()) {
+            SplineSet ViewSpline = splines.get(s);
+            if (DEBUG) {
+                Utils.log(TAG, "setPoint" + mFramePosition + "  spline set = " + s);
+            }
+            switch (s) {
+                case TypedValues.AttributesType.S_ALPHA:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mAlpha) ? 1 : mAlpha);
+                    break;
+                case TypedValues.AttributesType.S_ROTATION_Z:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mRotation) ? 0 : mRotation);
+                    break;
+                case TypedValues.AttributesType.S_ROTATION_X:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mRotationX) ? 0 : mRotationX);
+                    break;
+                case TypedValues.AttributesType.S_ROTATION_Y:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(rotationY) ? 0 : rotationY);
+                    break;
+                case TypedValues.AttributesType.S_PIVOT_X:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mPivotX) ? 0 : mPivotX);
+                    break;
+                case TypedValues.AttributesType.S_PIVOT_Y:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mPivotY) ? 0 : mPivotY);
+                    break;
+                case TypedValues.AttributesType.S_PATH_ROTATE:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mPathRotate) ? 0 : mPathRotate);
+                    break;
+                case TypedValues.AttributesType.S_PROGRESS:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mProgress) ? 0 : mProgress);
+                    break;
+                case TypedValues.AttributesType.S_SCALE_X:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mScaleX) ? 1 : mScaleX);
+                    break;
+                case TypedValues.AttributesType.S_SCALE_Y:
+                    ViewSpline.setPoint(mFramePosition, Float.isNaN(mScaleY) ? 1 : mScaleY);
+                    break;
+                case TypedValues.AttributesType.S_TRANSLATION_X:
+                    ViewSpline.setPoint(mFramePosition,
+                            Float.isNaN(mTranslationX) ? 0 : mTranslationX);
+                    break;
+                case TypedValues.AttributesType.S_TRANSLATION_Y:
+                    ViewSpline.setPoint(mFramePosition,
+                            Float.isNaN(mTranslationY) ? 0 : mTranslationY);
+                    break;
+                case TypedValues.AttributesType.S_TRANSLATION_Z:
+                    ViewSpline.setPoint(mFramePosition,
+                            Float.isNaN(mTranslationZ) ? 0 : mTranslationZ);
+                    break;
+                default:
+                    if (s.startsWith("CUSTOM")) {
+                        String customName = s.split(",")[1];
+                        if (mCustomVariable.containsKey(customName)) {
+                            CustomVariable custom = mCustomVariable.get(customName);
+                            if (ViewSpline instanceof SplineSet.CustomSpline) {
+                                ((SplineSet.CustomSpline) ViewSpline)
+                                        .setPoint(mFramePosition, custom);
+                            } else {
+                                Utils.loge(TAG, s + " ViewSpline not a CustomSet frame = "
+                                        + mFramePosition + ", value"
+                                        + custom.getValueToInterpolate() + ViewSpline);
+
+                            }
+
+                        }
+                    } else {
+                        Utils.loge(TAG, "UNKNOWN spline " + s);
+                    }
+            }
+        }
+
+    }
+
+    public void setState(MotionWidget view) {
+        setBounds(view.getX(), view.getY(), view.getWidth(), view.getHeight());
+        applyParameters(view);
+    }
+
+    /**
+     * @param rect     assumes pre rotated
+     * @param rotation mode Surface.ROTATION_0,Surface.ROTATION_90...
+     */
+    public void setState(Rect rect, MotionWidget view, int rotation, float prevous) {
+        setBounds(rect.left, rect.top, rect.width(), rect.height());
+        applyParameters(view);
+        mPivotX = Float.NaN;
+        mPivotY = Float.NaN;
+
+        switch (rotation) {
+            case MotionWidget.ROTATE_PORTRATE_OF_LEFT:
+                this.mRotation = prevous + 90;
+                break;
+            case MotionWidget.ROTATE_PORTRATE_OF_RIGHT:
+                this.mRotation = prevous - 90;
+                break;
+        }
+    }
+
+//   TODO support Screen Rotation
+//    /**
+//     * Sets the state of the position given a rect, constraintset, rotation and viewid
+//     *
+//     * @param cw
+//     * @param constraintSet
+//     * @param rotation
+//     * @param viewId
+//     */
+//    public void setState(Rect cw, ConstraintSet constraintSet, int rotation, int viewId) {
+//        setBounds(cw.left, cw.top, cw.width(), cw.height());
+//        applyParameters(constraintSet.getParameters(viewId));
+//        switch (rotation) {
+//            case ConstraintSet.ROTATE_PORTRATE_OF_RIGHT:
+//            case ConstraintSet.ROTATE_RIGHT_OF_PORTRATE:
+//                this.rotation -= 90;
+//                break;
+//            case ConstraintSet.ROTATE_PORTRATE_OF_LEFT:
+//            case ConstraintSet.ROTATE_LEFT_OF_PORTRATE:
+//                this.rotation += 90;
+//                if (this.rotation > 180) this.rotation -= 360;
+//                break;
+//        }
+//    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionPaths.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionPaths.java
@@ -1,0 +1,939 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion;
+
+import static androidx.constraintlayout.core.motion.MotionWidget.UNSET;
+
+import androidx.constraintlayout.core.motion.key.MotionKeyPosition;
+import androidx.constraintlayout.core.motion.utils.Easing;
+import androidx.constraintlayout.core.motion.utils.Utils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * This is used to capture and play back path of the layout.
+ * It is used to set the bounds of the view (view.layout(l, t, r, b))
+ */
+public class MotionPaths implements Comparable<MotionPaths> {
+    public static final String TAG = "MotionPaths";
+    public static final boolean DEBUG = false;
+    public static final boolean OLD_WAY = false; // the computes the positions the old way
+    static final int OFF_POSITION = 0;
+    static final int OFF_X = 1;
+    static final int OFF_Y = 2;
+    static final int OFF_WIDTH = 3;
+    static final int OFF_HEIGHT = 4;
+    static final int OFF_PATH_ROTATE = 5;
+
+    // mode and type have same numbering scheme
+    public static final int PERPENDICULAR = MotionKeyPosition.TYPE_PATH;
+    public static final int CARTESIAN = MotionKeyPosition.TYPE_CARTESIAN;
+    public static final int SCREEN = MotionKeyPosition.TYPE_SCREEN;
+    static String[] sNames = {"position", "x", "y", "width", "height", "pathRotate"};
+    public String mId;
+    Easing mKeyFrameEasing;
+    int mDrawPath = 0;
+    float mTime;
+    float mPosition;
+    float mX;
+    float mY;
+    float mWidth;
+    float mHeight;
+    float mPathRotate = Float.NaN;
+    float mProgress = Float.NaN;
+    int mPathMotionArc = UNSET;
+    String mAnimateRelativeTo = null;
+    float mRelativeAngle = Float.NaN;
+    Motion mRelativeToController = null;
+
+    HashMap<String, CustomVariable> mCustomAttributes = new HashMap<>();
+    int mMode = 0; // how was this point computed 1=perpendicular 2=deltaRelative
+    int mAnimateCircleAngleTo; // since angles loop there are 4 ways we can pic direction
+
+    public MotionPaths() {
+    }
+
+    /**
+     * set up with Cartesian
+     */
+    void initCartesian(MotionKeyPosition c, MotionPaths startTimePoint, MotionPaths endTimePoint) {
+        float position = c.mFramePosition / 100f;
+        MotionPaths point = this;
+        point.mTime = position;
+
+        mDrawPath = c.mDrawPath;
+        float scaleWidth = Float.isNaN(c.mPercentWidth) ? position : c.mPercentWidth;
+        float scaleHeight = Float.isNaN(c.mPercentHeight) ? position : c.mPercentHeight;
+        float scaleX = endTimePoint.mWidth - startTimePoint.mWidth;
+        float scaleY = endTimePoint.mHeight - startTimePoint.mHeight;
+
+        point.mPosition = point.mTime;
+
+        float path = position; // the position on the path
+
+        float startCenterX = startTimePoint.mX + startTimePoint.mWidth / 2;
+        float startCenterY = startTimePoint.mY + startTimePoint.mHeight / 2;
+        float endCenterX = endTimePoint.mX + endTimePoint.mWidth / 2;
+        float endCenterY = endTimePoint.mY + endTimePoint.mHeight / 2;
+        float pathVectorX = endCenterX - startCenterX;
+        float pathVectorY = endCenterY - startCenterY;
+        point.mX = (int) (startTimePoint.mX + pathVectorX * path - scaleX * scaleWidth / 2);
+        point.mY = (int) (startTimePoint.mY + pathVectorY * path - scaleY * scaleHeight / 2);
+        point.mWidth = (int) (startTimePoint.mWidth + scaleX * scaleWidth);
+        point.mHeight = (int) (startTimePoint.mHeight + scaleY * scaleHeight);
+
+        float dxdx = Float.isNaN(c.mPercentX) ? position : c.mPercentX;
+        float dydx = Float.isNaN(c.mAltPercentY) ? 0 : c.mAltPercentY;
+        float dydy = Float.isNaN(c.mPercentY) ? position : c.mPercentY;
+        float dxdy = Float.isNaN(c.mAltPercentX) ? 0 : c.mAltPercentX;
+        point.mMode = MotionPaths.CARTESIAN;
+        point.mX = (int) (startTimePoint.mX + pathVectorX * dxdx
+                + pathVectorY * dxdy - scaleX * scaleWidth / 2);
+        point.mY = (int) (startTimePoint.mY + pathVectorX * dydx
+                + pathVectorY * dydy - scaleY * scaleHeight / 2);
+
+        point.mKeyFrameEasing = Easing.getInterpolator(c.mTransitionEasing);
+        point.mPathMotionArc = c.mPathMotionArc;
+    }
+
+    /**
+     * takes the new keyPosition
+     */
+    public MotionPaths(int parentWidth,
+            int parentHeight,
+            MotionKeyPosition c,
+            MotionPaths startTimePoint,
+            MotionPaths endTimePoint) {
+        if (startTimePoint.mAnimateRelativeTo != null) {
+            initPolar(parentWidth, parentHeight, c, startTimePoint, endTimePoint);
+            return;
+        }
+        switch (c.mPositionType) {
+            case MotionKeyPosition.TYPE_SCREEN:
+                initScreen(parentWidth, parentHeight, c, startTimePoint, endTimePoint);
+                return;
+            case MotionKeyPosition.TYPE_PATH:
+                initPath(c, startTimePoint, endTimePoint);
+                return;
+            default:
+            case MotionKeyPosition.TYPE_CARTESIAN:
+                initCartesian(c, startTimePoint, endTimePoint);
+                return;
+        }
+    }
+
+    void initPolar(int parentWidth,
+            int parentHeight,
+            MotionKeyPosition c,
+            MotionPaths s,
+            MotionPaths e) {
+        float position = c.mFramePosition / 100f;
+        this.mTime = position;
+        mDrawPath = c.mDrawPath;
+        this.mMode = c.mPositionType; // mode and type have same numbering scheme
+        float scaleWidth = Float.isNaN(c.mPercentWidth) ? position : c.mPercentWidth;
+        float scaleHeight = Float.isNaN(c.mPercentHeight) ? position : c.mPercentHeight;
+        float scaleX = e.mWidth - s.mWidth;
+        float scaleY = e.mHeight - s.mHeight;
+        this.mPosition = this.mTime;
+        mWidth = (int) (s.mWidth + scaleX * scaleWidth);
+        mHeight = (int) (s.mHeight + scaleY * scaleHeight);
+        @SuppressWarnings("unused") float startfactor = 1 - position;
+        @SuppressWarnings("unused") float endfactor = position;
+
+        switch (c.mPositionType) {
+            case MotionKeyPosition.TYPE_SCREEN:
+                this.mX = Float.isNaN(c.mPercentX) ? (position * (e.mX - s.mX) + s.mX)
+                        : c.mPercentX * Math.min(scaleHeight, scaleWidth);
+                this.mY = Float.isNaN(c.mPercentY)
+                        ? (position * (e.mY - s.mY) + s.mY) : c.mPercentY;
+                break;
+
+            case MotionKeyPosition.TYPE_PATH:
+                this.mX = (Float.isNaN(c.mPercentX)
+                        ? position : c.mPercentX) * (e.mX - s.mX) + s.mX;
+                this.mY = (Float.isNaN(c.mPercentY)
+                        ? position : c.mPercentY) * (e.mY - s.mY) + s.mY;
+                break;
+            default:
+            case MotionKeyPosition.TYPE_CARTESIAN:
+                this.mX = (Float.isNaN(c.mPercentX)
+                        ? position : c.mPercentX) * (e.mX - s.mX) + s.mX;
+                this.mY = (Float.isNaN(c.mPercentY)
+                        ? position : c.mPercentY) * (e.mY - s.mY) + s.mY;
+                break;
+        }
+
+        this.mAnimateRelativeTo = s.mAnimateRelativeTo;
+        this.mKeyFrameEasing = Easing.getInterpolator(c.mTransitionEasing);
+        this.mPathMotionArc = c.mPathMotionArc;
+    }
+
+    // @TODO: add description
+    public void setupRelative(Motion mc, MotionPaths relative) {
+        double dx = mX + mWidth / 2 - relative.mX - relative.mWidth / 2;
+        double dy = mY + mHeight / 2 - relative.mY - relative.mHeight / 2;
+        mRelativeToController = mc;
+
+        mX = (float) Math.hypot(dy, dx);
+        if (Float.isNaN(mRelativeAngle)) {
+            mY = (float) (Math.atan2(dy, dx) + Math.PI / 2);
+        } else {
+            mY = (float) Math.toRadians(mRelativeAngle);
+        }
+    }
+
+    void initScreen(int parentWidth,
+            int parentHeight,
+            MotionKeyPosition c,
+            MotionPaths startTimePoint,
+            MotionPaths endTimePoint) {
+        float position = c.mFramePosition / 100f;
+        MotionPaths point = this;
+        point.mTime = position;
+
+        mDrawPath = c.mDrawPath;
+        float scaleWidth = Float.isNaN(c.mPercentWidth) ? position : c.mPercentWidth;
+        float scaleHeight = Float.isNaN(c.mPercentHeight) ? position : c.mPercentHeight;
+
+        float scaleX = endTimePoint.mWidth - startTimePoint.mWidth;
+        float scaleY = endTimePoint.mHeight - startTimePoint.mHeight;
+
+        point.mPosition = point.mTime;
+
+        float path = position; // the position on the path
+
+        float startCenterX = startTimePoint.mX + startTimePoint.mWidth / 2;
+        float startCenterY = startTimePoint.mY + startTimePoint.mHeight / 2;
+        float endCenterX = endTimePoint.mX + endTimePoint.mWidth / 2;
+        float endCenterY = endTimePoint.mY + endTimePoint.mHeight / 2;
+        float pathVectorX = endCenterX - startCenterX;
+        float pathVectorY = endCenterY - startCenterY;
+        point.mX = (int) (startTimePoint.mX + pathVectorX * path - scaleX * scaleWidth / 2);
+        point.mY = (int) (startTimePoint.mY + pathVectorY * path - scaleY * scaleHeight / 2);
+        point.mWidth = (int) (startTimePoint.mWidth + scaleX * scaleWidth);
+        point.mHeight = (int) (startTimePoint.mHeight + scaleY * scaleHeight);
+
+        point.mMode = MotionPaths.SCREEN;
+        if (!Float.isNaN(c.mPercentX)) {
+            parentWidth -= (int) point.mWidth;
+            point.mX = (int) (c.mPercentX * parentWidth);
+        }
+        if (!Float.isNaN(c.mPercentY)) {
+            parentHeight -= (int) point.mHeight;
+            point.mY = (int) (c.mPercentY * parentHeight);
+        }
+
+        point.mAnimateRelativeTo = mAnimateRelativeTo;
+        point.mKeyFrameEasing = Easing.getInterpolator(c.mTransitionEasing);
+        point.mPathMotionArc = c.mPathMotionArc;
+    }
+
+    void initPath(MotionKeyPosition c, MotionPaths startTimePoint, MotionPaths endTimePoint) {
+
+        float position = c.mFramePosition / 100f;
+        MotionPaths point = this;
+        point.mTime = position;
+
+        mDrawPath = c.mDrawPath;
+        float scaleWidth = Float.isNaN(c.mPercentWidth) ? position : c.mPercentWidth;
+        float scaleHeight = Float.isNaN(c.mPercentHeight) ? position : c.mPercentHeight;
+
+        float scaleX = endTimePoint.mWidth - startTimePoint.mWidth;
+        float scaleY = endTimePoint.mHeight - startTimePoint.mHeight;
+
+        point.mPosition = point.mTime;
+
+        float path = Float.isNaN(c.mPercentX) ? position : c.mPercentX; // the position on the path
+
+        float startCenterX = startTimePoint.mX + startTimePoint.mWidth / 2;
+        float startCenterY = startTimePoint.mY + startTimePoint.mHeight / 2;
+        float endCenterX = endTimePoint.mX + endTimePoint.mWidth / 2;
+        float endCenterY = endTimePoint.mY + endTimePoint.mHeight / 2;
+        float pathVectorX = endCenterX - startCenterX;
+        float pathVectorY = endCenterY - startCenterY;
+        point.mX = (int) (startTimePoint.mX + pathVectorX * path - scaleX * scaleWidth / 2);
+        point.mY = (int) (startTimePoint.mY + pathVectorY * path - scaleY * scaleHeight / 2);
+        point.mWidth = (int) (startTimePoint.mWidth + scaleX * scaleWidth);
+        point.mHeight = (int) (startTimePoint.mHeight + scaleY * scaleHeight);
+        float perpendicular = Float.isNaN(c.mPercentY)
+                ? 0 : c.mPercentY; // the position on the path
+        float perpendicularX = -pathVectorY;
+        float perpendicularY = pathVectorX;
+
+        float normalX = perpendicularX * perpendicular;
+        float normalY = perpendicularY * perpendicular;
+        point.mMode = MotionPaths.PERPENDICULAR;
+        point.mX = (int) (startTimePoint.mX + pathVectorX * path - scaleX * scaleWidth / 2);
+        point.mY = (int) (startTimePoint.mY + pathVectorY * path - scaleY * scaleHeight / 2);
+        point.mX += normalX;
+        point.mY += normalY;
+
+        point.mAnimateRelativeTo = mAnimateRelativeTo;
+        point.mKeyFrameEasing = Easing.getInterpolator(c.mTransitionEasing);
+        point.mPathMotionArc = c.mPathMotionArc;
+    }
+
+    private static float xRotate(float sin, float cos, float cx, float cy, float x, float y) {
+        x = x - cx;
+        y = y - cy;
+        return x * cos - y * sin + cx;
+    }
+
+    private static float yRotate(float sin, float cos, float cx, float cy, float x, float y) {
+        x = x - cx;
+        y = y - cy;
+        return x * sin + y * cos + cy;
+    }
+
+    private boolean diff(float a, float b) {
+        if (Float.isNaN(a) || Float.isNaN(b)) {
+            return Float.isNaN(a) != Float.isNaN(b);
+        }
+        return Math.abs(a - b) > 0.000001f;
+    }
+
+    void different(MotionPaths points, boolean[] mask, String[] custom, boolean arcMode) {
+        int c = 0;
+        boolean diffx = diff(mX, points.mX);
+        boolean diffy = diff(mY, points.mY);
+        mask[c++] |= diff(mPosition, points.mPosition);
+        mask[c++] |= diffx || diffy || arcMode;
+        mask[c++] |= diffx || diffy || arcMode;
+        mask[c++] |= diff(mWidth, points.mWidth);
+        mask[c++] |= diff(mHeight, points.mHeight);
+
+    }
+
+    void getCenter(double p, int[] toUse, double[] data, float[] point, int offset) {
+        float v_x = mX;
+        float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        float translationX = 0, translationY = 0;
+        for (int i = 0; i < toUse.length; i++) {
+            float value = (float) data[i];
+
+            switch (toUse[i]) {
+                case OFF_X:
+                    v_x = value;
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    break;
+            }
+        }
+        if (mRelativeToController != null) {
+            float[] pos = new float[2];
+            float[] vel = new float[2];
+
+            mRelativeToController.getCenter(p, pos, vel);
+            float rx = pos[0];
+            float ry = pos[1];
+            float radius = v_x;
+            float angle = v_y;
+            // TODO Debug angle
+            v_x = (float) (rx + radius * Math.sin(angle) - v_width / 2);
+            v_y = (float) (ry - radius * Math.cos(angle) - v_height / 2);
+        }
+
+        point[offset] = v_x + v_width / 2 + translationX;
+        point[offset + 1] = v_y + v_height / 2 + translationY;
+    }
+
+    void getCenter(double p,
+            int[] toUse,
+            double[] data,
+            float[] point,
+            double[] vdata,
+            float[] velocity) {
+        float v_x = mX;
+        float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        float dv_x = 0;
+        float dv_y = 0;
+        float dv_width = 0;
+        float dv_height = 0;
+
+        float translationX = 0, translationY = 0;
+        for (int i = 0; i < toUse.length; i++) {
+            float value = (float) data[i];
+            float dvalue = (float) vdata[i];
+
+            switch (toUse[i]) {
+                case OFF_X:
+                    v_x = value;
+                    dv_x = dvalue;
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    dv_y = dvalue;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    dv_width = dvalue;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    dv_height = dvalue;
+                    break;
+            }
+        }
+        float dpos_x = dv_x + dv_width / 2;
+        float dpos_y = dv_y + dv_height / 2;
+
+        if (mRelativeToController != null) {
+            float[] pos = new float[2];
+            float[] vel = new float[2];
+            mRelativeToController.getCenter(p, pos, vel);
+            float rx = pos[0];
+            float ry = pos[1];
+            float radius = v_x;
+            float angle = v_y;
+            float dradius = dv_x;
+            float dangle = dv_y;
+            float drx = vel[0];
+            float dry = vel[1];
+            // TODO Debug angle
+            v_x = (float) (rx + radius * Math.sin(angle) - v_width / 2);
+            v_y = (float) (ry - radius * Math.cos(angle) - v_height / 2);
+            dpos_x = (float) (drx + dradius * Math.sin(angle) + Math.cos(angle) * dangle);
+            dpos_y = (float) (dry - dradius * Math.cos(angle) + Math.sin(angle) * dangle);
+        }
+
+        point[0] = v_x + v_width / 2 + translationX;
+        point[1] = v_y + v_height / 2 + translationY;
+        velocity[0] = dpos_x;
+        velocity[1] = dpos_y;
+    }
+
+    void getCenterVelocity(double p, int[] toUse, double[] data, float[] point, int offset) {
+        float v_x = mX;
+        float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        float translationX = 0, translationY = 0;
+        for (int i = 0; i < toUse.length; i++) {
+            float value = (float) data[i];
+
+            switch (toUse[i]) {
+                case OFF_X:
+                    v_x = value;
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    break;
+            }
+        }
+        if (mRelativeToController != null) {
+            float[] pos = new float[2];
+            float[] vel = new float[2];
+            mRelativeToController.getCenter(p, pos, vel);
+            float rx = pos[0];
+            float ry = pos[1];
+            float radius = v_x;
+            float angle = v_y;
+            // TODO Debug angle
+            v_x = (float) (rx + radius * Math.sin(angle) - v_width / 2);
+            v_y = (float) (ry - radius * Math.cos(angle) - v_height / 2);
+        }
+
+        point[offset] = v_x + v_width / 2 + translationX;
+        point[offset + 1] = v_y + v_height / 2 + translationY;
+    }
+
+    void getBounds(int[] toUse, double[] data, float[] point, int offset) {
+        @SuppressWarnings("unused") float v_x = mX;
+        @SuppressWarnings("unused") float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        for (int i = 0; i < toUse.length; i++) {
+            float value = (float) data[i];
+
+            switch (toUse[i]) {
+                case OFF_X:
+                    v_x = value;
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    break;
+            }
+        }
+        point[offset] = v_width;
+        point[offset + 1] = v_height;
+    }
+
+    double[] mTempValue = new double[18];
+    double[] mTempDelta = new double[18];
+
+    // Called on the start Time Point
+    void setView(float position,
+            MotionWidget view,
+            int[] toUse,
+            double[] data,
+            double[] slope,
+            double[] cycle) {
+        float v_x = mX;
+        float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        float dv_x = 0;
+        float dv_y = 0;
+        float dv_width = 0;
+        float dv_height = 0;
+        @SuppressWarnings("unused") float delta_path = 0;
+        float path_rotate = Float.NaN;
+        @SuppressWarnings("unused") String mod;
+
+        if (toUse.length != 0 && mTempValue.length <= toUse[toUse.length - 1]) {
+            int scratch_data_length = toUse[toUse.length - 1] + 1;
+            mTempValue = new double[scratch_data_length];
+            mTempDelta = new double[scratch_data_length];
+        }
+        Arrays.fill(mTempValue, Double.NaN);
+        for (int i = 0; i < toUse.length; i++) {
+            mTempValue[toUse[i]] = data[i];
+            mTempDelta[toUse[i]] = slope[i];
+        }
+
+        for (int i = 0; i < mTempValue.length; i++) {
+            if (Double.isNaN(mTempValue[i]) && (cycle == null || cycle[i] == 0.0)) {
+                continue;
+            }
+            double deltaCycle = (cycle != null) ? cycle[i] : 0.0;
+            float value = (float) (Double.isNaN(mTempValue[i])
+                    ? deltaCycle : mTempValue[i] + deltaCycle);
+            float dvalue = (float) mTempDelta[i];
+
+            switch (i) {
+                case OFF_POSITION:
+                    delta_path = value;
+                    break;
+                case OFF_X:
+                    v_x = value;
+                    dv_x = dvalue;
+
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    dv_y = dvalue;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    dv_width = dvalue;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    dv_height = dvalue;
+                    break;
+                case OFF_PATH_ROTATE:
+                    path_rotate = value;
+                    break;
+            }
+        }
+
+        if (mRelativeToController != null) {
+            float[] pos = new float[2];
+            float[] vel = new float[2];
+
+            mRelativeToController.getCenter(position, pos, vel);
+            float rx = pos[0];
+            float ry = pos[1];
+            float radius = v_x;
+            float angle = v_y;
+            float dradius = dv_x;
+            float dangle = dv_y;
+            float drx = vel[0];
+            float dry = vel[1];
+
+            // TODO Debug angle
+            float pos_x = (float) (rx + radius * Math.sin(angle) - v_width / 2);
+            float pos_y = (float) (ry - radius * Math.cos(angle) - v_height / 2);
+            float dpos_x = (float) (drx + dradius * Math.sin(angle)
+                    + radius * Math.cos(angle) * dangle);
+            float dpos_y = (float) (dry - dradius * Math.cos(angle)
+                    + radius * Math.sin(angle) * dangle);
+            dv_x = dpos_x;
+            dv_y = dpos_y;
+            v_x = pos_x;
+            v_y = pos_y;
+            if (slope.length >= 2) {
+                slope[0] = dpos_x;
+                slope[1] = dpos_y;
+            }
+            if (!Float.isNaN(path_rotate)) {
+                float rot = (float) (path_rotate + Math.toDegrees(Math.atan2(dv_y, dv_x)));
+                view.setRotationZ(rot);
+            }
+
+        } else {
+
+            if (!Float.isNaN(path_rotate)) {
+                float rot = 0;
+                float dx = dv_x + dv_width / 2;
+                float dy = dv_y + dv_height / 2;
+                if (DEBUG) {
+                    Utils.log(TAG, "dv_x       =" + dv_x);
+                    Utils.log(TAG, "dv_y       =" + dv_y);
+                    Utils.log(TAG, "dv_width   =" + dv_width);
+                    Utils.log(TAG, "dv_height  =" + dv_height);
+                }
+                rot += (float) (path_rotate + Math.toDegrees(Math.atan2(dy, dx)));
+                view.setRotationZ(rot);
+                if (DEBUG) {
+                    Utils.log(TAG, "Rotated " + rot + "  = " + dx + "," + dy);
+                }
+            }
+        }
+
+        // Todo: develop a concept of Float layout in MotionWidget widget.layout(float ...)
+        int l = (int) (0.5f + v_x);
+        int t = (int) (0.5f + v_y);
+        int r = (int) (0.5f + v_x + v_width);
+        int b = (int) (0.5f + v_y + v_height);
+        int i_width = r - l;
+        int i_height = b - t;
+        if (OLD_WAY) { // This way may produce more stable with and height but risk gaps
+            l = (int) v_x;
+            t = (int) v_y;
+            i_width = (int) v_width;
+            i_height = (int) v_height;
+            r = l + i_width;
+            b = t + i_height;
+        }
+
+        // MotionWidget must do Android View measure if layout changes
+        view.layout(l, t, r, b);
+        if (DEBUG) {
+            if (toUse.length > 0) {
+                Utils.log(TAG, "setView " + mod);
+            }
+        }
+    }
+
+    void getRect(int[] toUse, double[] data, float[] path, int offset) {
+        float v_x = mX;
+        float v_y = mY;
+        float v_width = mWidth;
+        float v_height = mHeight;
+        @SuppressWarnings("unused") float delta_path = 0;
+        float rotation = 0;
+        @SuppressWarnings("unused") float alpha = 0;
+        @SuppressWarnings("unused") float rotationX = 0;
+        @SuppressWarnings("unused") float rotationY = 0;
+        float scaleX = 1;
+        float scaleY = 1;
+        float pivotX = Float.NaN;
+        float pivotY = Float.NaN;
+        float translationX = 0;
+        float translationY = 0;
+
+        @SuppressWarnings("unused") String mod;
+
+        for (int i = 0; i < toUse.length; i++) {
+            float value = (float) data[i];
+
+            switch (toUse[i]) {
+                case OFF_POSITION:
+                    delta_path = value;
+                    break;
+                case OFF_X:
+                    v_x = value;
+                    break;
+                case OFF_Y:
+                    v_y = value;
+                    break;
+                case OFF_WIDTH:
+                    v_width = value;
+                    break;
+                case OFF_HEIGHT:
+                    v_height = value;
+                    break;
+            }
+        }
+
+        if (mRelativeToController != null) {
+            float rx = mRelativeToController.getCenterX();
+            float ry = mRelativeToController.getCenterY();
+            float radius = v_x;
+            float angle = v_y;
+            // TODO Debug angle
+            v_x = (float) (rx + radius * Math.sin(angle) - v_width / 2);
+            v_y = (float) (ry - radius * Math.cos(angle) - v_height / 2);
+        }
+
+        float x1 = v_x;
+        float y1 = v_y;
+
+        float x2 = v_x + v_width;
+        float y2 = y1;
+
+        float x3 = x2;
+        float y3 = v_y + v_height;
+
+        float x4 = x1;
+        float y4 = y3;
+
+        float cx = x1 + v_width / 2;
+        float cy = y1 + v_height / 2;
+
+        if (!Float.isNaN(pivotX)) {
+            cx = x1 + (x2 - x1) * pivotX;
+        }
+        if (!Float.isNaN(pivotY)) {
+
+            cy = y1 + (y3 - y1) * pivotY;
+        }
+        if (scaleX != 1) {
+            float midx = (x1 + x2) / 2;
+            x1 = (x1 - midx) * scaleX + midx;
+            x2 = (x2 - midx) * scaleX + midx;
+            x3 = (x3 - midx) * scaleX + midx;
+            x4 = (x4 - midx) * scaleX + midx;
+        }
+        if (scaleY != 1) {
+            float midy = (y1 + y3) / 2;
+            y1 = (y1 - midy) * scaleY + midy;
+            y2 = (y2 - midy) * scaleY + midy;
+            y3 = (y3 - midy) * scaleY + midy;
+            y4 = (y4 - midy) * scaleY + midy;
+        }
+        if (rotation != 0) {
+            float sin = (float) Math.sin(Math.toRadians(rotation));
+            float cos = (float) Math.cos(Math.toRadians(rotation));
+            float tx1 = xRotate(sin, cos, cx, cy, x1, y1);
+            float ty1 = yRotate(sin, cos, cx, cy, x1, y1);
+            float tx2 = xRotate(sin, cos, cx, cy, x2, y2);
+            float ty2 = yRotate(sin, cos, cx, cy, x2, y2);
+            float tx3 = xRotate(sin, cos, cx, cy, x3, y3);
+            float ty3 = yRotate(sin, cos, cx, cy, x3, y3);
+            float tx4 = xRotate(sin, cos, cx, cy, x4, y4);
+            float ty4 = yRotate(sin, cos, cx, cy, x4, y4);
+            x1 = tx1;
+            y1 = ty1;
+            x2 = tx2;
+            y2 = ty2;
+            x3 = tx3;
+            y3 = ty3;
+            x4 = tx4;
+            y4 = ty4;
+        }
+
+        x1 += translationX;
+        y1 += translationY;
+        x2 += translationX;
+        y2 += translationY;
+        x3 += translationX;
+        y3 += translationY;
+        x4 += translationX;
+        y4 += translationY;
+
+        path[offset++] = x1;
+        path[offset++] = y1;
+        path[offset++] = x2;
+        path[offset++] = y2;
+        path[offset++] = x3;
+        path[offset++] = y3;
+        path[offset++] = x4;
+        path[offset++] = y4;
+    }
+
+    /**
+     * mAnchorDpDt
+     */
+    void setDpDt(float locationX,
+            float locationY,
+            float[] mAnchorDpDt,
+            int[] toUse,
+            double[] deltaData,
+            double[] data) {
+
+        float d_x = 0;
+        float d_y = 0;
+        float d_width = 0;
+        float d_height = 0;
+
+        float deltaScaleX = 0;
+        float deltaScaleY = 0;
+
+        @SuppressWarnings("unused") float mPathRotate = Float.NaN;
+        float deltaTranslationX = 0;
+        float deltaTranslationY = 0;
+
+        String mod = " dd = ";
+        for (int i = 0; i < toUse.length; i++) {
+            float deltaV = (float) deltaData[i];
+            if (DEBUG) {
+                mod += " , D" + sNames[toUse[i]] + "/Dt= " + deltaV;
+            }
+            switch (toUse[i]) {
+                case OFF_POSITION:
+                    break;
+                case OFF_X:
+                    d_x = deltaV;
+                    break;
+                case OFF_Y:
+                    d_y = deltaV;
+                    break;
+                case OFF_WIDTH:
+                    d_width = deltaV;
+                    break;
+                case OFF_HEIGHT:
+                    d_height = deltaV;
+                    break;
+
+            }
+        }
+        if (DEBUG) {
+            if (toUse.length > 0) {
+                Utils.log(TAG, "setDpDt " + mod);
+            }
+        }
+
+        float deltaX = d_x - deltaScaleX * d_width / 2;
+        float deltaY = d_y - deltaScaleY * d_height / 2;
+        float deltaWidth = d_width * (1 + deltaScaleX);
+        float deltaHeight = d_height * (1 + deltaScaleY);
+        float deltaRight = deltaX + deltaWidth;
+        float deltaBottom = deltaY + deltaHeight;
+        if (DEBUG) {
+            if (toUse.length > 0) {
+
+                Utils.log(TAG, "D x /dt           =" + d_x);
+                Utils.log(TAG, "D y /dt           =" + d_y);
+                Utils.log(TAG, "D width /dt       =" + d_width);
+                Utils.log(TAG, "D height /dt      =" + d_height);
+                Utils.log(TAG, "D deltaScaleX /dt =" + deltaScaleX);
+                Utils.log(TAG, "D deltaScaleY /dt =" + deltaScaleY);
+                Utils.log(TAG, "D deltaX /dt      =" + deltaX);
+                Utils.log(TAG, "D deltaY /dt      =" + deltaY);
+                Utils.log(TAG, "D deltaWidth /dt  =" + deltaWidth);
+                Utils.log(TAG, "D deltaHeight /dt =" + deltaHeight);
+                Utils.log(TAG, "D deltaRight /dt  =" + deltaRight);
+                Utils.log(TAG, "D deltaBottom /dt =" + deltaBottom);
+                Utils.log(TAG, "locationX         =" + locationX);
+                Utils.log(TAG, "locationY         =" + locationY);
+                Utils.log(TAG, "deltaTranslationX =" + deltaTranslationX);
+                Utils.log(TAG, "deltaTranslationX =" + deltaTranslationX);
+            }
+        }
+
+        mAnchorDpDt[0] = deltaX * (1 - locationX) + deltaRight * locationX + deltaTranslationX;
+        mAnchorDpDt[1] = deltaY * (1 - locationY) + deltaBottom * locationY + deltaTranslationY;
+    }
+
+    void fillStandard(double[] data, int[] toUse) {
+        float[] set = {mPosition, mX, mY, mWidth, mHeight, mPathRotate};
+        int c = 0;
+        for (int i = 0; i < toUse.length; i++) {
+            if (toUse[i] < set.length) {
+                data[c++] = set[toUse[i]];
+            }
+        }
+    }
+
+    boolean hasCustomData(String name) {
+        return mCustomAttributes.containsKey(name);
+    }
+
+    int getCustomDataCount(String name) {
+        CustomVariable a = mCustomAttributes.get(name);
+        if (a == null) {
+            return 0;
+        }
+        return a.numberOfInterpolatedValues();
+    }
+
+    int getCustomData(String name, double[] value, int offset) {
+        CustomVariable a = mCustomAttributes.get(name);
+        if (a == null) {
+            return 0;
+        } else if (a.numberOfInterpolatedValues() == 1) {
+            value[offset] = a.getValueToInterpolate();
+            return 1;
+        } else {
+            int n = a.numberOfInterpolatedValues();
+            float[] f = new float[n];
+            a.getValuesToInterpolate(f);
+            for (int i = 0; i < n; i++) {
+                value[offset++] = f[i];
+            }
+            return n;
+        }
+    }
+
+    void setBounds(float x, float y, float w, float h) {
+        this.mX = x;
+        this.mY = y;
+        mWidth = w;
+        mHeight = h;
+    }
+
+    @Override
+    public int compareTo(MotionPaths o) {
+        return Float.compare(mPosition, o.mPosition);
+    }
+
+    // @TODO: add description
+    public void applyParameters(MotionWidget c) {
+        MotionPaths point = this;
+        point.mKeyFrameEasing = Easing.getInterpolator(c.mMotion.mTransitionEasing);
+        point.mPathMotionArc = c.mMotion.mPathMotionArc;
+        point.mAnimateRelativeTo = c.mMotion.mAnimateRelativeTo;
+        point.mPathRotate = c.mMotion.mPathRotate;
+        point.mDrawPath = c.mMotion.mDrawPath;
+        point.mAnimateCircleAngleTo = c.mMotion.mAnimateCircleAngleTo;
+        point.mProgress = c.mPropertySet.mProgress;
+        if (c.mWidgetFrame != null && c.mWidgetFrame.widget != null) {
+            point.mRelativeAngle = c.mWidgetFrame.widget.mCircleConstraintAngle;
+        }
+
+        Set<String> at = c.getCustomAttributeNames();
+        for (String s : at) {
+            CustomVariable attr = c.getCustomAttribute(s);
+            if (attr != null && attr.isContinuous()) {
+                this.mCustomAttributes.put(s, attr);
+            }
+        }
+    }
+
+    // @TODO: add description
+    public void configureRelativeTo(Motion toOrbit) {
+        @SuppressWarnings("unused") double[] p = toOrbit.getPos(mProgress); // get the position
+        // in the orbit
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionWidget.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/MotionWidget.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion;
+
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.state.WidgetFrame;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+import java.util.Set;
+
+public class MotionWidget implements TypedValues {
+    WidgetFrame mWidgetFrame = new WidgetFrame();
+    Motion mMotion = new Motion();
+    PropertySet mPropertySet = new PropertySet();
+    private float mProgress;
+    float mTransitionPathRotate;
+
+    public static final int VISIBILITY_MODE_NORMAL = 0;
+    public static final int VISIBILITY_MODE_IGNORE = 1;
+    @SuppressWarnings("unused") private static final int INTERNAL_MATCH_PARENT = -1;
+    @SuppressWarnings("unused") private static final int INTERNAL_WRAP_CONTENT = -2;
+    public static final int INVISIBLE = 0;
+    public static final int VISIBLE = 4;
+    @SuppressWarnings("unused") private static final int INTERNAL_MATCH_CONSTRAINT = -3;
+    @SuppressWarnings("unused") private static final int INTERNAL_WRAP_CONTENT_CONSTRAINED = -4;
+
+    public static final int ROTATE_NONE = 0;
+    public static final int ROTATE_PORTRATE_OF_RIGHT = 1;
+    public static final int ROTATE_PORTRATE_OF_LEFT = 2;
+    public static final int ROTATE_RIGHT_OF_PORTRATE = 3;
+    public static final int ROTATE_LEFT_OF_PORTRATE = 4;
+    public static final int UNSET = -1;
+    public static final int MATCH_CONSTRAINT = 0;
+    public static final int PARENT_ID = 0;
+    public static final int FILL_PARENT = -1;
+    public static final int MATCH_PARENT = -1;
+    public static final int WRAP_CONTENT = -2;
+    public static final int GONE_UNSET = Integer.MIN_VALUE;
+    public static final int MATCH_CONSTRAINT_WRAP = ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+
+
+    /**
+     *
+     */
+    public static class Motion {
+        public String mAnimateRelativeTo = null;
+        public int mAnimateCircleAngleTo = 0;
+        public String mTransitionEasing = null;
+        public int mPathMotionArc = UNSET;
+        public int mDrawPath = 0;
+        public float mMotionStagger = Float.NaN;
+        public int mPolarRelativeTo = UNSET;
+        public float mPathRotate = Float.NaN;
+        public float mQuantizeMotionPhase = Float.NaN;
+        public int mQuantizeMotionSteps = UNSET;
+        public String mQuantizeInterpolatorString = null;
+        public int mQuantizeInterpolatorType = INTERPOLATOR_UNDEFINED; // undefined
+        public int mQuantizeInterpolatorID = -1;
+        @SuppressWarnings("unused") private static final int INTERPOLATOR_REFERENCE_ID = -2;
+        @SuppressWarnings("unused") private static final int SPLINE_STRING = -1;
+        private static final int INTERPOLATOR_UNDEFINED = -3;
+    }
+
+    public static class PropertySet {
+        public int visibility = VISIBLE;
+        public int mVisibilityMode = VISIBILITY_MODE_NORMAL;
+        public float alpha = 1;
+        public float mProgress = Float.NaN;
+    }
+
+    public MotionWidget() {
+
+    }
+
+    public MotionWidget getParent() {
+        return null;
+    }
+
+    // @TODO: add description
+    public MotionWidget findViewById(int mTransformPivotTarget) {
+        return null;
+    }
+
+    public void setVisibility(int visibility) {
+        mPropertySet.visibility = visibility;
+    }
+
+    public String getName() {
+        return mWidgetFrame.getId();
+    }
+
+    // @TODO: add description
+    public void layout(int l, int t, int r, int b) {
+        setBounds(l, t, r, b);
+    }
+
+    // @TODO: add description
+    @Override
+    public String toString() {
+        return mWidgetFrame.left + ", " + mWidgetFrame.top + ", "
+                + mWidgetFrame.right + ", " + mWidgetFrame.bottom;
+    }
+
+    // @TODO: add description
+    public void setBounds(int left, int top, int right, int bottom) {
+        if (mWidgetFrame == null) {
+            mWidgetFrame = new WidgetFrame((ConstraintWidget) null);
+        }
+        mWidgetFrame.top = top;
+        mWidgetFrame.left = left;
+        mWidgetFrame.right = right;
+        mWidgetFrame.bottom = bottom;
+    }
+
+    public MotionWidget(WidgetFrame f) {
+        mWidgetFrame = f;
+    }
+
+    /**
+     * This populates the motion attributes from widgetFrame to the MotionWidget
+     */
+    public void updateMotion(TypedValues toUpdate) {
+        if (mWidgetFrame.getMotionProperties() != null) {
+            mWidgetFrame.getMotionProperties().applyDelta(toUpdate);
+        }
+    }
+
+    @Override
+    public boolean setValue(int id, int value) {
+        boolean set = setValueAttributes(id, value);
+        if (set) {
+            return true;
+        }
+        return setValueMotion(id, value);
+    }
+
+    @Override
+    public boolean setValue(int id, float value) {
+        boolean set = setValueAttributes(id, value);
+        if (set) {
+            return true;
+        }
+        return setValueMotion(id, value);
+    }
+
+    @Override
+    public boolean setValue(int id, String value) {
+        if (id == MotionType.TYPE_ANIMATE_RELATIVE_TO) {
+            mMotion.mAnimateRelativeTo = value;
+            return true;
+        }
+        return setValueMotion(id, value);
+    }
+
+    @Override
+    public boolean setValue(int id, boolean value) {
+        return false;
+    }
+
+    // @TODO: add description
+    public boolean setValueMotion(int id, int value) {
+        switch (id) {
+            case MotionType.TYPE_ANIMATE_CIRCLEANGLE_TO:
+                mMotion.mAnimateCircleAngleTo = value;
+                break;
+            case MotionType.TYPE_PATHMOTION_ARC:
+                mMotion.mPathMotionArc = value;
+                break;
+            case MotionType.TYPE_DRAW_PATH:
+                mMotion.mDrawPath = value;
+                break;
+            case MotionType.TYPE_POLAR_RELATIVETO:
+                mMotion.mPolarRelativeTo = value;
+                break;
+            case MotionType.TYPE_QUANTIZE_MOTIONSTEPS:
+                mMotion.mQuantizeMotionSteps = value;
+                break;
+            case MotionType.TYPE_QUANTIZE_INTERPOLATOR_TYPE:
+                mMotion.mQuantizeInterpolatorType = value;
+                break; // undefined
+            case MotionType.TYPE_QUANTIZE_INTERPOLATOR_ID:
+                mMotion.mQuantizeInterpolatorID = value;
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    public boolean setValueMotion(int id, String value) {
+        switch (id) {
+
+            case MotionType.TYPE_EASING:
+                mMotion.mTransitionEasing = value;
+                break;
+            case MotionType.TYPE_QUANTIZE_INTERPOLATOR:
+                mMotion.mQuantizeInterpolatorString = value;
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    public boolean setValueMotion(int id, float value) {
+        switch (id) {
+            case MotionType.TYPE_STAGGER:
+                mMotion.mMotionStagger = value;
+                break;
+            case MotionType.TYPE_PATH_ROTATE:
+                mMotion.mPathRotate = value;
+                break;
+            case MotionType.TYPE_QUANTIZE_MOTION_PHASE:
+                mMotion.mQuantizeMotionPhase = value;
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Sets the attributes
+     */
+    public boolean setValueAttributes(int id, float value) {
+        switch (id) {
+            case AttributesType.TYPE_ALPHA:
+                mWidgetFrame.alpha = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_X:
+                mWidgetFrame.translationX = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_Y:
+                mWidgetFrame.translationY = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_Z:
+                mWidgetFrame.translationZ = value;
+                break;
+            case AttributesType.TYPE_ROTATION_X:
+                mWidgetFrame.rotationX = value;
+                break;
+            case AttributesType.TYPE_ROTATION_Y:
+                mWidgetFrame.rotationY = value;
+                break;
+            case AttributesType.TYPE_ROTATION_Z:
+                mWidgetFrame.rotationZ = value;
+                break;
+            case AttributesType.TYPE_SCALE_X:
+                mWidgetFrame.scaleX = value;
+                break;
+            case AttributesType.TYPE_SCALE_Y:
+                mWidgetFrame.scaleY = value;
+                break;
+            case AttributesType.TYPE_PIVOT_X:
+                mWidgetFrame.pivotX = value;
+                break;
+            case AttributesType.TYPE_PIVOT_Y:
+                mWidgetFrame.pivotY = value;
+                break;
+            case AttributesType.TYPE_PROGRESS:
+                mProgress = value;
+                break;
+            case AttributesType.TYPE_PATH_ROTATE:
+                mTransitionPathRotate = value;
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Sets the attributes
+     */
+    public float getValueAttributes(int id) {
+        switch (id) {
+            case AttributesType.TYPE_ALPHA:
+                return mWidgetFrame.alpha;
+            case AttributesType.TYPE_TRANSLATION_X:
+                return mWidgetFrame.translationX;
+            case AttributesType.TYPE_TRANSLATION_Y:
+                return mWidgetFrame.translationY;
+            case AttributesType.TYPE_TRANSLATION_Z:
+                return mWidgetFrame.translationZ;
+            case AttributesType.TYPE_ROTATION_X:
+                return mWidgetFrame.rotationX;
+            case AttributesType.TYPE_ROTATION_Y:
+                return mWidgetFrame.rotationY;
+            case AttributesType.TYPE_ROTATION_Z:
+                return mWidgetFrame.rotationZ;
+            case AttributesType.TYPE_SCALE_X:
+                return mWidgetFrame.scaleX;
+            case AttributesType.TYPE_SCALE_Y:
+                return mWidgetFrame.scaleY;
+            case AttributesType.TYPE_PIVOT_X:
+                return mWidgetFrame.pivotX;
+            case AttributesType.TYPE_PIVOT_Y:
+                return mWidgetFrame.pivotY;
+            case AttributesType.TYPE_PROGRESS:
+                return mProgress;
+            case AttributesType.TYPE_PATH_ROTATE:
+                return mTransitionPathRotate;
+            default:
+                return Float.NaN;
+        }
+
+    }
+
+    @Override
+    public int getId(String name) {
+        int ret = AttributesType.getId(name);
+        if (ret != -1) {
+            return ret;
+        }
+        return MotionType.getId(name);
+    }
+
+    public int getTop() {
+        return mWidgetFrame.top;
+    }
+
+    public int getLeft() {
+        return mWidgetFrame.left;
+    }
+
+    public int getBottom() {
+        return mWidgetFrame.bottom;
+    }
+
+    public int getRight() {
+        return mWidgetFrame.right;
+    }
+
+    public void setPivotX(float px) {
+        mWidgetFrame.pivotX = px;
+    }
+
+    public void setPivotY(float py) {
+        mWidgetFrame.pivotY = py;
+    }
+
+    public float getRotationX() {
+        return mWidgetFrame.rotationX;
+    }
+
+    public void setRotationX(float rotationX) {
+        mWidgetFrame.rotationX = rotationX;
+    }
+
+    public float getRotationY() {
+        return mWidgetFrame.rotationY;
+    }
+
+    public void setRotationY(float rotationY) {
+        mWidgetFrame.rotationY = rotationY;
+    }
+
+    public float getRotationZ() {
+        return mWidgetFrame.rotationZ;
+    }
+
+    public void setRotationZ(float rotationZ) {
+        mWidgetFrame.rotationZ = rotationZ;
+    }
+
+    public float getTranslationX() {
+        return mWidgetFrame.translationX;
+    }
+
+    public void setTranslationX(float translationX) {
+        mWidgetFrame.translationX = translationX;
+    }
+
+    public float getTranslationY() {
+        return mWidgetFrame.translationY;
+    }
+
+    public void setTranslationY(float translationY) {
+        mWidgetFrame.translationY = translationY;
+    }
+
+    public void setTranslationZ(float tz) {
+        mWidgetFrame.translationZ = tz;
+    }
+
+    public float getTranslationZ() {
+        return mWidgetFrame.translationZ;
+    }
+
+    public float getScaleX() {
+        return mWidgetFrame.scaleX;
+    }
+
+    public void setScaleX(float scaleX) {
+        mWidgetFrame.scaleX = scaleX;
+    }
+
+    public float getScaleY() {
+        return mWidgetFrame.scaleY;
+    }
+
+    public void setScaleY(float scaleY) {
+        mWidgetFrame.scaleY = scaleY;
+    }
+
+    public int getVisibility() {
+        return mPropertySet.visibility;
+    }
+
+    public float getPivotX() {
+        return mWidgetFrame.pivotX;
+    }
+
+    public float getPivotY() {
+        return mWidgetFrame.pivotY;
+    }
+
+    public float getAlpha() {
+        return mWidgetFrame.alpha;
+    }
+
+    public int getX() {
+        return mWidgetFrame.left;
+    }
+
+    public int getY() {
+        return mWidgetFrame.top;
+    }
+
+    public int getWidth() {
+        return mWidgetFrame.right - mWidgetFrame.left;
+    }
+
+    public int getHeight() {
+        return mWidgetFrame.bottom - mWidgetFrame.top;
+    }
+
+    public WidgetFrame getWidgetFrame() {
+        return mWidgetFrame;
+    }
+
+    public Set<String> getCustomAttributeNames() {
+        return mWidgetFrame.getCustomAttributeNames();
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, float value) {
+        mWidgetFrame.setCustomAttribute(name, type, value);
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, int value) {
+        mWidgetFrame.setCustomAttribute(name, type, value);
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, boolean value) {
+        mWidgetFrame.setCustomAttribute(name, type, value);
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, String value) {
+        mWidgetFrame.setCustomAttribute(name, type, value);
+    }
+
+    // @TODO: add description
+    public CustomVariable getCustomAttribute(String name) {
+        return mWidgetFrame.getCustomAttribute(name);
+    }
+
+    // @TODO: add description
+    public void setInterpolatedValue(CustomAttribute attribute, float[] mCache) {
+        mWidgetFrame.setCustomAttribute(attribute.mName, TypedValues.Custom.TYPE_FLOAT, mCache[0]);
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionConstraintSet.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionConstraintSet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+public class MotionConstraintSet {
+    @SuppressWarnings("unused") private static final String ERROR_MESSAGE = "XML parser error "
+            + "must be within a Constraint ";
+
+    @SuppressWarnings("unused") private static final int INTERNAL_MATCH_PARENT = -1;
+    @SuppressWarnings("unused") private static final int INTERNAL_WRAP_CONTENT = -2;
+    @SuppressWarnings("unused") private static final int INTERNAL_MATCH_CONSTRAINT = -3;
+    @SuppressWarnings("unused") private static final int INTERNAL_WRAP_CONTENT_CONSTRAINED = -4;
+
+    @SuppressWarnings("unused") private boolean mValidate;
+    public String mIdString;
+    public static final int ROTATE_NONE = 0;
+    public static final int ROTATE_PORTRATE_OF_RIGHT = 1;
+    public static final int ROTATE_PORTRATE_OF_LEFT = 2;
+    public static final int ROTATE_RIGHT_OF_PORTRATE = 3;
+    public static final int ROTATE_LEFT_OF_PORTRATE = 4;
+    public int mRotate = 0;
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKey.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKey.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Base class in an element in a KeyFrame
+ *
+ */
+public abstract class MotionKey implements TypedValues {
+    public static int UNSET = -1;
+    public int mFramePosition = UNSET;
+    int mTargetId = UNSET;
+    String mTargetString = null;
+    public int mType;
+    public HashMap<String, CustomVariable> mCustom;
+
+    // @TODO: add description
+    public abstract void getAttributeNames(HashSet<String> attributes);
+
+    public static final String ALPHA = "alpha";
+    public static final String ELEVATION = "elevation";
+    public static final String ROTATION = "rotationZ";
+    public static final String ROTATION_X = "rotationX";
+
+    public static final String TRANSITION_PATH_ROTATE = "transitionPathRotate";
+    public static final String SCALE_X = "scaleX";
+    public static final String SCALE_Y = "scaleY";
+
+
+    public static final String TRANSLATION_X = "translationX";
+    public static final String TRANSLATION_Y = "translationY";
+
+    public static final String CUSTOM = "CUSTOM";
+
+    public static final String VISIBILITY = "visibility";
+
+    boolean matches(String constraintTag) {
+        if (mTargetString == null || constraintTag == null) return false;
+        return constraintTag.matches(mTargetString);
+    }
+
+    /**
+     * Defines method to add a a view to splines derived form this key frame.
+     * The values are written to the spline
+     *
+     * @param splines splines to write values to
+     */
+    public abstract void addValues(HashMap<String, SplineSet> splines);
+
+    /**
+     * Return the float given a value. If the value is a "Float" object it is casted
+     *
+     */
+    float toFloat(Object value) {
+        return (value instanceof Float) ? (Float) value : Float.parseFloat(value.toString());
+    }
+
+    /**
+     * Return the int version of an object if the value is an Integer object it is casted.
+     *
+     *
+     */
+    int toInt(Object value) {
+        return (value instanceof Integer) ? (Integer) value : Integer.parseInt(value.toString());
+    }
+
+    /**
+     * Return the boolean version this object if the object is a Boolean it is casted.
+     *
+     *
+     */
+    boolean toBoolean(Object value) {
+        return (value instanceof Boolean)
+                ? (Boolean) value : Boolean.parseBoolean(value.toString());
+    }
+
+    /**
+     * Key frame can specify the type of interpolation it wants on various attributes
+     * For each string it set it to -1, CurveFit.LINEAR or  CurveFit.SPLINE
+     */
+    public void setInterpolation(HashMap<String, Integer> interpolation) {
+    }
+
+    // @TODO: add description
+    public MotionKey copy(MotionKey src) {
+        mFramePosition = src.mFramePosition;
+        mTargetId = src.mTargetId;
+        mTargetString = src.mTargetString;
+        mType = src.mType;
+        return this;
+    }
+
+    // @TODO: add description
+    @Override
+    public abstract MotionKey clone();
+
+    // @TODO: add description
+    public MotionKey setViewId(int id) {
+        mTargetId = id;
+        return this;
+    }
+
+    /**
+     * sets the frame position
+     */
+    public void setFramePosition(int pos) {
+        mFramePosition = pos;
+    }
+
+    /**
+     * Gets the current frame position
+     */
+    public int getFramePosition() {
+        return mFramePosition;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, int value) {
+
+        switch (type) {
+            case TypedValues.TYPE_FRAME_POSITION:
+                mFramePosition = value;
+                return true;
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, float value) {
+        return false;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case TypedValues.TYPE_TARGET:
+                mTargetString = value;
+                return true;
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, boolean value) {
+        return false;
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, float value) {
+        mCustom.put(name, new CustomVariable(name, type, value));
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, int value) {
+        mCustom.put(name, new CustomVariable(name, type, value));
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, boolean value) {
+        mCustom.put(name, new CustomVariable(name, type, value));
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, String value) {
+        mCustom.put(name, new CustomVariable(name, type, value));
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyAttributes.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyAttributes.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class MotionKeyAttributes extends MotionKey {
+    static final String NAME = "KeyAttribute";
+    private static final String TAG = "KeyAttributes";
+    @SuppressWarnings("unused") private static final boolean DEBUG = false;
+    @SuppressWarnings("unused") private String mTransitionEasing;
+    private int mCurveFit = -1;
+    @SuppressWarnings("unused") private int mVisibility = 0;
+    private float mAlpha = Float.NaN;
+    private float mElevation = Float.NaN;
+    private float mRotation = Float.NaN;
+    private float mRotationX = Float.NaN;
+    private float mRotationY = Float.NaN;
+    private float mPivotX = Float.NaN;
+    private float mPivotY = Float.NaN;
+    private float mTransitionPathRotate = Float.NaN;
+    private float mScaleX = Float.NaN;
+    private float mScaleY = Float.NaN;
+    private float mTranslationX = Float.NaN;
+    private float mTranslationY = Float.NaN;
+    private float mTranslationZ = Float.NaN;
+    private float mProgress = Float.NaN;
+
+    public static final int KEY_TYPE = 1;
+
+    {
+        mType = KEY_TYPE;
+        mCustom = new HashMap<>();
+    }
+
+    @Override
+    public void getAttributeNames(HashSet<String> attributes) {
+
+        if (!Float.isNaN(mAlpha)) {
+            attributes.add(AttributesType.S_ALPHA);
+        }
+        if (!Float.isNaN(mElevation)) {
+            attributes.add(AttributesType.S_ELEVATION);
+        }
+        if (!Float.isNaN(mRotation)) {
+            attributes.add(AttributesType.S_ROTATION_Z);
+        }
+        if (!Float.isNaN(mRotationX)) {
+            attributes.add(AttributesType.S_ROTATION_X);
+        }
+        if (!Float.isNaN(mRotationY)) {
+            attributes.add(AttributesType.S_ROTATION_Y);
+        }
+        if (!Float.isNaN(mPivotX)) {
+            attributes.add(AttributesType.S_PIVOT_X);
+        }
+        if (!Float.isNaN(mPivotY)) {
+            attributes.add(AttributesType.S_PIVOT_Y);
+        }
+        if (!Float.isNaN(mTranslationX)) {
+            attributes.add(AttributesType.S_TRANSLATION_X);
+        }
+        if (!Float.isNaN(mTranslationY)) {
+            attributes.add(AttributesType.S_TRANSLATION_Y);
+        }
+        if (!Float.isNaN(mTranslationZ)) {
+            attributes.add(AttributesType.S_TRANSLATION_Z);
+        }
+        if (!Float.isNaN(mTransitionPathRotate)) {
+            attributes.add(AttributesType.S_PATH_ROTATE);
+        }
+        if (!Float.isNaN(mScaleX)) {
+            attributes.add(AttributesType.S_SCALE_X);
+        }
+        if (!Float.isNaN(mScaleY)) {
+            attributes.add(AttributesType.S_SCALE_Y);
+        }
+        if (!Float.isNaN(mProgress)) {
+            attributes.add(AttributesType.S_PROGRESS);
+        }
+        if (mCustom.size() > 0) {
+            for (String s : mCustom.keySet()) {
+                attributes.add(TypedValues.S_CUSTOM + "," + s);
+            }
+        }
+    }
+
+    @Override
+    public void addValues(HashMap<String, SplineSet> splines) {
+        for (String s : splines.keySet()) {
+            SplineSet splineSet = splines.get(s);
+            if (splineSet == null) {
+                continue;
+            }
+            // TODO support custom
+            if (s.startsWith(AttributesType.S_CUSTOM)) {
+                String cKey = s.substring(AttributesType.S_CUSTOM.length() + 1);
+                CustomVariable cValue = mCustom.get(cKey);
+                if (cValue != null) {
+                    ((SplineSet.CustomSpline) splineSet).setPoint(mFramePosition, cValue);
+                }
+                continue;
+            }
+            switch (s) {
+                case AttributesType.S_ALPHA:
+                    if (!Float.isNaN(mAlpha)) {
+                        splineSet.setPoint(mFramePosition, mAlpha);
+                    }
+                    break;
+                case AttributesType.S_ELEVATION:
+                    if (!Float.isNaN(mElevation)) {
+                        splineSet.setPoint(mFramePosition, mElevation);
+                    }
+                    break;
+                case AttributesType.S_ROTATION_Z:
+                    if (!Float.isNaN(mRotation)) {
+                        splineSet.setPoint(mFramePosition, mRotation);
+                    }
+                    break;
+                case AttributesType.S_ROTATION_X:
+                    if (!Float.isNaN(mRotationX)) {
+                        splineSet.setPoint(mFramePosition, mRotationX);
+                    }
+                    break;
+                case AttributesType.S_ROTATION_Y:
+                    if (!Float.isNaN(mRotationY)) {
+                        splineSet.setPoint(mFramePosition, mRotationY);
+                    }
+                    break;
+                case AttributesType.S_PIVOT_X:
+                    if (!Float.isNaN(mRotationX)) {
+                        splineSet.setPoint(mFramePosition, mPivotX);
+                    }
+                    break;
+                case AttributesType.S_PIVOT_Y:
+                    if (!Float.isNaN(mRotationY)) {
+                        splineSet.setPoint(mFramePosition, mPivotY);
+                    }
+                    break;
+                case AttributesType.S_PATH_ROTATE:
+                    if (!Float.isNaN(mTransitionPathRotate)) {
+                        splineSet.setPoint(mFramePosition, mTransitionPathRotate);
+                    }
+                    break;
+                case AttributesType.S_SCALE_X:
+                    if (!Float.isNaN(mScaleX)) {
+                        splineSet.setPoint(mFramePosition, mScaleX);
+                    }
+                    break;
+                case AttributesType.S_SCALE_Y:
+                    if (!Float.isNaN(mScaleY)) {
+                        splineSet.setPoint(mFramePosition, mScaleY);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_X:
+                    if (!Float.isNaN(mTranslationX)) {
+                        splineSet.setPoint(mFramePosition, mTranslationX);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_Y:
+                    if (!Float.isNaN(mTranslationY)) {
+                        splineSet.setPoint(mFramePosition, mTranslationY);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_Z:
+                    if (!Float.isNaN(mTranslationZ)) {
+                        splineSet.setPoint(mFramePosition, mTranslationZ);
+                    }
+                    break;
+                case AttributesType.S_PROGRESS:
+                    if (!Float.isNaN(mProgress)) {
+                        splineSet.setPoint(mFramePosition, mProgress);
+                    }
+                    break;
+                default:
+                    System.err.println("not supported by KeyAttributes " + s);
+            }
+        }
+    }
+
+    @Override
+    public MotionKey clone() {
+        return null;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, int value) {
+
+        switch (type) {
+            case AttributesType.TYPE_VISIBILITY:
+                mVisibility = value;
+                break;
+            case AttributesType.TYPE_CURVE_FIT:
+                mCurveFit = value;
+                break;
+            case TypedValues.TYPE_FRAME_POSITION:
+                mFramePosition = value;
+                break;
+            default:
+                if (!setValue(type, value)) {
+                    return super.setValue(type, value);
+                }
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, float value) {
+        switch (type) {
+            case AttributesType.TYPE_ALPHA:
+                mAlpha = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_X:
+                mTranslationX = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_Y:
+                mTranslationY = value;
+                break;
+            case AttributesType.TYPE_TRANSLATION_Z:
+                mTranslationZ = value;
+                break;
+            case AttributesType.TYPE_ELEVATION:
+                mElevation = value;
+                break;
+            case AttributesType.TYPE_ROTATION_X:
+                mRotationX = value;
+                break;
+            case AttributesType.TYPE_ROTATION_Y:
+                mRotationY = value;
+                break;
+            case AttributesType.TYPE_ROTATION_Z:
+                mRotation = value;
+                break;
+            case AttributesType.TYPE_SCALE_X:
+                mScaleX = value;
+                break;
+            case AttributesType.TYPE_SCALE_Y:
+                mScaleY = value;
+                break;
+            case AttributesType.TYPE_PIVOT_X:
+                mPivotX = value;
+                break;
+            case AttributesType.TYPE_PIVOT_Y:
+                mPivotY = value;
+                break;
+            case AttributesType.TYPE_PROGRESS:
+                mProgress = value;
+                break;
+            case AttributesType.TYPE_PATH_ROTATE:
+                mTransitionPathRotate = value;
+                break;
+            case TypedValues.TYPE_FRAME_POSITION:
+                mTransitionPathRotate = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public void setInterpolation(HashMap<String, Integer> interpolation) {
+        if (!Float.isNaN(mAlpha)) {
+            interpolation.put(AttributesType.S_ALPHA, mCurveFit);
+        }
+        if (!Float.isNaN(mElevation)) {
+            interpolation.put(AttributesType.S_ELEVATION, mCurveFit);
+        }
+        if (!Float.isNaN(mRotation)) {
+            interpolation.put(AttributesType.S_ROTATION_Z, mCurveFit);
+        }
+        if (!Float.isNaN(mRotationX)) {
+            interpolation.put(AttributesType.S_ROTATION_X, mCurveFit);
+        }
+        if (!Float.isNaN(mRotationY)) {
+            interpolation.put(AttributesType.S_ROTATION_Y, mCurveFit);
+        }
+        if (!Float.isNaN(mPivotX)) {
+            interpolation.put(AttributesType.S_PIVOT_X, mCurveFit);
+        }
+        if (!Float.isNaN(mPivotY)) {
+            interpolation.put(AttributesType.S_PIVOT_Y, mCurveFit);
+        }
+        if (!Float.isNaN(mTranslationX)) {
+            interpolation.put(AttributesType.S_TRANSLATION_X, mCurveFit);
+        }
+        if (!Float.isNaN(mTranslationY)) {
+            interpolation.put(AttributesType.S_TRANSLATION_Y, mCurveFit);
+        }
+        if (!Float.isNaN(mTranslationZ)) {
+            interpolation.put(AttributesType.S_TRANSLATION_Z, mCurveFit);
+        }
+        if (!Float.isNaN(mTransitionPathRotate)) {
+            interpolation.put(AttributesType.S_PATH_ROTATE, mCurveFit);
+        }
+        if (!Float.isNaN(mScaleX)) {
+            interpolation.put(AttributesType.S_SCALE_X, mCurveFit);
+        }
+        if (!Float.isNaN(mScaleY)) {
+            interpolation.put(AttributesType.S_SCALE_Y, mCurveFit);
+        }
+        if (!Float.isNaN(mProgress)) {
+            interpolation.put(AttributesType.S_PROGRESS, mCurveFit);
+        }
+        if (mCustom.size() > 0) {
+            for (String s : mCustom.keySet()) {
+                interpolation.put(AttributesType.S_CUSTOM + "," + s, mCurveFit);
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case AttributesType.TYPE_EASING:
+                mTransitionEasing = value;
+                break;
+
+            case TypedValues.TYPE_TARGET:
+                mTargetString = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    @Override
+    public int getId(String name) {
+        return AttributesType.getId(name);
+    }
+
+    public int getCurveFit() {
+        return mCurveFit;
+    }
+
+    // @TODO: add description
+    public void printAttributes() {
+        HashSet<String> nameSet = new HashSet<>();
+        getAttributeNames(nameSet);
+
+        System.out.println(" ------------- " + mFramePosition + " -------------");
+        String[] names = nameSet.toArray(new String[0]);
+        for (int i = 0; i < names.length; i++) {
+            int id = AttributesType.getId(names[i]);
+            System.out.println(names[i] + ":" + getFloatValue(id));
+        }
+    }
+
+    private float getFloatValue(int id) {
+        switch (id) {
+            case AttributesType.TYPE_ALPHA:
+                return mAlpha;
+            case AttributesType.TYPE_TRANSLATION_X:
+                return mTranslationX;
+            case AttributesType.TYPE_TRANSLATION_Y:
+                return mTranslationY;
+            case AttributesType.TYPE_TRANSLATION_Z:
+                return mTranslationZ;
+            case AttributesType.TYPE_ELEVATION:
+                return mElevation;
+            case AttributesType.TYPE_ROTATION_X:
+                return mRotationX;
+            case AttributesType.TYPE_ROTATION_Y:
+                return mRotationY;
+            case AttributesType.TYPE_ROTATION_Z:
+                return mRotation;
+            case AttributesType.TYPE_SCALE_X:
+                return mScaleX;
+            case AttributesType.TYPE_SCALE_Y:
+                return mScaleY;
+            case AttributesType.TYPE_PIVOT_X:
+                return mPivotX;
+            case AttributesType.TYPE_PIVOT_Y:
+                return mPivotY;
+            case AttributesType.TYPE_PROGRESS:
+                return mProgress;
+            case AttributesType.TYPE_PATH_ROTATE:
+                return mTransitionPathRotate;
+            case TypedValues.TYPE_FRAME_POSITION:
+                return mFramePosition;
+            default:
+                return Float.NaN;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyCycle.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyCycle.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.KeyCycleOscillator;
+import androidx.constraintlayout.core.motion.utils.Oscillator;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.motion.utils.Utils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class MotionKeyCycle extends MotionKey {
+    private static final String TAG = "KeyCycle";
+    static final String NAME = "KeyCycle";
+    public static final String WAVE_PERIOD = "wavePeriod";
+    public static final String WAVE_OFFSET = "waveOffset";
+    public static final String WAVE_PHASE = "wavePhase";
+    public static final String WAVE_SHAPE = "waveShape";
+    public static final int SHAPE_SIN_WAVE = Oscillator.SIN_WAVE;
+    public static final int SHAPE_SQUARE_WAVE = Oscillator.SQUARE_WAVE;
+    public static final int SHAPE_TRIANGLE_WAVE = Oscillator.TRIANGLE_WAVE;
+    public static final int SHAPE_SAW_WAVE = Oscillator.SAW_WAVE;
+    public static final int SHAPE_REVERSE_SAW_WAVE = Oscillator.REVERSE_SAW_WAVE;
+    public static final int SHAPE_COS_WAVE = Oscillator.COS_WAVE;
+    public static final int SHAPE_BOUNCE = Oscillator.BOUNCE;
+
+    @SuppressWarnings("unused") private String mTransitionEasing = null;
+    @SuppressWarnings("unused") private int mCurveFit = 0;
+    private int mWaveShape = -1;
+    private String mCustomWaveShape = null;
+    private float mWavePeriod = Float.NaN;
+    private float mWaveOffset = 0;
+    private float mWavePhase = 0;
+    private float mProgress = Float.NaN;
+    private float mAlpha = Float.NaN;
+    private float mElevation = Float.NaN;
+    private float mRotation = Float.NaN;
+    private float mTransitionPathRotate = Float.NaN;
+    private float mRotationX = Float.NaN;
+    private float mRotationY = Float.NaN;
+    private float mScaleX = Float.NaN;
+    private float mScaleY = Float.NaN;
+    private float mTranslationX = Float.NaN;
+    private float mTranslationY = Float.NaN;
+    private float mTranslationZ = Float.NaN;
+    public static final int KEY_TYPE = 4;
+
+    {
+        mType = KEY_TYPE;
+        mCustom = new HashMap<>();
+    }
+
+    @Override
+    public void getAttributeNames(HashSet<String> attributes) {
+        if (!Float.isNaN(mAlpha)) {
+            attributes.add(CycleType.S_ALPHA);
+        }
+        if (!Float.isNaN(mElevation)) {
+            attributes.add(CycleType.S_ELEVATION);
+        }
+        if (!Float.isNaN(mRotation)) {
+            attributes.add(CycleType.S_ROTATION_Z);
+        }
+        if (!Float.isNaN(mRotationX)) {
+            attributes.add(CycleType.S_ROTATION_X);
+        }
+        if (!Float.isNaN(mRotationY)) {
+            attributes.add(CycleType.S_ROTATION_Y);
+        }
+        if (!Float.isNaN(mScaleX)) {
+            attributes.add(CycleType.S_SCALE_X);
+        }
+        if (!Float.isNaN(mScaleY)) {
+            attributes.add(CycleType.S_SCALE_Y);
+        }
+        if (!Float.isNaN(mTransitionPathRotate)) {
+            attributes.add(CycleType.S_PATH_ROTATE);
+        }
+        if (!Float.isNaN(mTranslationX)) {
+            attributes.add(CycleType.S_TRANSLATION_X);
+        }
+        if (!Float.isNaN(mTranslationY)) {
+            attributes.add(CycleType.S_TRANSLATION_Y);
+        }
+        if (!Float.isNaN(mTranslationZ)) {
+            attributes.add(CycleType.S_TRANSLATION_Z);
+        }
+        if (mCustom.size() > 0) {
+            for (String s : mCustom.keySet()) {
+                attributes.add(TypedValues.S_CUSTOM + "," + s);
+            }
+        }
+    }
+
+    @Override
+    public void addValues(HashMap<String, SplineSet> splines) {
+
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, int value) {
+        switch (type) {
+            case CycleType.TYPE_CURVE_FIT:
+                mCurveFit = value;
+                return true;
+            case CycleType.TYPE_WAVE_SHAPE:
+                mWaveShape = value;
+                return true;
+            default:
+                boolean ret = setValue(type, (float) value);
+                if (ret) {
+                    return true;
+                }
+                return super.setValue(type, value);
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case CycleType.TYPE_EASING:
+                mTransitionEasing = value;
+                return true;
+            case CycleType.TYPE_CUSTOM_WAVE_SHAPE:
+                mCustomWaveShape = value;
+                return true;
+            default:
+                return super.setValue(type, value);
+        }
+
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, float value) {
+        switch (type) {
+            case CycleType.TYPE_ALPHA:
+                mAlpha = value;
+                break;
+            case CycleType.TYPE_TRANSLATION_X:
+                mTranslationX = value;
+                break;
+            case CycleType.TYPE_TRANSLATION_Y:
+                mTranslationY = value;
+                break;
+            case CycleType.TYPE_TRANSLATION_Z:
+                mTranslationZ = value;
+                break;
+            case CycleType.TYPE_ELEVATION:
+                mElevation = value;
+                break;
+            case CycleType.TYPE_ROTATION_X:
+                mRotationX = value;
+                break;
+            case CycleType.TYPE_ROTATION_Y:
+                mRotationY = value;
+                break;
+            case CycleType.TYPE_ROTATION_Z:
+                mRotation = value;
+                break;
+            case CycleType.TYPE_SCALE_X:
+                mScaleX = value;
+                break;
+            case CycleType.TYPE_SCALE_Y:
+                mScaleY = value;
+                break;
+            case CycleType.TYPE_PROGRESS:
+                mProgress = value;
+                break;
+            case CycleType.TYPE_PATH_ROTATE:
+                mTransitionPathRotate = value;
+                break;
+            case CycleType.TYPE_WAVE_PERIOD:
+                mWavePeriod = value;
+                break;
+            case CycleType.TYPE_WAVE_OFFSET:
+                mWaveOffset = value;
+                break;
+            case CycleType.TYPE_WAVE_PHASE:
+                mWavePhase = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    public float getValue(String key) {
+        switch (key) {
+            case CycleType.S_ALPHA:
+                return mAlpha;
+            case CycleType.S_ELEVATION:
+                return mElevation;
+            case CycleType.S_ROTATION_Z:
+                return mRotation;
+            case CycleType.S_ROTATION_X:
+                return mRotationX;
+            case CycleType.S_ROTATION_Y:
+                return mRotationY;
+            case CycleType.S_PATH_ROTATE:
+                return mTransitionPathRotate;
+            case CycleType.S_SCALE_X:
+                return mScaleX;
+            case CycleType.S_SCALE_Y:
+                return mScaleY;
+            case CycleType.S_TRANSLATION_X:
+                return mTranslationX;
+            case CycleType.S_TRANSLATION_Y:
+                return mTranslationY;
+            case CycleType.S_TRANSLATION_Z:
+                return mTranslationZ;
+            case CycleType.S_WAVE_OFFSET:
+                return mWaveOffset;
+            case CycleType.S_WAVE_PHASE:
+                return mWavePhase;
+            case CycleType.S_PROGRESS:
+                return mProgress;
+            default:
+                return Float.NaN;
+        }
+    }
+
+    @Override
+    public MotionKey clone() {
+        return null;
+    }
+
+    @Override
+    public int getId(String name) {
+        switch (name) {
+            case CycleType.S_CURVE_FIT:
+                return CycleType.TYPE_CURVE_FIT;
+            case CycleType.S_VISIBILITY:
+                return CycleType.TYPE_VISIBILITY;
+            case CycleType.S_ALPHA:
+                return CycleType.TYPE_ALPHA;
+            case CycleType.S_TRANSLATION_X:
+                return CycleType.TYPE_TRANSLATION_X;
+            case CycleType.S_TRANSLATION_Y:
+                return CycleType.TYPE_TRANSLATION_Y;
+            case CycleType.S_TRANSLATION_Z:
+                return CycleType.TYPE_TRANSLATION_Z;
+            case CycleType.S_ROTATION_X:
+                return CycleType.TYPE_ROTATION_X;
+            case CycleType.S_ROTATION_Y:
+                return CycleType.TYPE_ROTATION_Y;
+            case CycleType.S_ROTATION_Z:
+                return CycleType.TYPE_ROTATION_Z;
+            case CycleType.S_SCALE_X:
+                return CycleType.TYPE_SCALE_X;
+            case CycleType.S_SCALE_Y:
+                return CycleType.TYPE_SCALE_Y;
+            case CycleType.S_PIVOT_X:
+                return CycleType.TYPE_PIVOT_X;
+            case CycleType.S_PIVOT_Y:
+                return CycleType.TYPE_PIVOT_Y;
+            case CycleType.S_PROGRESS:
+                return CycleType.TYPE_PROGRESS;
+            case CycleType.S_PATH_ROTATE:
+                return CycleType.TYPE_PATH_ROTATE;
+            case CycleType.S_EASING:
+                return CycleType.TYPE_EASING;
+            case CycleType.S_WAVE_PERIOD:
+                return CycleType.TYPE_WAVE_PERIOD;
+            case CycleType.S_WAVE_SHAPE:
+                return CycleType.TYPE_WAVE_SHAPE;
+            case CycleType.S_WAVE_PHASE:
+                return CycleType.TYPE_WAVE_PHASE;
+            case CycleType.S_WAVE_OFFSET:
+                return CycleType.TYPE_WAVE_OFFSET;
+            case CycleType.S_CUSTOM_WAVE_SHAPE:
+                return CycleType.TYPE_CUSTOM_WAVE_SHAPE;
+
+        }
+        return -1;
+    }
+
+    // @TODO: add description
+    public void addCycleValues(HashMap<String, KeyCycleOscillator> oscSet) {
+
+        for (String key : oscSet.keySet()) {
+            if (key.startsWith(TypedValues.S_CUSTOM)) {
+                String customKey = key.substring(TypedValues.S_CUSTOM.length() + 1);
+                CustomVariable cValue = mCustom.get(customKey);
+                if (cValue == null || cValue.getType() != Custom.TYPE_FLOAT) {
+                    continue;
+                }
+
+                KeyCycleOscillator osc = oscSet.get(key);
+                if (osc == null) {
+                    continue;
+                }
+
+                osc.setPoint(mFramePosition, mWaveShape, mCustomWaveShape, -1, mWavePeriod,
+                        mWaveOffset, mWavePhase / 360, cValue.getValueToInterpolate(), cValue);
+                continue;
+            }
+            float value = getValue(key);
+            if (Float.isNaN(value)) {
+                continue;
+            }
+
+            KeyCycleOscillator osc = oscSet.get(key);
+            if (osc == null) {
+                continue;
+            }
+
+            osc.setPoint(mFramePosition, mWaveShape, mCustomWaveShape,
+                    -1, mWavePeriod, mWaveOffset, mWavePhase / 360, value);
+        }
+    }
+
+
+    // @TODO: add description
+    public void dump() {
+        System.out.println("MotionKeyCycle{"
+                + "mWaveShape=" + mWaveShape
+                + ", mWavePeriod=" + mWavePeriod
+                + ", mWaveOffset=" + mWaveOffset
+                + ", mWavePhase=" + mWavePhase
+                + ", mRotation=" + mRotation
+                + '}');
+    }
+
+    // @TODO: add description
+    public void printAttributes() {
+        HashSet<String> nameSet = new HashSet<>();
+        getAttributeNames(nameSet);
+
+        Utils.log(" ------------- " + mFramePosition + " -------------");
+        Utils.log("MotionKeyCycle{"
+                + "Shape=" + mWaveShape
+                + ", Period=" + mWavePeriod
+                + ", Offset=" + mWaveOffset
+                + ", Phase=" + mWavePhase
+                + '}');
+        String[] names = nameSet.toArray(new String[0]);
+        for (int i = 0; i < names.length; i++) {
+            Utils.log(names[i] + ":" + getValue(names[i]));
+        }
+    }
+
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyPosition.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyPosition.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.MotionWidget;
+import androidx.constraintlayout.core.motion.utils.FloatRect;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class MotionKeyPosition extends MotionKey {
+    static final String NAME = "KeyPosition";
+    protected static final float SELECTION_SLOPE = 20;
+    public int mCurveFit = UNSET;
+    public String mTransitionEasing = null;
+    public int mPathMotionArc = UNSET; // -1 means not set
+    public int mDrawPath = 0;
+    public float mPercentWidth = Float.NaN;
+    public float mPercentHeight = Float.NaN;
+    public float mPercentX = Float.NaN;
+    public float mPercentY = Float.NaN;
+    public float mAltPercentX = Float.NaN;
+    public float mAltPercentY = Float.NaN;
+    public static final int TYPE_SCREEN = 2;
+    public static final int TYPE_PATH = 1;
+    public static final int TYPE_CARTESIAN = 0;
+    public int mPositionType = TYPE_CARTESIAN;
+
+    private float mCalculatedPositionX = Float.NaN;
+    private float mCalculatedPositionY = Float.NaN;
+    static final int KEY_TYPE = 2;
+
+    {
+        mType = KEY_TYPE;
+    }
+
+    // TODO this needs the views dimensions to be accurate
+    private void calcScreenPosition(int layoutWidth, int layoutHeight) {
+        int viewWidth = 0;
+        int viewHeight = 0;
+        mCalculatedPositionX = (layoutWidth - viewWidth) * mPercentX + viewWidth / 2;
+        mCalculatedPositionY = (layoutHeight - viewHeight) * mPercentX + viewHeight / 2;
+    }
+
+    private void calcPathPosition(float startX, float startY,
+            float endX, float endY) {
+        float pathVectorX = endX - startX;
+        float pathVectorY = endY - startY;
+        float perpendicularX = -pathVectorY;
+        float perpendicularY = pathVectorX;
+        mCalculatedPositionX = startX + pathVectorX * mPercentX + perpendicularX * mPercentY;
+        mCalculatedPositionY = startY + pathVectorY * mPercentX + perpendicularY * mPercentY;
+    }
+
+    private void calcCartesianPosition(float startX, float startY,
+            float endX, float endY) {
+        float pathVectorX = endX - startX;
+        float pathVectorY = endY - startY;
+        float dxdx = Float.isNaN(mPercentX) ? 0 : mPercentX;
+        float dydx = Float.isNaN(mAltPercentY) ? 0 : mAltPercentY;
+        float dydy = Float.isNaN(mPercentY) ? 0 : mPercentY;
+        float dxdy = Float.isNaN(mAltPercentX) ? 0 : mAltPercentX;
+        mCalculatedPositionX = (int) (startX + pathVectorX * dxdx + pathVectorY * dxdy);
+        mCalculatedPositionY = (int) (startY + pathVectorX * dydx + pathVectorY * dydy);
+    }
+
+    float getPositionX() {
+        return mCalculatedPositionX;
+    }
+
+    float getPositionY() {
+        return mCalculatedPositionY;
+    }
+
+    // @TODO: add description
+    public void positionAttributes(MotionWidget view,
+            FloatRect start,
+            FloatRect end,
+            float x,
+            float y,
+            String[] attribute,
+            float[] value) {
+        switch (mPositionType) {
+
+            case TYPE_PATH:
+                positionPathAttributes(start, end, x, y, attribute, value);
+                return;
+            case TYPE_SCREEN:
+                positionScreenAttributes(view, start, end, x, y, attribute, value);
+                return;
+            case TYPE_CARTESIAN:
+            default:
+                positionCartAttributes(start, end, x, y, attribute, value);
+                return;
+
+        }
+    }
+
+    void positionPathAttributes(FloatRect start,
+            FloatRect end,
+            float x,
+            float y,
+            String[] attribute,
+            float[] value) {
+        float startCenterX = start.centerX();
+        float startCenterY = start.centerY();
+        float endCenterX = end.centerX();
+        float endCenterY = end.centerY();
+        float pathVectorX = endCenterX - startCenterX;
+        float pathVectorY = endCenterY - startCenterY;
+        float distance = (float) Math.hypot(pathVectorX, pathVectorY);
+        if (distance < 0.0001) {
+            System.out.println("distance ~ 0");
+            value[0] = 0;
+            value[1] = 0;
+            return;
+        }
+
+        float dx = pathVectorX / distance;
+        float dy = pathVectorY / distance;
+        float perpendicular = (dx * (y - startCenterY) - (x - startCenterX) * dy) / distance;
+        float dist = (dx * (x - startCenterX) + dy * (y - startCenterY)) / distance;
+        if (attribute[0] != null) {
+            if (PositionType.S_PERCENT_X.equals(attribute[0])) {
+                value[0] = dist;
+                value[1] = perpendicular;
+            }
+        } else {
+            attribute[0] = PositionType.S_PERCENT_X;
+            attribute[1] = PositionType.S_PERCENT_Y;
+            value[0] = dist;
+            value[1] = perpendicular;
+        }
+    }
+
+    void positionScreenAttributes(MotionWidget view,
+            FloatRect start,
+            FloatRect end,
+            float x,
+            float y,
+            String[] attribute,
+            float[] value) {
+        float startCenterX = start.centerX();
+        float startCenterY = start.centerY();
+        float endCenterX = end.centerX();
+        float endCenterY = end.centerY();
+        @SuppressWarnings("unused") float pathVectorX = endCenterX - startCenterX;
+        @SuppressWarnings("unused") float pathVectorY = endCenterY - startCenterY;
+        MotionWidget viewGroup = ((MotionWidget) view.getParent());
+        int width = viewGroup.getWidth();
+        int height = viewGroup.getHeight();
+
+        if (attribute[0] != null) { // they are saying what to use
+            if (PositionType.S_PERCENT_X.equals(attribute[0])) {
+                value[0] = x / width;
+                value[1] = y / height;
+            } else {
+                value[1] = x / width;
+                value[0] = y / height;
+            }
+        } else { // we will use what we want to
+            attribute[0] = PositionType.S_PERCENT_X;
+            value[0] = x / width;
+            attribute[1] = PositionType.S_PERCENT_Y;
+            value[1] = y / height;
+        }
+    }
+
+    void positionCartAttributes(FloatRect start,
+            FloatRect end,
+            float x,
+            float y,
+            String[] attribute,
+            float[] value) {
+        float startCenterX = start.centerX();
+        float startCenterY = start.centerY();
+        float endCenterX = end.centerX();
+        float endCenterY = end.centerY();
+        float pathVectorX = endCenterX - startCenterX;
+        float pathVectorY = endCenterY - startCenterY;
+        if (attribute[0] != null) { // they are saying what to use
+            if (PositionType.S_PERCENT_X.equals(attribute[0])) {
+                value[0] = (x - startCenterX) / pathVectorX;
+                value[1] = (y - startCenterY) / pathVectorY;
+            } else {
+                value[1] = (x - startCenterX) / pathVectorX;
+                value[0] = (y - startCenterY) / pathVectorY;
+            }
+        } else { // we will use what we want to
+            attribute[0] = PositionType.S_PERCENT_X;
+            value[0] = (x - startCenterX) / pathVectorX;
+            attribute[1] = PositionType.S_PERCENT_Y;
+            value[1] = (y - startCenterY) / pathVectorY;
+        }
+    }
+
+    // @TODO: add description
+    public boolean intersects(int layoutWidth,
+            int layoutHeight,
+            FloatRect start,
+            FloatRect end,
+            float x,
+            float y) {
+        calcPosition(layoutWidth, layoutHeight, start.centerX(),
+                start.centerY(), end.centerX(), end.centerY());
+        if ((Math.abs(x - mCalculatedPositionX) < SELECTION_SLOPE)
+                && (Math.abs(y - mCalculatedPositionY) < SELECTION_SLOPE)) {
+            return true;
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKey copy(MotionKey src) {
+        super.copy(src);
+        MotionKeyPosition k = (MotionKeyPosition) src;
+        mTransitionEasing = k.mTransitionEasing;
+        mPathMotionArc = k.mPathMotionArc;
+        mDrawPath = k.mDrawPath;
+        mPercentWidth = k.mPercentWidth;
+        mPercentHeight = Float.NaN;
+        mPercentX = k.mPercentX;
+        mPercentY = k.mPercentY;
+        mAltPercentX = k.mAltPercentX;
+        mAltPercentY = k.mAltPercentY;
+        mCalculatedPositionX = k.mCalculatedPositionX;
+        mCalculatedPositionY = k.mCalculatedPositionY;
+        return this;
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKey clone() {
+        return new MotionKeyPosition().copy(this);
+    }
+
+    void calcPosition(int layoutWidth,
+            int layoutHeight,
+            float startX,
+            float startY,
+            float endX,
+            float endY) {
+        switch (mPositionType) {
+            case TYPE_SCREEN:
+                calcScreenPosition(layoutWidth, layoutHeight);
+                return;
+
+            case TYPE_PATH:
+                calcPathPosition(startX, startY, endX, endY);
+                return;
+            case TYPE_CARTESIAN:
+            default:
+                calcCartesianPosition(startX, startY, endX, endY);
+                return;
+        }
+    }
+
+    @Override
+    public void getAttributeNames(HashSet<String> attributes) {
+
+    }
+
+    // @TODO: add description
+
+    /**
+     * @param splines splines to write values to
+     */
+    @Override
+    public void addValues(HashMap<String, SplineSet> splines) {
+    }
+
+    @Override
+    public boolean setValue(int type, int value) {
+        switch (type) {
+            case PositionType.TYPE_POSITION_TYPE:
+                mPositionType = value;
+                break;
+            case TypedValues.TYPE_FRAME_POSITION:
+                mFramePosition = value;
+                break;
+            case PositionType.TYPE_CURVE_FIT:
+                mCurveFit = value;
+                break;
+
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+
+    }
+
+    @Override
+    public boolean setValue(int type, float value) {
+        switch (type) {
+            case PositionType.TYPE_PERCENT_WIDTH:
+                mPercentWidth = value;
+                break;
+            case PositionType.TYPE_PERCENT_HEIGHT:
+                mPercentHeight = value;
+                break;
+            case PositionType.TYPE_SIZE_PERCENT:
+                mPercentHeight = mPercentWidth = value;
+                break;
+            case PositionType.TYPE_PERCENT_X:
+                mPercentX = value;
+                break;
+            case PositionType.TYPE_PERCENT_Y:
+                mPercentY = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case PositionType.TYPE_TRANSITION_EASING:
+                mTransitionEasing = value.toString();
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    @Override
+    public int getId(String name) {
+        return PositionType.getId(name);
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyTimeCycle.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyTimeCycle.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.Oscillator;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+import androidx.constraintlayout.core.motion.utils.TimeCycleSplineSet;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.motion.utils.Utils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class MotionKeyTimeCycle extends MotionKey {
+    static final String NAME = "KeyTimeCycle";
+    private static final String TAG = NAME;
+
+    private String mTransitionEasing;
+    private int mCurveFit = -1;
+    private float mAlpha = Float.NaN;
+    private float mElevation = Float.NaN;
+    private float mRotation = Float.NaN;
+    private float mRotationX = Float.NaN;
+    private float mRotationY = Float.NaN;
+    private float mTransitionPathRotate = Float.NaN;
+    private float mScaleX = Float.NaN;
+    private float mScaleY = Float.NaN;
+    private float mTranslationX = Float.NaN;
+    private float mTranslationY = Float.NaN;
+    private float mTranslationZ = Float.NaN;
+    private float mProgress = Float.NaN;
+    private int mWaveShape = 0;
+
+    // TODO add support of custom wave shapes in KeyTimeCycle
+    @SuppressWarnings("unused") private String mCustomWaveShape = null;
+    private float mWavePeriod = Float.NaN;
+    private float mWaveOffset = 0;
+    public static final int KEY_TYPE = 3;
+
+    {
+        mType = KEY_TYPE;
+        mCustom = new HashMap<>();
+    }
+
+    // @TODO: add description
+    public void addTimeValues(HashMap<String, TimeCycleSplineSet> splines) {
+        for (String s : splines.keySet()) {
+            TimeCycleSplineSet splineSet = splines.get(s);
+            if (splineSet == null) {
+                continue;
+            }
+            if (s.startsWith(CUSTOM)) {
+                String cKey = s.substring(CUSTOM.length() + 1);
+                CustomVariable cValue = mCustom.get(cKey);
+                if (cValue != null) {
+                    ((TimeCycleSplineSet.CustomVarSet) splineSet)
+                            .setPoint(mFramePosition, cValue, mWavePeriod, mWaveShape, mWaveOffset);
+                }
+                continue;
+            }
+            switch (s) {
+                case AttributesType.S_ALPHA:
+                    if (!Float.isNaN(mAlpha)) {
+                        splineSet.setPoint(mFramePosition,
+                                mAlpha, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+
+                case AttributesType.S_ROTATION_X:
+                    if (!Float.isNaN(mRotationX)) {
+                        splineSet.setPoint(mFramePosition,
+                                mRotationX, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_ROTATION_Y:
+                    if (!Float.isNaN(mRotationY)) {
+                        splineSet.setPoint(mFramePosition,
+                                mRotationY, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_ROTATION_Z:
+                    if (!Float.isNaN(mRotation)) {
+                        splineSet.setPoint(mFramePosition,
+                                mRotation, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_PATH_ROTATE:
+                    if (!Float.isNaN(mTransitionPathRotate)) {
+                        splineSet.setPoint(mFramePosition,
+                                mTransitionPathRotate, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+
+                case AttributesType.S_SCALE_X:
+                    if (!Float.isNaN(mScaleX)) {
+                        splineSet.setPoint(mFramePosition,
+                                mScaleX, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_SCALE_Y:
+                    if (!Float.isNaN(mScaleY)) {
+                        splineSet.setPoint(mFramePosition,
+                                mScaleY, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_X:
+                    if (!Float.isNaN(mTranslationX)) {
+                        splineSet.setPoint(mFramePosition,
+                                mTranslationX, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_Y:
+                    if (!Float.isNaN(mTranslationY)) {
+                        splineSet.setPoint(mFramePosition,
+                                mTranslationY, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_TRANSLATION_Z:
+                    if (!Float.isNaN(mTranslationZ)) {
+                        splineSet.setPoint(mFramePosition,
+                                mTranslationZ, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_ELEVATION:
+                    if (!Float.isNaN(mTranslationZ)) {
+                        splineSet.setPoint(mFramePosition,
+                                mTranslationZ, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                case AttributesType.S_PROGRESS:
+                    if (!Float.isNaN(mProgress)) {
+                        splineSet.setPoint(mFramePosition,
+                                mProgress, mWavePeriod, mWaveShape, mWaveOffset);
+                    }
+                    break;
+                default:
+                    Utils.loge("KeyTimeCycles", "UNKNOWN addValues \"" + s + "\"");
+            }
+        }
+    }
+
+    @Override
+    public void addValues(HashMap<String, SplineSet> splines) {
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, int value) {
+
+        switch (type) {
+            case TypedValues.TYPE_FRAME_POSITION:
+                mFramePosition = value;
+                break;
+            case CycleType.TYPE_WAVE_SHAPE:
+                mWaveShape = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, float value) {
+        switch (type) {
+            case CycleType.TYPE_ALPHA:
+                mAlpha = value;
+                break;
+            case CycleType.TYPE_CURVE_FIT:
+                mCurveFit = toInt(value);
+                break;
+            case CycleType.TYPE_ELEVATION:
+                mElevation = toFloat(value);
+                break;
+            case CycleType.TYPE_PROGRESS:
+                mProgress = toFloat(value);
+                break;
+            case CycleType.TYPE_ROTATION_Z:
+                mRotation = toFloat(value);
+                break;
+            case CycleType.TYPE_ROTATION_X:
+                mRotationX = toFloat(value);
+                break;
+            case CycleType.TYPE_ROTATION_Y:
+                mRotationY = toFloat(value);
+                break;
+            case CycleType.TYPE_SCALE_X:
+                mScaleX = toFloat(value);
+                break;
+            case CycleType.TYPE_SCALE_Y:
+                mScaleY = toFloat(value);
+                break;
+            case CycleType.TYPE_PATH_ROTATE:
+                mTransitionPathRotate = toFloat(value);
+                break;
+            case CycleType.TYPE_TRANSLATION_X:
+                mTranslationX = toFloat(value);
+                break;
+            case CycleType.TYPE_TRANSLATION_Y:
+                mTranslationY = toFloat(value);
+                break;
+            case CycleType.TYPE_TRANSLATION_Z:
+                mTranslationZ = toFloat(value);
+                break;
+            case CycleType.TYPE_WAVE_PERIOD:
+                mWavePeriod = toFloat(value);
+                break;
+            case CycleType.TYPE_WAVE_OFFSET:
+                mWaveOffset = toFloat(value);
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case CycleType.TYPE_WAVE_SHAPE:
+                mWaveShape = Oscillator.CUSTOM;
+                mCustomWaveShape = value;
+                break;
+            case CycleType.TYPE_EASING:
+                mTransitionEasing = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, boolean value) {
+        return super.setValue(type, value);
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKeyTimeCycle copy(MotionKey src) {
+        super.copy(src);
+        MotionKeyTimeCycle k = (MotionKeyTimeCycle) src;
+        mTransitionEasing = k.mTransitionEasing;
+        mCurveFit = k.mCurveFit;
+        mWaveShape = k.mWaveShape;
+        mWavePeriod = k.mWavePeriod;
+        mWaveOffset = k.mWaveOffset;
+        mProgress = k.mProgress;
+        mAlpha = k.mAlpha;
+        mElevation = k.mElevation;
+        mRotation = k.mRotation;
+        mTransitionPathRotate = k.mTransitionPathRotate;
+        mRotationX = k.mRotationX;
+        mRotationY = k.mRotationY;
+        mScaleX = k.mScaleX;
+        mScaleY = k.mScaleY;
+        mTranslationX = k.mTranslationX;
+        mTranslationY = k.mTranslationY;
+        mTranslationZ = k.mTranslationZ;
+        return this;
+    }
+
+    @Override
+    public void getAttributeNames(HashSet<String> attributes) {
+        if (!Float.isNaN(mAlpha)) {
+            attributes.add(CycleType.S_ALPHA);
+        }
+        if (!Float.isNaN(mElevation)) {
+            attributes.add(CycleType.S_ELEVATION);
+        }
+        if (!Float.isNaN(mRotation)) {
+            attributes.add(CycleType.S_ROTATION_Z);
+        }
+        if (!Float.isNaN(mRotationX)) {
+            attributes.add(CycleType.S_ROTATION_X);
+        }
+        if (!Float.isNaN(mRotationY)) {
+            attributes.add(CycleType.S_ROTATION_Y);
+        }
+        if (!Float.isNaN(mScaleX)) {
+            attributes.add(CycleType.S_SCALE_X);
+        }
+        if (!Float.isNaN(mScaleY)) {
+            attributes.add(CycleType.S_SCALE_Y);
+        }
+        if (!Float.isNaN(mTransitionPathRotate)) {
+            attributes.add(CycleType.S_PATH_ROTATE);
+        }
+        if (!Float.isNaN(mTranslationX)) {
+            attributes.add(CycleType.S_TRANSLATION_X);
+        }
+        if (!Float.isNaN(mTranslationY)) {
+            attributes.add(CycleType.S_TRANSLATION_Y);
+        }
+        if (!Float.isNaN(mTranslationZ)) {
+            attributes.add(CycleType.S_TRANSLATION_Z);
+        }
+        if (mCustom.size() > 0) {
+            for (String s : mCustom.keySet()) {
+                attributes.add(TypedValues.S_CUSTOM + "," + s);
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKey clone() {
+        return new MotionKeyTimeCycle().copy(this);
+    }
+
+    @Override
+    public int getId(String name) {
+        return CycleType.getId(name);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyTrigger.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/key/MotionKeyTrigger.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.key;
+
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.MotionWidget;
+import androidx.constraintlayout.core.motion.utils.FloatRect;
+import androidx.constraintlayout.core.motion.utils.SplineSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+
+public class MotionKeyTrigger extends MotionKey {
+    private static final String TAG = "KeyTrigger";
+    public static final String VIEW_TRANSITION_ON_CROSS = "viewTransitionOnCross";
+    public static final String VIEW_TRANSITION_ON_POSITIVE_CROSS = "viewTransitionOnPositiveCross";
+    public static final String VIEW_TRANSITION_ON_NEGATIVE_CROSS = "viewTransitionOnNegativeCross";
+    public static final String POST_LAYOUT = "postLayout";
+    public static final String TRIGGER_SLACK = "triggerSlack";
+    public static final String TRIGGER_COLLISION_VIEW = "triggerCollisionView";
+    public static final String TRIGGER_COLLISION_ID = "triggerCollisionId";
+    public static final String TRIGGER_ID = "triggerID";
+    public static final String POSITIVE_CROSS = "positiveCross";
+    public static final String NEGATIVE_CROSS = "negativeCross";
+    public static final String TRIGGER_RECEIVER = "triggerReceiver";
+    public static final String CROSS = "CROSS";
+
+    private int mCurveFit = -1;
+    private String mCross = null;
+    private int mTriggerReceiver = UNSET;
+    private String mNegativeCross = null;
+    private String mPositiveCross = null;
+    private int mTriggerID = UNSET;
+    private int mTriggerCollisionId = UNSET;
+    //   TODO private MotionWidget mTriggerCollisionView = null;
+    float mTriggerSlack = .1f;
+    private boolean mFireCrossReset = true;
+    private boolean mFireNegativeReset = true;
+    private boolean mFirePositiveReset = true;
+    private float mFireThreshold = Float.NaN;
+    private float mFireLastPos;
+    private boolean mPostLayout = false;
+    int mViewTransitionOnNegativeCross = UNSET;
+    int mViewTransitionOnPositiveCross = UNSET;
+    int mViewTransitionOnCross = UNSET;
+
+    public static final int TYPE_VIEW_TRANSITION_ON_CROSS = 301;
+    public static final int TYPE_VIEW_TRANSITION_ON_POSITIVE_CROSS = 302;
+    public static final int TYPE_VIEW_TRANSITION_ON_NEGATIVE_CROSS = 303;
+    public static final int TYPE_POST_LAYOUT = 304;
+    public static final int TYPE_TRIGGER_SLACK = 305;
+    public static final int TYPE_TRIGGER_COLLISION_VIEW = 306;
+    public static final int TYPE_TRIGGER_COLLISION_ID = 307;
+    public static final int TYPE_TRIGGER_ID = 308;
+    public static final int TYPE_POSITIVE_CROSS = 309;
+    public static final int TYPE_NEGATIVE_CROSS = 310;
+    public static final int TYPE_TRIGGER_RECEIVER = 311;
+    public static final int TYPE_CROSS = 312;
+
+    FloatRect mCollisionRect = new FloatRect();
+    FloatRect mTargetRect = new FloatRect();
+    public static final int KEY_TYPE = 5;
+
+    {
+        mType = KEY_TYPE;
+        mCustom = new HashMap<>();
+    }
+
+    @Override
+    public void getAttributeNames(HashSet<String> attributes) {
+
+    }
+
+    @Override
+    public void addValues(HashMap<String, SplineSet> splines) {
+
+    }
+
+    @Override
+    public int getId(String name) {
+        switch (name) {
+            case VIEW_TRANSITION_ON_CROSS:
+                return TYPE_VIEW_TRANSITION_ON_CROSS;
+            case VIEW_TRANSITION_ON_POSITIVE_CROSS:
+                return TYPE_VIEW_TRANSITION_ON_POSITIVE_CROSS;
+            case VIEW_TRANSITION_ON_NEGATIVE_CROSS:
+                return TYPE_VIEW_TRANSITION_ON_NEGATIVE_CROSS;
+            case POST_LAYOUT:
+                return TYPE_POST_LAYOUT;
+            case TRIGGER_SLACK:
+                return TYPE_TRIGGER_SLACK;
+            case TRIGGER_COLLISION_VIEW:
+                return TYPE_TRIGGER_COLLISION_VIEW;
+            case TRIGGER_COLLISION_ID:
+                return TYPE_TRIGGER_COLLISION_ID;
+            case TRIGGER_ID:
+                return TYPE_TRIGGER_ID;
+            case POSITIVE_CROSS:
+                return TYPE_POSITIVE_CROSS;
+            case NEGATIVE_CROSS:
+                return TYPE_NEGATIVE_CROSS;
+            case TRIGGER_RECEIVER:
+                return TYPE_TRIGGER_RECEIVER;
+        }
+        return -1;
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKeyTrigger copy(MotionKey src) {
+        super.copy(src);
+        MotionKeyTrigger k = (MotionKeyTrigger) src;
+        mCurveFit = k.mCurveFit;
+        mCross = k.mCross;
+        mTriggerReceiver = k.mTriggerReceiver;
+        mNegativeCross = k.mNegativeCross;
+        mPositiveCross = k.mPositiveCross;
+        mTriggerID = k.mTriggerID;
+        mTriggerCollisionId = k.mTriggerCollisionId;
+        // TODO mTriggerCollisionView = k.mTriggerCollisionView;
+        mTriggerSlack = k.mTriggerSlack;
+        mFireCrossReset = k.mFireCrossReset;
+        mFireNegativeReset = k.mFireNegativeReset;
+        mFirePositiveReset = k.mFirePositiveReset;
+        mFireThreshold = k.mFireThreshold;
+        mFireLastPos = k.mFireLastPos;
+        mPostLayout = k.mPostLayout;
+        mCollisionRect = k.mCollisionRect;
+        mTargetRect = k.mTargetRect;
+        return this;
+    }
+
+    // @TODO: add description
+    @Override
+    public MotionKey clone() {
+        return new MotionKeyTrigger().copy(this);
+    }
+
+    @SuppressWarnings("unused")
+    private void fireCustom(String str, MotionWidget widget) {
+        boolean callAll = str.length() == 1;
+        if (!callAll) {
+            str = str.substring(1).toLowerCase(Locale.ROOT);
+        }
+        for (String name : mCustom.keySet()) {
+            String lowerCase = name.toLowerCase(Locale.ROOT);
+            if (callAll || lowerCase.matches(str)) {
+                CustomVariable custom = mCustom.get(name);
+                if (custom != null) {
+                    custom.applyToWidget(widget);
+                }
+            }
+        }
+    }
+
+    // @TODO: add description
+    public void conditionallyFire(float position, MotionWidget child) {
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, int value) {
+        switch (type) {
+            case TriggerType.TYPE_TRIGGER_RECEIVER:
+                mTriggerReceiver = value;
+                break;
+            case TriggerType.TYPE_TRIGGER_ID:
+                mTriggerID = toInt(value);
+                break;
+            case TriggerType.TYPE_TRIGGER_COLLISION_ID:
+                mTriggerCollisionId = value;
+                break;
+            case TriggerType.TYPE_VIEW_TRANSITION_ON_NEGATIVE_CROSS:
+                mViewTransitionOnNegativeCross = value;
+                break;
+            case TriggerType.TYPE_VIEW_TRANSITION_ON_POSITIVE_CROSS:
+                mViewTransitionOnPositiveCross = value;
+                break;
+
+            case TriggerType.TYPE_VIEW_TRANSITION_ON_CROSS:
+                mViewTransitionOnCross = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, float value) {
+        switch (type) {
+            case TriggerType.TYPE_TRIGGER_SLACK:
+                mTriggerSlack = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, String value) {
+        switch (type) {
+            case TriggerType.TYPE_CROSS:
+                mCross = value;
+                break;
+            case TriggerType.TYPE_NEGATIVE_CROSS:
+                mNegativeCross = value;
+                break;
+            case TriggerType.TYPE_POSITIVE_CROSS:
+                mPositiveCross = value;
+                break;
+//                TODO
+//            case TRIGGER_COLLISION_VIEW:
+//                mTriggerCollisionView = (MotionWidget) value;
+//                break;
+
+            default:
+
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public boolean setValue(int type, boolean value) {
+        switch (type) {
+            case TriggerType.TYPE_POST_LAYOUT:
+                mPostLayout = value;
+                break;
+            default:
+                return super.setValue(type, value);
+        }
+        return true;
+    }
+
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/parse/KeyParser.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/parse/KeyParser.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.parse;
+
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.parser.CLElement;
+import androidx.constraintlayout.core.parser.CLKey;
+import androidx.constraintlayout.core.parser.CLObject;
+import androidx.constraintlayout.core.parser.CLParser;
+import androidx.constraintlayout.core.parser.CLParsingException;
+
+import java.util.Arrays;
+
+public class KeyParser {
+
+    private interface Ids {
+        int get(String str);
+    }
+
+    private interface DataType {
+        int get(int str);
+    }
+
+    private static TypedBundle parse(String str, Ids table, DataType dtype) {
+        TypedBundle bundle = new TypedBundle();
+
+        try {
+            CLObject parsedContent = CLParser.parse(str);
+            int n = parsedContent.size();
+            for (int i = 0; i < n; i++) {
+                CLKey clkey = ((CLKey) parsedContent.get(i));
+                String type = clkey.content();
+                CLElement value = clkey.getValue();
+                int id = table.get(type);
+                if (id == -1) {
+                    System.err.println("unknown type " + type);
+                    continue;
+                }
+                switch (dtype.get(id)) {
+                    case TypedValues.FLOAT_MASK:
+                        bundle.add(id, value.getFloat());
+                        System.out.println("parse " + type + " FLOAT_MASK > " + value.getFloat());
+                        break;
+                    case TypedValues.STRING_MASK:
+                        bundle.add(id, value.content());
+                        System.out.println("parse " + type + " STRING_MASK > " + value.content());
+
+                        break;
+                    case TypedValues.INT_MASK:
+                        bundle.add(id, value.getInt());
+                        System.out.println("parse " + type + " INT_MASK > " + value.getInt());
+                        break;
+                    case TypedValues.BOOLEAN_MASK:
+                        bundle.add(id, parsedContent.getBoolean(i));
+                        break;
+                }
+            }
+        } catch (CLParsingException e) {
+            //TODO replace with something not equal to printStackTrace();
+            System.err.println(e.toString()+"\n"+ Arrays.toString(e.getStackTrace())
+                    .replace("[","   at ")
+                    .replace(",","\n   at")
+                    .replace("]",""));
+        }
+        return bundle;
+    }
+
+    // @TODO: add description
+    public static TypedBundle parseAttributes(String str) {
+        return parse(str, TypedValues.AttributesType::getId, TypedValues.AttributesType::getType);
+    }
+
+    // @TODO: add description
+    public static void main(String[] args) {
+        String str = "{"
+                + "frame:22,\n"
+                + "target:'widget1',\n"
+                + "easing:'easeIn',\n"
+                + "curveFit:'spline',\n"
+                + "progress:0.3,\n"
+                + "alpha:0.2,\n"
+                + "elevation:0.7,\n"
+                + "rotationZ:23,\n"
+                + "rotationX:25.0,\n"
+                + "rotationY:27.0,\n"
+                + "pivotX:15,\n"
+                + "pivotY:17,\n"
+                + "pivotTarget:'32',\n"
+                + "pathRotate:23,\n"
+                + "scaleX:0.5,\n"
+                + "scaleY:0.7,\n"
+                + "translationX:5,\n"
+                + "translationY:7,\n"
+                + "translationZ:11,\n"
+                + "}";
+        parseAttributes(str);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/ArcCurveFit.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/ArcCurveFit.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+
+/**
+ * This provides provides a curve fit system that stitches the x,y path together with
+ * quarter ellipses
+ */
+
+public class ArcCurveFit extends CurveFit {
+    public static final int ARC_START_VERTICAL = 1;
+    public static final int ARC_START_HORIZONTAL = 2;
+    public static final int ARC_START_FLIP = 3;
+    public static final int ARC_BELOW = 4;
+    public static final int ARC_ABOVE = 5;
+
+    public static final int ARC_START_LINEAR = 0;
+
+    private static final int START_VERTICAL = 1;
+    private static final int START_HORIZONTAL = 2;
+    private static final int START_LINEAR = 3;
+    private static final int DOWN_ARC = 4;
+    private static final int UP_ARC = 5;
+
+    private final double[] mTime;
+    Arc[] mArcs;
+    private boolean mExtrapolate = true;
+
+    @Override
+    public void getPos(double t, double[] v) {
+        if (mExtrapolate) {
+            if (t < mArcs[0].mTime1) {
+                double t0 = mArcs[0].mTime1;
+                double dt = t - mArcs[0].mTime1;
+                int p = 0;
+                if (mArcs[p].mLinear) {
+                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0));
+                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0));
+                } else {
+                    mArcs[p].setPoint(t0);
+                    v[0] = mArcs[p].getX() + dt * mArcs[p].getDX();
+                    v[1] = mArcs[p].getY() + dt * mArcs[p].getDY();
+                }
+                return;
+            }
+            if (t > mArcs[mArcs.length - 1].mTime2) {
+                double t0 = mArcs[mArcs.length - 1].mTime2;
+                double dt = t - t0;
+                int p = mArcs.length - 1;
+                if (mArcs[p].mLinear) {
+                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0));
+                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0));
+                } else {
+                    mArcs[p].setPoint(t);
+                    v[0] = mArcs[p].getX() + dt * mArcs[p].getDX();
+                    v[1] = mArcs[p].getY() + dt * mArcs[p].getDY();
+                }
+                return;
+            }
+        } else {
+            if (t < mArcs[0].mTime1) {
+                t = mArcs[0].mTime1;
+            }
+            if (t > mArcs[mArcs.length - 1].mTime2) {
+                t = mArcs[mArcs.length - 1].mTime2;
+            }
+        }
+
+        for (int i = 0; i < mArcs.length; i++) {
+            if (t <= mArcs[i].mTime2) {
+                if (mArcs[i].mLinear) {
+                    v[0] = mArcs[i].getLinearX(t);
+                    v[1] = mArcs[i].getLinearY(t);
+                    return;
+                }
+                mArcs[i].setPoint(t);
+                v[0] = mArcs[i].getX();
+                v[1] = mArcs[i].getY();
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void getPos(double t, float[] v) {
+        if (mExtrapolate) {
+            if (t < mArcs[0].mTime1) {
+                double t0 = mArcs[0].mTime1;
+                double dt = t - mArcs[0].mTime1;
+                int p = 0;
+                if (mArcs[p].mLinear) {
+                    v[0] = (float) (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0));
+                    v[1] = (float) (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0));
+                } else {
+                    mArcs[p].setPoint(t0);
+                    v[0] = (float) (mArcs[p].getX() + dt * mArcs[p].getDX());
+                    v[1] = (float) (mArcs[p].getY() + dt * mArcs[p].getDY());
+                }
+                return;
+            }
+            if (t > mArcs[mArcs.length - 1].mTime2) {
+                double t0 = mArcs[mArcs.length - 1].mTime2;
+                double dt = t - t0;
+                int p = mArcs.length - 1;
+                if (mArcs[p].mLinear) {
+                    v[0] = (float) (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0));
+                    v[1] = (float) (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0));
+                } else {
+                    mArcs[p].setPoint(t);
+                    v[0] = (float) mArcs[p].getX();
+                    v[1] = (float) mArcs[p].getY();
+                }
+                return;
+            }
+        } else {
+            if (t < mArcs[0].mTime1) {
+                t = mArcs[0].mTime1;
+            } else if (t > mArcs[mArcs.length - 1].mTime2) {
+                t = mArcs[mArcs.length - 1].mTime2;
+            }
+        }
+        for (int i = 0; i < mArcs.length; i++) {
+            if (t <= mArcs[i].mTime2) {
+                if (mArcs[i].mLinear) {
+                    v[0] = (float) mArcs[i].getLinearX(t);
+                    v[1] = (float) mArcs[i].getLinearY(t);
+                    return;
+                }
+                mArcs[i].setPoint(t);
+                v[0] = (float) mArcs[i].getX();
+                v[1] = (float) mArcs[i].getY();
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void getSlope(double t, double[] v) {
+        if (t < mArcs[0].mTime1) {
+            t = mArcs[0].mTime1;
+        } else if (t > mArcs[mArcs.length - 1].mTime2) {
+            t = mArcs[mArcs.length - 1].mTime2;
+        }
+
+        for (int i = 0; i < mArcs.length; i++) {
+            if (t <= mArcs[i].mTime2) {
+                if (mArcs[i].mLinear) {
+                    v[0] = mArcs[i].getLinearDX(t);
+                    v[1] = mArcs[i].getLinearDY(t);
+                    return;
+                }
+                mArcs[i].setPoint(t);
+                v[0] = mArcs[i].getDX();
+                v[1] = mArcs[i].getDY();
+                return;
+            }
+        }
+    }
+
+    @Override
+    public double getPos(double t, int j) {
+        if (mExtrapolate) {
+            if (t < mArcs[0].mTime1) {
+                double t0 = mArcs[0].mTime1;
+                double dt = t - mArcs[0].mTime1;
+                int p = 0;
+                if (mArcs[p].mLinear) {
+                    if (j == 0) {
+                        return mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0);
+                    }
+                    return mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0);
+                } else {
+                    mArcs[p].setPoint(t0);
+                    if (j == 0) {
+                        return mArcs[p].getX() + dt * mArcs[p].getDX();
+                    }
+                    return mArcs[p].getY() + dt * mArcs[p].getDY();
+                }
+            }
+            if (t > mArcs[mArcs.length - 1].mTime2) {
+                double t0 = mArcs[mArcs.length - 1].mTime2;
+                double dt = t - t0;
+                int p = mArcs.length - 1;
+                if (j == 0) {
+                    return mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0);
+                }
+                return mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0);
+            }
+        } else {
+            if (t < mArcs[0].mTime1) {
+                t = mArcs[0].mTime1;
+            } else if (t > mArcs[mArcs.length - 1].mTime2) {
+                t = mArcs[mArcs.length - 1].mTime2;
+            }
+        }
+
+        for (int i = 0; i < mArcs.length; i++) {
+            if (t <= mArcs[i].mTime2) {
+
+                if (mArcs[i].mLinear) {
+                    if (j == 0) {
+                        return mArcs[i].getLinearX(t);
+                    }
+                    return mArcs[i].getLinearY(t);
+                }
+                mArcs[i].setPoint(t);
+
+                if (j == 0) {
+                    return mArcs[i].getX();
+                }
+                return mArcs[i].getY();
+            }
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public double getSlope(double t, int j) {
+        if (t < mArcs[0].mTime1) {
+            t = mArcs[0].mTime1;
+        }
+        if (t > mArcs[mArcs.length - 1].mTime2) {
+            t = mArcs[mArcs.length - 1].mTime2;
+        }
+
+        for (int i = 0; i < mArcs.length; i++) {
+            if (t <= mArcs[i].mTime2) {
+                if (mArcs[i].mLinear) {
+                    if (j == 0) {
+                        return mArcs[i].getLinearDX(t);
+                    }
+                    return mArcs[i].getLinearDY(t);
+                }
+                mArcs[i].setPoint(t);
+                if (j == 0) {
+                    return mArcs[i].getDX();
+                }
+                return mArcs[i].getDY();
+            }
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public double[] getTimePoints() {
+        return mTime;
+    }
+
+    public ArcCurveFit(int[] arcModes, double[] time, double[][] y) {
+        mTime = time;
+        mArcs = new Arc[time.length - 1];
+        int mode = START_VERTICAL;
+        int last = START_VERTICAL;
+        for (int i = 0; i < mArcs.length; i++) {
+            switch (arcModes[i]) {
+                case ARC_START_VERTICAL:
+                    last = mode = START_VERTICAL;
+                    break;
+                case ARC_START_HORIZONTAL:
+                    last = mode = START_HORIZONTAL;
+                    break;
+                case ARC_START_FLIP:
+                    mode = (last == START_VERTICAL) ? START_HORIZONTAL : START_VERTICAL;
+                    last = mode;
+                    break;
+                case ARC_START_LINEAR:
+                    mode = START_LINEAR;
+                    break;
+                case ARC_ABOVE:
+                    mode = UP_ARC;
+                    break;
+                case ARC_BELOW:
+                    mode = DOWN_ARC;
+                    break;
+            }
+            mArcs[i] =
+                    new Arc(mode, time[i], time[i + 1], y[i][0], y[i][1], y[i + 1][0], y[i + 1][1]);
+        }
+    }
+
+    private static class Arc {
+        private static final String TAG = "Arc";
+        private static double[] sOurPercent = new double[91];
+        double[] mLut;
+        double mArcDistance;
+        double mTime1;
+        double mTime2;
+        double mX1, mX2, mY1, mY2;
+        double mOneOverDeltaTime;
+        double mEllipseA;
+        double mEllipseB;
+        double mEllipseCenterX; // also used to cache the slope in the unused center
+        double mEllipseCenterY; // also used to cache the slope in the unused center
+        double mArcVelocity;
+        double mTmpSinAngle;
+        double mTmpCosAngle;
+        boolean mVertical;
+        boolean mLinear = false;
+        private static final double EPSILON = 0.001;
+
+        Arc(int mode, double t1, double t2, double x1, double y1, double x2, double y2) {
+            double dx = x2 - x1;
+            double dy = y2 - y1;
+            switch (mode) {
+                case START_VERTICAL:
+                    mVertical = true;
+                    break;
+                case UP_ARC:
+                    mVertical = dy < 0;
+                    break;
+                case DOWN_ARC:
+                    mVertical = dy > 0;
+                    break;
+                default:
+                    mVertical = false;
+            }
+
+            mTime1 = t1;
+            mTime2 = t2;
+            mOneOverDeltaTime = 1 / (mTime2 - mTime1);
+            if (START_LINEAR == mode) {
+                mLinear = true;
+            }
+
+            if (mLinear || Math.abs(dx) < EPSILON || Math.abs(dy) < EPSILON) {
+                mLinear = true;
+                mX1 = x1;
+                mX2 = x2;
+                mY1 = y1;
+                mY2 = y2;
+                mArcDistance = Math.hypot(dy, dx);
+                mArcVelocity = mArcDistance * mOneOverDeltaTime;
+                mEllipseCenterX = dx / (mTime2 - mTime1); // cache the slope in the unused center
+                mEllipseCenterY = dy / (mTime2 - mTime1); // cache the slope in the unused center
+                return;
+            }
+            mLut = new double[101];
+            mEllipseA = dx * (mVertical ? -1 : 1);
+            mEllipseB = dy * (mVertical ? 1 : -1);
+            mEllipseCenterX = mVertical ? x2 : x1;
+            mEllipseCenterY = mVertical ? y1 : y2;
+            buildTable(x1, y1, x2, y2);
+            mArcVelocity = mArcDistance * mOneOverDeltaTime;
+        }
+
+        void setPoint(double time) {
+            double percent = (mVertical ? (mTime2 - time) : (time - mTime1)) * mOneOverDeltaTime;
+            double angle = Math.PI * 0.5 * lookup(percent);
+
+            mTmpSinAngle = Math.sin(angle);
+            mTmpCosAngle = Math.cos(angle);
+        }
+
+        double getX() {
+            return mEllipseCenterX + mEllipseA * mTmpSinAngle;
+        }
+
+        double getY() {
+            return mEllipseCenterY + mEllipseB * mTmpCosAngle;
+        }
+
+        double getDX() {
+            double vx = mEllipseA * mTmpCosAngle;
+            double vy = -mEllipseB * mTmpSinAngle;
+            double norm = mArcVelocity / Math.hypot(vx, vy);
+            return mVertical ? -vx * norm : vx * norm;
+        }
+
+        double getDY() {
+            double vx = mEllipseA * mTmpCosAngle;
+            double vy = -mEllipseB * mTmpSinAngle;
+            double norm = mArcVelocity / Math.hypot(vx, vy);
+            return mVertical ? -vy * norm : vy * norm;
+        }
+
+        public double getLinearX(double t) {
+            t = (t - mTime1) * mOneOverDeltaTime;
+            return mX1 + t * (mX2 - mX1);
+        }
+
+        public double getLinearY(double t) {
+            t = (t - mTime1) * mOneOverDeltaTime;
+            return mY1 + t * (mY2 - mY1);
+        }
+
+        @SuppressWarnings("UnusedVariable")
+        public double getLinearDX(double t) {
+            return mEllipseCenterX;
+        }
+
+        @SuppressWarnings("UnusedVariable")
+        public double getLinearDY(double t) {
+            return mEllipseCenterY;
+        }
+
+        double lookup(double v) {
+            if (v <= 0) {
+                return 0;
+            }
+            if (v >= 1) {
+                return 1;
+            }
+            double pos = v * (mLut.length - 1);
+            int iv = (int) pos;
+            double off = pos - (int) pos;
+
+            return mLut[iv] + (off * (mLut[iv + 1] - mLut[iv]));
+        }
+
+        private void buildTable(double x1, double y1, double x2, double y2) {
+            double a = x2 - x1;
+            double b = y1 - y2;
+            double lx = 0, ly = 0;
+            double dist = 0;
+            for (int i = 0; i < sOurPercent.length; i++) {
+                double angle = Math.toRadians(90.0 * i / (sOurPercent.length - 1));
+                double s = Math.sin(angle);
+                double c = Math.cos(angle);
+                double px = a * s;
+                double py = b * c;
+                if (i > 0) {
+                    dist += Math.hypot(px - lx, py - ly);
+                    sOurPercent[i] = dist;
+                }
+                lx = px;
+                ly = py;
+            }
+
+            mArcDistance = dist;
+
+            for (int i = 0; i < sOurPercent.length; i++) {
+                sOurPercent[i] /= dist;
+            }
+            for (int i = 0; i < mLut.length; i++) {
+                double pos = i / (double) (mLut.length - 1);
+                int index = Arrays.binarySearch(sOurPercent, pos);
+                if (index >= 0) {
+                    mLut[i] = index / (double) (sOurPercent.length - 1);
+                } else if (index == -1) {
+                    mLut[i] = 0;
+                } else {
+                    int p1 = -index - 2;
+                    int p2 = -index - 1;
+
+                    double ans = (p1 + (pos - sOurPercent[p1])
+                            / (sOurPercent[p2] - sOurPercent[p1])) / (sOurPercent.length - 1);
+                    mLut[i] = ans;
+                }
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/CurveFit.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/CurveFit.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * Base class for curve fitting / interpolation
+ * Curve fits must be capable of being differentiable and extend beyond the points (extrapolate)
+ *
+ *
+ */
+
+public abstract class CurveFit {
+    public static final int SPLINE = 0;
+    public static final int LINEAR = 1;
+    public static final int CONSTANT = 2;
+
+    // @TODO: add description
+    public static CurveFit get(int type, double[] time, double[][] y) {
+        if (time.length == 1) {
+            type = CONSTANT;
+        }
+        switch (type) {
+            case SPLINE:
+                return new MonotonicCurveFit(time, y);
+            case CONSTANT:
+                return new Constant(time[0], y[0]);
+            default:
+                return new LinearCurveFit(time, y);
+        }
+    }
+
+    // @TODO: add description
+    public static CurveFit getArc(int[] arcModes, double[] time, double[][] y) {
+        return new ArcCurveFit(arcModes, time, y);
+    }
+
+    // @TODO: add description
+    public abstract void getPos(double t, double[] v);
+
+    // @TODO: add description
+    public abstract void getPos(double t, float[] v);
+
+    // @TODO: add description
+    public abstract double getPos(double t, int j);
+
+    // @TODO: add description
+    public abstract void getSlope(double t, double[] v);
+
+    // @TODO: add description
+    public abstract double getSlope(double t, int j);
+
+    // @TODO: add description
+    public abstract double[] getTimePoints();
+
+    static class Constant extends CurveFit {
+        double mTime;
+        double[] mValue;
+
+        Constant(double time, double[] value) {
+            mTime = time;
+            mValue = value;
+        }
+
+        @Override
+        public void getPos(double t, double[] v) {
+            System.arraycopy(mValue, 0, v, 0, mValue.length);
+        }
+
+        @Override
+        public void getPos(double t, float[] v) {
+            for (int i = 0; i < mValue.length; i++) {
+                v[i] = (float) mValue[i];
+            }
+        }
+
+        @Override
+        public double getPos(double t, int j) {
+            return mValue[j];
+        }
+
+        @Override
+        public void getSlope(double t, double[] v) {
+            for (int i = 0; i < mValue.length; i++) {
+                v[i] = 0;
+            }
+        }
+
+        @Override
+        public double getSlope(double t, int j) {
+            return 0;
+        }
+
+        @Override
+        public double[] getTimePoints() {
+            return new double[]{mTime};
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/DifferentialInterpolator.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/DifferentialInterpolator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+public interface DifferentialInterpolator {
+    // @TODO: add description
+    float getInterpolation(float v);
+
+    // @TODO: add description
+    float getVelocity();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Easing.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Easing.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+
+/**
+ * Provide the engine for cubic spline easing
+ *
+ *
+ */
+public class Easing {
+    static Easing sDefault = new Easing();
+    String mStr = "identity";
+    private static final String STANDARD = "cubic(0.4, 0.0, 0.2, 1)";
+    private static final String ACCELERATE = "cubic(0.4, 0.05, 0.8, 0.7)";
+    private static final String DECELERATE = "cubic(0.0, 0.0, 0.2, 0.95)";
+    private static final String LINEAR = "cubic(1, 1, 0, 0)";
+    private static final String ANTICIPATE = "cubic(0.36, 0, 0.66, -0.56)";
+    private static final String OVERSHOOT = "cubic(0.34, 1.56, 0.64, 1)";
+
+    private static final String DECELERATE_NAME = "decelerate";
+    private static final String ACCELERATE_NAME = "accelerate";
+    private static final String STANDARD_NAME = "standard";
+    private static final String LINEAR_NAME = "linear";
+    private static final String ANTICIPATE_NAME = "anticipate";
+    private static final String OVERSHOOT_NAME = "overshoot";
+
+    public static String[] NAMED_EASING =
+            {STANDARD_NAME, ACCELERATE_NAME, DECELERATE_NAME, LINEAR_NAME};
+
+    // @TODO: add description
+    public static Easing getInterpolator(String configString) {
+        if (configString == null) {
+            return null;
+        }
+        if (configString.startsWith("cubic")) {
+            return new CubicEasing(configString);
+        } else if (configString.startsWith("spline")) {
+            return new StepCurve(configString);
+        } else if (configString.startsWith("Schlick")) {
+            return new Schlick(configString);
+        } else {
+            switch (configString) {
+                case STANDARD_NAME:
+                    return new CubicEasing(STANDARD);
+                case ACCELERATE_NAME:
+                    return new CubicEasing(ACCELERATE);
+                case DECELERATE_NAME:
+                    return new CubicEasing(DECELERATE);
+                case LINEAR_NAME:
+                    return new CubicEasing(LINEAR);
+                case ANTICIPATE_NAME:
+                    return new CubicEasing(ANTICIPATE);
+                case OVERSHOOT_NAME:
+                    return new CubicEasing(OVERSHOOT);
+                default:
+                    System.err.println("transitionEasing syntax error syntax:"
+                            + "transitionEasing=\"cubic(1.0,0.5,0.0,0.6)\" or "
+                            + Arrays.toString(NAMED_EASING));
+            }
+
+        }
+        return sDefault;
+    }
+
+    // @TODO: add description
+    public double get(double x) {
+        return x;
+    }
+
+    // @TODO: add description
+    @Override
+    public String toString() {
+        return mStr;
+    }
+
+    // @TODO: add description
+    public double getDiff(double x) {
+        return 1;
+    }
+
+    static class CubicEasing extends Easing {
+
+        private static double sError = 0.01;
+        private static double sDError = 0.0001;
+        double mX1, mY1, mX2, mY2;
+
+        CubicEasing(String configString) {
+            // done this way for efficiency
+            mStr = configString;
+            int start = configString.indexOf('(');
+            int off1 = configString.indexOf(',', start);
+            mX1 = Double.parseDouble(configString.substring(start + 1, off1).trim());
+            int off2 = configString.indexOf(',', off1 + 1);
+            mY1 = Double.parseDouble(configString.substring(off1 + 1, off2).trim());
+            int off3 = configString.indexOf(',', off2 + 1);
+            mX2 = Double.parseDouble(configString.substring(off2 + 1, off3).trim());
+            int end = configString.indexOf(')', off3 + 1);
+            mY2 = Double.parseDouble(configString.substring(off3 + 1, end).trim());
+        }
+
+        CubicEasing(double x1, double y1, double x2, double y2) {
+            setup(x1, y1, x2, y2);
+        }
+
+        void setup(double x1, double y1, double x2, double y2) {
+            this.mX1 = x1;
+            this.mY1 = y1;
+            this.mX2 = x2;
+            this.mY2 = y2;
+        }
+
+        private double getX(double t) {
+            double t1 = 1 - t;
+            // no need for because start at 0,0 double f0 = (1 - t) * (1 - t) * (1 - t);
+            double f1 = 3 * t1 * t1 * t;
+            double f2 = 3 * t1 * t * t;
+            double f3 = t * t * t;
+            return mX1 * f1 + mX2 * f2 + f3;
+        }
+
+        private double getY(double t) {
+            double t1 = 1 - t;
+            // no need for because start at 0,0 double f0 = (1 - t) * (1 - t) * (1 - t);
+            double f1 = 3 * t1 * t1 * t;
+            double f2 = 3 * t1 * t * t;
+            double f3 = t * t * t;
+            return mY1 * f1 + mY2 * f2 + f3;
+        }
+
+        @SuppressWarnings("unused")
+        private double getDiffX(double t) {
+            double t1 = 1 - t;
+            return 3 * t1 * t1 * mX1 + 6 * t1 * t * (mX2 - mX1) + 3 * t * t * (1 - mX2);
+        }
+
+        @SuppressWarnings("unused")
+        private double getDiffY(double t) {
+            double t1 = 1 - t;
+            return 3 * t1 * t1 * mY1 + 6 * t1 * t * (mY2 - mY1) + 3 * t * t * (1 - mY2);
+        }
+
+        /**
+         * binary search for the region
+         * and linear interpolate the answer
+         */
+        @Override
+        public double getDiff(double x) {
+            double t = 0.5;
+            double range = 0.5;
+            while (range > sDError) {
+                double tx = getX(t);
+                range *= 0.5;
+                if (tx < x) {
+                    t += range;
+                } else {
+                    t -= range;
+                }
+            }
+
+            double x1 = getX(t - range);
+            double x2 = getX(t + range);
+            double y1 = getY(t - range);
+            double y2 = getY(t + range);
+
+            return (y2 - y1) / (x2 - x1);
+        }
+
+        /**
+         * binary search for the region
+         * and linear interpolate the answer
+         */
+        @Override
+        public double get(double x) {
+            if (x <= 0.0) {
+                return 0;
+            }
+            if (x >= 1.0) {
+                return 1.0;
+            }
+            double t = 0.5;
+            double range = 0.5;
+            while (range > sError) {
+                double tx = getX(t);
+                range *= 0.5;
+                if (tx < x) {
+                    t += range;
+                } else {
+                    t -= range;
+                }
+            }
+
+            double x1 = getX(t - range);
+            double x2 = getX(t + range);
+            double y1 = getY(t - range);
+            double y2 = getY(t + range);
+
+            return (y2 - y1) * (x - x1) / (x2 - x1) + y1;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/FloatRect.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/FloatRect.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+public class FloatRect {
+    public float bottom;
+    public float left;
+    public float right;
+    public float top;
+
+    // @TODO: add description
+    public final float centerX() {
+        return (left + right) * 0.5f;
+    }
+
+    // @TODO: add description
+    public final float centerY() {
+        return (top + bottom) * 0.5f;
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/HyperSpline.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/HyperSpline.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * Provides spline interpolation code.
+ * Currently not used but it is anticipated that we will be using it in the
+ * KeyMotion
+ *
+ *
+ */
+
+public class HyperSpline {
+    int mPoints;
+    Cubic[][] mCurve;
+    int mDimensionality;
+    double[] mCurveLength;
+    double mTotalLength;
+    double[][] mCtl;
+
+    /**
+     * Spline in N dimensions
+     *
+     * @param points [mPoints][dimensionality]
+     */
+    public HyperSpline(double[][] points) {
+        setup(points);
+    }
+
+    public HyperSpline() {
+    }
+
+    // @TODO: add description
+    public void setup(double[][] points) {
+        mDimensionality = points[0].length;
+        mPoints = points.length;
+        mCtl = new double[mDimensionality][mPoints];
+        mCurve = new Cubic[mDimensionality][];
+        for (int d = 0; d < mDimensionality; d++) {
+            for (int p = 0; p < mPoints; p++) {
+                mCtl[d][p] = points[p][d];
+            }
+        }
+
+        for (int d = 0; d < mDimensionality; d++) {
+            mCurve[d] = calcNaturalCubic(mCtl[d].length, mCtl[d]);
+        }
+
+        mCurveLength = new double[mPoints - 1];
+        mTotalLength = 0;
+        Cubic[] temp = new Cubic[mDimensionality];
+        for (int p = 0; p < mCurveLength.length; p++) {
+            for (int d = 0; d < mDimensionality; d++) {
+
+                temp[d] = mCurve[d][p];
+
+            }
+            mTotalLength += mCurveLength[p] = approxLength(temp);
+        }
+    }
+
+    // @TODO: add description
+    public void getVelocity(double p, double[] v) {
+        double pos = p * mTotalLength;
+        int k = 0;
+        for (; k < mCurveLength.length - 1 && mCurveLength[k] < pos; k++) {
+            pos -= mCurveLength[k];
+        }
+        for (int i = 0; i < v.length; i++) {
+            v[i] = mCurve[i][k].vel(pos / mCurveLength[k]);
+        }
+    }
+
+    // @TODO: add description
+    public void getPos(double p, double[] x) {
+        double pos = p * mTotalLength;
+        int k = 0;
+        for (; k < mCurveLength.length - 1 && mCurveLength[k] < pos; k++) {
+            pos -= mCurveLength[k];
+        }
+        for (int i = 0; i < x.length; i++) {
+            x[i] = mCurve[i][k].eval(pos / mCurveLength[k]);
+        }
+    }
+
+    // @TODO: add description
+    public void getPos(double p, float[] x) {
+        double pos = p * mTotalLength;
+        int k = 0;
+        for (; k < mCurveLength.length - 1 && mCurveLength[k] < pos; k++) {
+            pos -= mCurveLength[k];
+        }
+        for (int i = 0; i < x.length; i++) {
+            x[i] = (float) mCurve[i][k].eval(pos / mCurveLength[k]);
+        }
+    }
+
+    // @TODO: add description
+    public double getPos(double p, int splineNumber) {
+        double pos = p * mTotalLength;
+        int k = 0;
+        for (; k < mCurveLength.length - 1 && mCurveLength[k] < pos; k++) {
+            pos -= mCurveLength[k];
+        }
+        return mCurve[splineNumber][k].eval(pos / mCurveLength[k]);
+    }
+
+    // @TODO: add description
+    public double approxLength(Cubic[] curve) {
+        double sum = 0;
+
+        int n = curve.length;
+        double[] old = new double[n];
+        for (double i = 0; i < 1; i += .1) {
+            double s = 0;
+            for (int j = 0; j < n; j++) {
+                double tmp = old[j];
+                tmp -= old[j] = curve[j].eval(i);
+                s += tmp * tmp;
+            }
+            if (i > 0) {
+                sum += Math.sqrt(s);
+            }
+
+        }
+        double s = 0;
+        for (int j = 0; j < n; j++) {
+            double tmp = old[j];
+            tmp -= old[j] = curve[j].eval(1);
+            s += tmp * tmp;
+        }
+        sum += Math.sqrt(s);
+        return sum;
+    }
+
+    static Cubic[] calcNaturalCubic(int n, double[] x) {
+        double[] gamma = new double[n];
+        double[] delta = new double[n];
+        double[] d = new double[n];
+        n -= 1;
+
+        gamma[0] = 1.0f / 2.0f;
+        for (int i = 1; i < n; i++) {
+            gamma[i] = 1 / (4 - gamma[i - 1]);
+        }
+        gamma[n] = 1 / (2 - gamma[n - 1]);
+
+        delta[0] = 3 * (x[1] - x[0]) * gamma[0];
+        for (int i = 1; i < n; i++) {
+            delta[i] = (3 * (x[i + 1] - x[i - 1]) - delta[i - 1]) * gamma[i];
+        }
+        delta[n] = (3 * (x[n] - x[n - 1]) - delta[n - 1]) * gamma[n];
+
+        d[n] = delta[n];
+        for (int i = n - 1; i >= 0; i--) {
+            d[i] = delta[i] - gamma[i] * d[i + 1];
+        }
+
+        Cubic[] c = new Cubic[n];
+        for (int i = 0; i < n; i++) {
+            c[i] = new Cubic((float) x[i], d[i], 3 * (x[i + 1] - x[i]) - 2
+                    * d[i] - d[i + 1], 2 * (x[i] - x[i + 1]) + d[i] + d[i + 1]);
+        }
+        return c;
+    }
+
+    public static class Cubic {
+        double mA, mB, mC, mD;
+
+        public Cubic(double a, double b, double c, double d) {
+            mA = a;
+            mB = b;
+            mC = c;
+            mD = d;
+        }
+
+        // @TODO: add description
+        public double eval(double u) {
+            return (((mD * u) + mC) * u + mB) * u + mA;
+        }
+
+        // @TODO: add description
+        public double vel(double v) {
+            //  (((mD * u) + mC) * u + mB) * u + mA
+            //  =  "mA + u*mB + u*u*mC+u*u*u*mD" a cubic expression
+            // diff with respect to u = mB + u*mC/2+ u*u*mD/3
+            // made efficient (mD*u/3+mC/2)*u+mB;
+
+            return (mD * 3 * v + mC * 2) * v + mB;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyCache.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Used by KeyTimeCycles (and any future time dependent behaviour) to cache its current parameters
+ * to maintain consistency across requestLayout type rebuilds.
+ */
+public class KeyCache {
+
+    HashMap<Object, HashMap<String, float[]>> mMap = new HashMap<>();
+
+    // @TODO: add description
+    public void setFloatValue(Object view, String type, int element, float value) {
+        if (!mMap.containsKey(view)) {
+            HashMap<String, float[]> array = new HashMap<>();
+            float[] vArray = new float[element + 1];
+            vArray[element] = value;
+            array.put(type, vArray);
+            mMap.put(view, array);
+        } else {
+            HashMap<String, float[]> array = mMap.get(view);
+            if (array == null) {
+                array = new HashMap<>();
+            }
+
+            if (!array.containsKey(type)) {
+                float[] vArray = new float[element + 1];
+                vArray[element] = value;
+                array.put(type, vArray);
+                mMap.put(view, array);
+            } else {
+                float[] vArray = array.get(type);
+                if (vArray == null) {
+                    vArray = new float[0];
+                }
+                if (vArray.length <= element) {
+                    vArray = Arrays.copyOf(vArray, element + 1);
+                }
+                vArray[element] = value;
+                array.put(type, vArray);
+            }
+        }
+    }
+
+    // @TODO: add description
+    public float getFloatValue(Object view, String type, int element) {
+        if (!mMap.containsKey(view)) {
+            return Float.NaN;
+        } else {
+            HashMap<String, float[]> array = mMap.get(view);
+            if (array == null || !array.containsKey(type)) {
+                return Float.NaN;
+            }
+            float[] vArray = array.get(type);
+            if (vArray == null) {
+                return Float.NaN;
+            }
+            if (vArray.length > element) {
+                return vArray[element];
+            }
+            return Float.NaN;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyCycleOscillator.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyCycleOscillator.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import androidx.constraintlayout.core.motion.MotionWidget;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+/**
+ * Provide the engine for executing cycles.
+ * KeyCycleOscillator
+ *
+ *
+ */
+public abstract class KeyCycleOscillator {
+    private static final String TAG = "KeyCycleOscillator";
+    private CurveFit mCurveFit;
+    private CycleOscillator mCycleOscillator;
+    private String mType;
+    private int mWaveShape = 0;
+    private String mWaveString = null;
+
+    public int mVariesBy = 0; // 0 = position, 2=path
+    ArrayList<WavePoint> mWavePoints = new ArrayList<>();
+
+    // @TODO: add description
+    public static KeyCycleOscillator makeWidgetCycle(String attribute) {
+        if (attribute.equals(TypedValues.AttributesType.S_PATH_ROTATE)) {
+            return new PathRotateSet(attribute);
+        }
+        return new CoreSpline(attribute);
+    }
+
+    private static class CoreSpline extends KeyCycleOscillator {
+        String mType;
+        int mTypeId;
+
+        CoreSpline(String str) {
+            mType = str;
+            mTypeId = TypedValues.CycleType.getId(mType);
+        }
+
+        @Override
+        public void setProperty(MotionWidget widget, float t) {
+            widget.setValue(mTypeId, get(t));
+        }
+    }
+
+    public static class PathRotateSet extends KeyCycleOscillator {
+        String mType;
+        int mTypeId;
+
+        public PathRotateSet(String str) {
+            mType = str;
+            mTypeId = TypedValues.CycleType.getId(mType);
+        }
+
+        @Override
+        public void setProperty(MotionWidget widget, float t) {
+            widget.setValue(mTypeId, get(t));
+        }
+
+        // @TODO: add description
+        public void setPathRotate(MotionWidget view, float t, double dx, double dy) {
+            view.setRotationZ(get(t) + (float) Math.toDegrees(Math.atan2(dy, dx)));
+        }
+    }
+
+    // @TODO: add description
+    public boolean variesByPath() {
+        return mVariesBy == 1;
+    }
+
+    static class WavePoint {
+        int mPosition;
+        float mValue;
+        float mOffset;
+        float mPeriod;
+        float mPhase;
+
+        WavePoint(int position, float period, float offset, float phase, float value) {
+            mPosition = position;
+            mValue = value;
+            mOffset = offset;
+            mPeriod = period;
+            mPhase = phase;
+        }
+    }
+
+    @Override
+    public String toString() {
+        String str = mType;
+        DecimalFormat df = new DecimalFormat("##.##");
+        for (WavePoint wp : mWavePoints) {
+            str += "[" + wp.mPosition + " , " + df.format(wp.mValue) + "] ";
+        }
+        return str;
+    }
+
+    public void setType(String type) {
+        mType = type;
+    }
+
+    // @TODO: add description
+    public float get(float t) {
+        return (float) mCycleOscillator.getValues(t);
+    }
+
+    // @TODO: add description
+    public float getSlope(float position) {
+        return (float) mCycleOscillator.getSlope(position);
+    }
+
+    public CurveFit getCurveFit() {
+        return mCurveFit;
+    }
+
+    protected void setCustom(Object custom) {
+
+    }
+
+    /**
+     * sets a oscillator wave point
+     *
+     * @param framePosition the position
+     * @param shape         the wave shape
+     * @param waveString    the wave string
+     * @param variesBy      only varies by path supported for now
+     * @param period        the period of the wave
+     * @param offset        the offset value
+     * @param phase         the phase of the new wavepoint
+     * @param value         the adder
+     * @param custom        The ConstraintAttribute used to set the value
+     */
+    public void setPoint(int framePosition,
+            int shape,
+            String waveString,
+            int variesBy,
+            float period,
+            float offset,
+            float phase,
+            float value,
+            Object custom) {
+        mWavePoints.add(new WavePoint(framePosition, period, offset, phase, value));
+        if (variesBy != -1) {
+            mVariesBy = variesBy;
+        }
+        mWaveShape = shape;
+        setCustom(custom);
+        mWaveString = waveString;
+    }
+
+    /**
+     * sets a oscillator wave point
+     *
+     * @param framePosition the position
+     * @param shape         the wave shape
+     * @param waveString    the wave string
+     * @param variesBy      only varies by path supported for now
+     * @param period        the period of the wave
+     * @param offset        the offset value
+     * @param phase         the phase of the new wavepoint
+     * @param value         the adder
+     */
+    public void setPoint(int framePosition,
+            int shape,
+            String waveString,
+            int variesBy,
+            float period,
+            float offset,
+            float phase,
+            float value) {
+        mWavePoints.add(new WavePoint(framePosition, period, offset, phase, value));
+        if (variesBy != -1) {
+            mVariesBy = variesBy;
+        }
+        mWaveShape = shape;
+        mWaveString = waveString;
+    }
+
+    // @TODO: add description
+    public void setup(float pathLength) {
+        int count = mWavePoints.size();
+        if (count == 0) {
+            return;
+        }
+        Collections.sort(mWavePoints, new Comparator<WavePoint>() {
+            @Override
+            public int compare(WavePoint lhs, WavePoint rhs) {
+                return Integer.compare(lhs.mPosition, rhs.mPosition);
+            }
+        });
+        double[] time = new double[count];
+        double[][] values = new double[count][3];
+        mCycleOscillator = new CycleOscillator(mWaveShape, mWaveString, mVariesBy, count);
+        int i = 0;
+        for (WavePoint wp : mWavePoints) {
+            time[i] = wp.mPeriod * 1E-2;
+            values[i][0] = wp.mValue;
+            values[i][1] = wp.mOffset;
+            values[i][2] = wp.mPhase;
+            mCycleOscillator.setPoint(i, wp.mPosition, wp.mPeriod,
+                    wp.mOffset, wp.mPhase, wp.mValue);
+            i++;
+        }
+        mCycleOscillator.setup(pathLength);
+        mCurveFit = CurveFit.get(CurveFit.SPLINE, time, values);
+    }
+
+    static class CycleOscillator {
+        static final int UNSET = -1; // -1 is typically used through out android to the UNSET value
+        private static final String TAG = "CycleOscillator";
+        @SuppressWarnings("unused") private final int mVariesBy;
+        Oscillator mOscillator = new Oscillator();
+        private final int mOffst = 0;
+        private final int mPhase = 1;
+        private final int mValue = 2;
+
+        float[] mValues;
+        double[] mPosition;
+        float[] mPeriod;
+        float[] mOffsetArr; // offsets will be spline interpolated
+        float[] mPhaseArr; // phase will be spline interpolated
+        float[] mScale; // scales will be spline interpolated
+        int mWaveShape;
+        CurveFit mCurveFit;
+        double[] mSplineValueCache; // for the return value of the curve fit
+        double[] mSplineSlopeCache; // for the return value of the curve fit
+        float mPathLength;
+
+        CycleOscillator(int waveShape, String customShape, int variesBy, int steps) {
+            mWaveShape = waveShape;
+            mVariesBy = variesBy;
+            mOscillator.setType(waveShape, customShape);
+            mValues = new float[steps];
+            mPosition = new double[steps];
+            mPeriod = new float[steps];
+            mOffsetArr = new float[steps];
+            mPhaseArr = new float[steps];
+            mScale = new float[steps];
+        }
+
+        public double getValues(float time) {
+            if (mCurveFit != null) {
+                mCurveFit.getPos(time, mSplineValueCache);
+            } else { // only one value no need to interpolate
+                mSplineValueCache[mOffst] = mOffsetArr[0];
+                mSplineValueCache[mPhase] = mPhaseArr[0];
+                mSplineValueCache[mValue] = mValues[0];
+
+            }
+            double offset = mSplineValueCache[mOffst];
+            double phase = mSplineValueCache[this.mPhase];
+            double waveValue = mOscillator.getValue(time, phase);
+            return offset + waveValue * mSplineValueCache[mValue];
+        }
+
+        public double getLastPhase() {
+            return mSplineValueCache[1];
+        }
+
+        public double getSlope(float time) {
+            if (mCurveFit != null) {
+                mCurveFit.getSlope(time, mSplineSlopeCache);
+                mCurveFit.getPos(time, mSplineValueCache);
+            } else { // only one value no need to interpolate
+                mSplineSlopeCache[mOffst] = 0;
+                mSplineSlopeCache[mPhase] = 0;
+                mSplineSlopeCache[mValue] = 0;
+            }
+            double waveValue = mOscillator.getValue(time, mSplineValueCache[mPhase]);
+            double waveSlope = mOscillator.getSlope(time,
+                    mSplineValueCache[mPhase], mSplineSlopeCache[mPhase]);
+            return mSplineSlopeCache[mOffst] + waveValue * mSplineSlopeCache[mValue]
+                    + waveSlope * mSplineValueCache[mValue];
+        }
+
+        /**
+         *
+         */
+        public void setPoint(int index,
+                int framePosition,
+                float wavePeriod,
+                float offset,
+                float phase,
+                float values) {
+            mPosition[index] = framePosition / 100.0;
+            mPeriod[index] = wavePeriod;
+            mOffsetArr[index] = offset;
+            mPhaseArr[index] = phase;
+            mValues[index] = values;
+        }
+
+        public void setup(float pathLength) {
+            mPathLength = pathLength;
+            double[][] splineValues = new double[mPosition.length][3];
+            mSplineValueCache = new double[2 + mValues.length];
+            mSplineSlopeCache = new double[2 + mValues.length];
+            if (mPosition[0] > 0) {
+                mOscillator.addPoint(0, mPeriod[0]);
+            }
+            int last = mPosition.length - 1;
+            if (mPosition[last] < 1.0f) {
+                mOscillator.addPoint(1, mPeriod[last]);
+            }
+
+            for (int i = 0; i < splineValues.length; i++) {
+                splineValues[i][mOffst] = mOffsetArr[i];
+                splineValues[i][mPhase] = mPhaseArr[i];
+                splineValues[i][mValue] = mValues[i];
+                mOscillator.addPoint(mPosition[i], mPeriod[i]);
+            }
+
+            // TODO: add mVariesBy and get total time and path length
+            mOscillator.normalize();
+            if (mPosition.length > 1) {
+                mCurveFit = CurveFit.get(CurveFit.SPLINE, mPosition, splineValues);
+            } else {
+                mCurveFit = null;
+            }
+        }
+    }
+
+    // @TODO: add description
+    public void setProperty(MotionWidget widget, float t) {
+
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyFrameArray.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/KeyFrameArray.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import androidx.constraintlayout.core.motion.CustomAttribute;
+import androidx.constraintlayout.core.motion.CustomVariable;
+
+import java.util.Arrays;
+
+public class KeyFrameArray {
+
+    // =================================== CustomAttribute =================================
+    public static class CustomArray {
+        int[] mKeys = new int[101];
+        CustomAttribute[] mValues = new CustomAttribute[101];
+        int mCount;
+        private static final int EMPTY = 999;
+
+        public CustomArray() {
+            clear();
+        }
+
+        // @TODO: add description
+        public void clear() {
+            Arrays.fill(mKeys, EMPTY);
+            Arrays.fill(mValues, null);
+            mCount = 0;
+        }
+
+        // @TODO: add description
+        public void dump() {
+            System.out.println("V: " + Arrays.toString(Arrays.copyOf(mKeys, mCount)));
+            System.out.print("K: [");
+            for (int i = 0; i < mCount; i++) {
+                System.out.print((i == 0 ? "" : ", ") + valueAt(i));
+            }
+            System.out.println("]");
+        }
+
+        // @TODO: add description
+        public int size() {
+            return mCount;
+        }
+
+        // @TODO: add description
+        public CustomAttribute valueAt(int i) {
+            return mValues[mKeys[i]];
+        }
+
+        // @TODO: add description
+        public int keyAt(int i) {
+            return mKeys[i];
+        }
+
+        // @TODO: add description
+        public void append(int position, CustomAttribute value) {
+            if (mValues[position] != null) {
+                remove(position);
+            }
+            mValues[position] = value;
+            mKeys[mCount++] = position;
+            Arrays.sort(mKeys);
+        }
+
+        // @TODO: add description
+        public void remove(int position) {
+            mValues[position] = null;
+            for (int j = 0, i = 0; i < mCount; i++) {
+                if (position == mKeys[i]) {
+                    mKeys[i] = EMPTY;
+                    j++;
+                }
+                if (i != j) {
+                    mKeys[i] = mKeys[j];
+                }
+                j++;
+
+            }
+            mCount--;
+        }
+    }
+
+    // =================================== CustomVar =================================
+    public static class CustomVar {
+        int[] mKeys = new int[101];
+        CustomVariable[] mValues = new CustomVariable[101];
+        int mCount;
+        private static final int EMPTY = 999;
+
+        public CustomVar() {
+            clear();
+        }
+
+        // @TODO: add description
+        public void clear() {
+            Arrays.fill(mKeys, EMPTY);
+            Arrays.fill(mValues, null);
+            mCount = 0;
+        }
+
+        // @TODO: add description
+        public void dump() {
+            System.out.println("V: " + Arrays.toString(Arrays.copyOf(mKeys, mCount)));
+            System.out.print("K: [");
+            for (int i = 0; i < mCount; i++) {
+                System.out.print((i == 0 ? "" : ", ") + valueAt(i));
+            }
+            System.out.println("]");
+        }
+
+        // @TODO: add description
+        public int size() {
+            return mCount;
+        }
+
+        // @TODO: add description
+        public CustomVariable valueAt(int i) {
+            return mValues[mKeys[i]];
+        }
+
+        // @TODO: add description
+        public int keyAt(int i) {
+            return mKeys[i];
+        }
+
+        // @TODO: add description
+        public void append(int position, CustomVariable value) {
+            if (mValues[position] != null) {
+                remove(position);
+            }
+            mValues[position] = value;
+            mKeys[mCount++] = position;
+            Arrays.sort(mKeys);
+        }
+
+        // @TODO: add description
+        public void remove(int position) {
+            mValues[position] = null;
+            for (int j = 0, i = 0; i < mCount; i++) {
+                if (position == mKeys[i]) {
+                    mKeys[i] = EMPTY;
+                    j++;
+                }
+                if (i != j) {
+                    mKeys[i] = mKeys[j];
+                }
+                j++;
+
+            }
+            mCount--;
+        }
+    }
+
+    // =================================== FloatArray ======================================
+    static class FloatArray {
+        int[] mKeys = new int[101];
+        float[][] mValues = new float[101][];
+        int mCount;
+        private static final int EMPTY = 999;
+
+        FloatArray() {
+            clear();
+        }
+
+        public void clear() {
+            Arrays.fill(mKeys, EMPTY);
+            Arrays.fill(mValues, null);
+            mCount = 0;
+        }
+
+        public void dump() {
+            System.out.println("V: " + Arrays.toString(Arrays.copyOf(mKeys, mCount)));
+            System.out.print("K: [");
+            for (int i = 0; i < mCount; i++) {
+                System.out.print((i == 0 ? "" : ", ") + Arrays.toString(valueAt(i)));
+            }
+            System.out.println("]");
+        }
+
+        public int size() {
+            return mCount;
+        }
+
+        public float[] valueAt(int i) {
+            return mValues[mKeys[i]];
+        }
+
+        public int keyAt(int i) {
+            return mKeys[i];
+        }
+
+        public void append(int position, float[] value) {
+            if (mValues[position] != null) {
+                remove(position);
+            }
+            mValues[position] = value;
+            mKeys[mCount++] = position;
+            Arrays.sort(mKeys);
+        }
+
+        public void remove(int position) {
+            mValues[position] = null;
+            for (int j = 0, i = 0; i < mCount; i++) {
+                if (position == mKeys[i]) {
+                    mKeys[i] = EMPTY;
+                    j++;
+                }
+                if (i != j) {
+                    mKeys[i] = mKeys[j];
+                }
+                j++;
+
+            }
+            mCount--;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/LinearCurveFit.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/LinearCurveFit.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * This performs a simple linear interpolation in multiple dimensions
+ *
+ *
+ */
+public class LinearCurveFit extends CurveFit {
+    private static final String TAG = "LinearCurveFit";
+    private double[] mT;
+    private double[][] mY;
+    private double mTotalLength = Double.NaN;
+    private boolean mExtrapolate = true;
+    double[] mSlopeTemp;
+
+    public LinearCurveFit(double[] time, double[][] y) {
+        final int dim = y[0].length;
+        mSlopeTemp = new double[dim];
+        mT = time;
+        mY = y;
+        if (dim > 2) {
+            @SuppressWarnings("unused") double sum = 0;
+            double lastx = 0, lasty = 0;
+            for (int i = 0; i < time.length; i++) {
+                double px = y[i][0];
+                double py = y[i][0];
+                if (i > 0) {
+                    sum += Math.hypot(px - lastx, py - lasty);
+                }
+                lastx = px;
+                lasty = py;
+            }
+            mTotalLength = 0;
+        }
+    }
+
+    /**
+     * Calculate the length traveled by the first two parameters assuming they are x and y.
+     * (Added for future work)
+     *
+     * @param t the point to calculate the length to
+     */
+    @SuppressWarnings("unused")
+    private double getLength2D(double t) {
+        if (Double.isNaN(mTotalLength)) {
+            return 0;
+        }
+        final int n = mT.length;
+        if (t <= mT[0]) {
+            return 0;
+        }
+        if (t >= mT[n - 1]) {
+            return mTotalLength;
+        }
+        double sum = 0;
+        double last_x = 0, last_y = 0;
+
+        for (int i = 0; i < n - 1; i++) {
+            double px = mY[i][0];
+            double py = mY[i][1];
+            if (i > 0) {
+                sum += Math.hypot(px - last_x, py - last_y);
+            }
+            last_x = px;
+            last_y = py;
+            if (t == mT[i]) {
+                return sum;
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                double x1 = mY[i][0];
+                double x2 = mY[i + 1][0];
+                double y1 = mY[i][1];
+                double y2 = mY[i + 1][1];
+
+                py -= y1 * (1 - x) + y2 * x;
+                px -= x1 * (1 - x) + x2 * x;
+                sum += Math.hypot(py, px);
+
+                return sum;
+            }
+        }
+        return 0;
+    }
+
+    // @TODO: add description
+    @Override
+    public void getPos(double t, double[] v) {
+        final int n = mT.length;
+        final int dim = mY[0].length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                getSlope(mT[0], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[0][j] + (t - mT[0]) * mSlopeTemp[j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                getSlope(mT[n - 1], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[n - 1][j] + (t - mT[n - 1]) * mSlopeTemp[j];
+                }
+                return;
+            }
+        } else {
+            if (t <= mT[0]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[0][j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[n - 1][j];
+                }
+                return;
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[i][j];
+                }
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+
+                    v[j] = y1 * (1 - x) + y2 * x;
+                }
+                return;
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public void getPos(double t, float[] v) {
+        final int n = mT.length;
+        final int dim = mY[0].length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                getSlope(mT[0], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) (mY[0][j] + (t - mT[0]) * mSlopeTemp[j]);
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                getSlope(mT[n - 1], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) (mY[n - 1][j] + (t - mT[n - 1]) * mSlopeTemp[j]);
+                }
+                return;
+            }
+        } else {
+            if (t <= mT[0]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[0][j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[n - 1][j];
+                }
+                return;
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[i][j];
+                }
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+
+                    v[j] = (float) (y1 * (1 - x) + y2 * x);
+                }
+                return;
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public double getPos(double t, int j) {
+        final int n = mT.length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                return mY[0][j] + (t - mT[0]) * getSlope(mT[0], j);
+            }
+            if (t >= mT[n - 1]) {
+                return mY[n - 1][j] + (t - mT[n - 1]) * getSlope(mT[n - 1], j);
+            }
+        } else {
+            if (t <= mT[0]) {
+                return mY[0][j];
+            }
+            if (t >= mT[n - 1]) {
+                return mY[n - 1][j];
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                return mY[i][j];
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                double y1 = mY[i][j];
+                double y2 = mY[i + 1][j];
+                return (y1 * (1 - x) + y2 * x);
+
+            }
+        }
+        return 0; // should never reach here
+    }
+
+    // @TODO: add description
+    @Override
+    public void getSlope(double t, double[] v) {
+        final int n = mT.length;
+        int dim = mY[0].length;
+        if (t <= mT[0]) {
+            t = mT[0];
+        } else if (t >= mT[n - 1]) {
+            t = mT[n - 1];
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t <= mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+
+                    v[j] = (y2 - y1) / h;
+                }
+                break;
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public double getSlope(double t, int j) {
+        final int n = mT.length;
+
+        if (t < mT[0]) {
+            t = mT[0];
+        } else if (t >= mT[n - 1]) {
+            t = mT[n - 1];
+        }
+        for (int i = 0; i < n - 1; i++) {
+            if (t <= mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double y1 = mY[i][j];
+                double y2 = mY[i + 1][j];
+                return (y2 - y1) / h;
+            }
+        }
+        return 0; // should never reach here
+    }
+
+    @Override
+    public double[] getTimePoints() {
+        return mT;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/MonotonicCurveFit.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/MonotonicCurveFit.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+
+/**
+ * This performs a spline interpolation in multiple dimensions
+ *
+ *
+ */
+public class MonotonicCurveFit extends CurveFit {
+    private static final String TAG = "MonotonicCurveFit";
+    private double[] mT;
+    private double[][] mY;
+    private double[][] mTangent;
+    private boolean mExtrapolate = true;
+    double[] mSlopeTemp;
+
+    public MonotonicCurveFit(double[] time, double[][] y) {
+        final int n = time.length;
+        final int dim = y[0].length;
+        mSlopeTemp = new double[dim];
+        double[][] slope = new double[n - 1][dim]; // could optimize this out
+        double[][] tangent = new double[n][dim];
+        for (int j = 0; j < dim; j++) {
+            for (int i = 0; i < n - 1; i++) {
+                double dt = time[i + 1] - time[i];
+                slope[i][j] = (y[i + 1][j] - y[i][j]) / dt;
+                if (i == 0) {
+                    tangent[i][j] = slope[i][j];
+                } else {
+                    tangent[i][j] = (slope[i - 1][j] + slope[i][j]) * 0.5f;
+                }
+            }
+            tangent[n - 1][j] = slope[n - 2][j];
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            for (int j = 0; j < dim; j++) {
+                if (slope[i][j] == 0.) {
+                    tangent[i][j] = 0.;
+                    tangent[i + 1][j] = 0.;
+                } else {
+                    double a = tangent[i][j] / slope[i][j];
+                    double b = tangent[i + 1][j] / slope[i][j];
+                    double h = Math.hypot(a, b);
+                    if (h > 9.0) {
+                        double t = 3. / h;
+                        tangent[i][j] = t * a * slope[i][j];
+                        tangent[i + 1][j] = t * b * slope[i][j];
+                    }
+                }
+            }
+        }
+        mT = time;
+        mY = y;
+        mTangent = tangent;
+    }
+
+    @Override
+    public void getPos(double t, double[] v) {
+        final int n = mT.length;
+        final int dim = mY[0].length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                getSlope(mT[0], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[0][j] + (t - mT[0]) * mSlopeTemp[j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                getSlope(mT[n - 1], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[n - 1][j] + (t - mT[n - 1]) * mSlopeTemp[j];
+                }
+                return;
+            }
+        } else {
+            if (t <= mT[0]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[0][j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[n - 1][j];
+                }
+                return;
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = mY[i][j];
+                }
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+                    double t1 = mTangent[i][j];
+                    double t2 = mTangent[i + 1][j];
+                    v[j] = interpolate(h, x, y1, y2, t1, t2);
+                }
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void getPos(double t, float[] v) {
+        final int n = mT.length;
+        final int dim = mY[0].length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                getSlope(mT[0], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) (mY[0][j] + (t - mT[0]) * mSlopeTemp[j]);
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                getSlope(mT[n - 1], mSlopeTemp);
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) (mY[n - 1][j] + (t - mT[n - 1]) * mSlopeTemp[j]);
+                }
+                return;
+            }
+        } else {
+            if (t <= mT[0]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[0][j];
+                }
+                return;
+            }
+            if (t >= mT[n - 1]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[n - 1][j];
+                }
+                return;
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (float) mY[i][j];
+                }
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+                    double t1 = mTangent[i][j];
+                    double t2 = mTangent[i + 1][j];
+                    v[j] = (float) interpolate(h, x, y1, y2, t1, t2);
+                }
+                return;
+            }
+        }
+    }
+
+    @Override
+    public double getPos(double t, int j) {
+        final int n = mT.length;
+        if (mExtrapolate) {
+            if (t <= mT[0]) {
+                return mY[0][j] + (t - mT[0]) * getSlope(mT[0], j);
+            }
+            if (t >= mT[n - 1]) {
+                return mY[n - 1][j] + (t - mT[n - 1]) * getSlope(mT[n - 1], j);
+            }
+        } else {
+            if (t <= mT[0]) {
+                return mY[0][j];
+            }
+            if (t >= mT[n - 1]) {
+                return mY[n - 1][j];
+            }
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t == mT[i]) {
+                return mY[i][j];
+            }
+            if (t < mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                double y1 = mY[i][j];
+                double y2 = mY[i + 1][j];
+                double t1 = mTangent[i][j];
+                double t2 = mTangent[i + 1][j];
+                return interpolate(h, x, y1, y2, t1, t2);
+
+            }
+        }
+        return 0; // should never reach here
+    }
+
+    @Override
+    public void getSlope(double t, double[] v) {
+        final int n = mT.length;
+        int dim = mY[0].length;
+        if (t <= mT[0]) {
+            t = mT[0];
+        } else if (t >= mT[n - 1]) {
+            t = mT[n - 1];
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            if (t <= mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                for (int j = 0; j < dim; j++) {
+                    double y1 = mY[i][j];
+                    double y2 = mY[i + 1][j];
+                    double t1 = mTangent[i][j];
+                    double t2 = mTangent[i + 1][j];
+                    v[j] = diff(h, x, y1, y2, t1, t2) / h;
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public double getSlope(double t, int j) {
+        final int n = mT.length;
+
+        if (t < mT[0]) {
+            t = mT[0];
+        } else if (t >= mT[n - 1]) {
+            t = mT[n - 1];
+        }
+        for (int i = 0; i < n - 1; i++) {
+            if (t <= mT[i + 1]) {
+                double h = mT[i + 1] - mT[i];
+                double x = (t - mT[i]) / h;
+                double y1 = mY[i][j];
+                double y2 = mY[i + 1][j];
+                double t1 = mTangent[i][j];
+                double t2 = mTangent[i + 1][j];
+                return diff(h, x, y1, y2, t1, t2) / h;
+            }
+        }
+        return 0; // should never reach here
+    }
+
+    @Override
+    public double[] getTimePoints() {
+        return mT;
+    }
+
+    /**
+     * Cubic Hermite spline
+     */
+    private static double interpolate(double h,
+            double x,
+            double y1,
+            double y2,
+            double t1,
+            double t2) {
+        double x2 = x * x;
+        double x3 = x2 * x;
+        return -2 * x3 * y2 + 3 * x2 * y2 + 2 * x3 * y1 - 3 * x2 * y1 + y1
+                + h * t2 * x3 + h * t1 * x3 - h * t2 * x2 - 2 * h * t1 * x2
+                + h * t1 * x;
+    }
+
+    /**
+     * Cubic Hermite spline slope differentiated
+     */
+    private static double diff(double h, double x, double y1, double y2, double t1, double t2) {
+        double x2 = x * x;
+        return -6 * x2 * y2 + 6 * x * y2 + 6 * x2 * y1 - 6 * x * y1 + 3 * h * t2 * x2
+                + 3 * h * t1 * x2 - 2 * h * t2 * x - 4 * h * t1 * x + h * t1;
+    }
+
+    /**
+     * This builds a monotonic spline to be used as a wave function
+     */
+    public static MonotonicCurveFit buildWave(String configString) {
+        // done this way for efficiency
+        String str = configString;
+        double[] values = new double[str.length() / 2];
+        int start = configString.indexOf('(') + 1;
+        int off1 = configString.indexOf(',', start);
+        int count = 0;
+        while (off1 != -1) {
+            String tmp = configString.substring(start, off1).trim();
+            values[count++] = Double.parseDouble(tmp);
+            off1 = configString.indexOf(',', start = off1 + 1);
+        }
+        off1 = configString.indexOf(')', start);
+        String tmp = configString.substring(start, off1).trim();
+        values[count++] = Double.parseDouble(tmp);
+
+        return buildWave(Arrays.copyOf(values, count));
+    }
+
+    private static MonotonicCurveFit buildWave(double[] values) {
+        int length = values.length * 3 - 2;
+        int len = values.length - 1;
+        double gap = 1.0 / len;
+        double[][] points = new double[length][1];
+        double[] time = new double[length];
+        for (int i = 0; i < values.length; i++) {
+            double v = values[i];
+            points[i + len][0] = v;
+            time[i + len] = i * gap;
+            if (i > 0) {
+                points[i + len * 2][0] = v + 1;
+                time[i + len * 2] = i * gap + 1;
+
+                points[i - 1][0] = v - 1 - gap;
+                time[i - 1] = i * gap + -1 - gap;
+            }
+        }
+
+        return new MonotonicCurveFit(time, points);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Oscillator.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Oscillator.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+
+/**
+ * This generates variable frequency oscillation curves
+ *
+ *
+ */
+public class Oscillator {
+    public static String TAG = "Oscillator";
+    float[] mPeriod = {};
+    double[] mPosition = {};
+    double[] mArea;
+    public static final int SIN_WAVE = 0; // theses must line up with attributes
+    public static final int SQUARE_WAVE = 1;
+    public static final int TRIANGLE_WAVE = 2;
+    public static final int SAW_WAVE = 3;
+    public static final int REVERSE_SAW_WAVE = 4;
+    public static final int COS_WAVE = 5;
+    public static final int BOUNCE = 6;
+    public static final int CUSTOM = 7;
+    String mCustomType;
+    MonotonicCurveFit mCustomCurve;
+    int mType;
+    double mPI2 = Math.PI * 2;
+    @SuppressWarnings("unused") private boolean mNormalized = false;
+
+    public Oscillator() {
+    }
+
+    @Override
+    public String toString() {
+        return "pos =" + Arrays.toString(mPosition) + " period=" + Arrays.toString(mPeriod);
+    }
+
+    // @TODO: add description
+    public void setType(int type, String customType) {
+        mType = type;
+        mCustomType = customType;
+        if (mCustomType != null) {
+            mCustomCurve = MonotonicCurveFit.buildWave(customType);
+        }
+    }
+
+    // @TODO: add description
+    public void addPoint(double position, float period) {
+        int len = mPeriod.length + 1;
+        int j = Arrays.binarySearch(mPosition, position);
+        if (j < 0) {
+            j = -j - 1;
+        }
+        mPosition = Arrays.copyOf(mPosition, len);
+        mPeriod = Arrays.copyOf(mPeriod, len);
+        mArea = new double[len];
+        System.arraycopy(mPosition, j, mPosition, j + 1, len - j - 1);
+        mPosition[j] = position;
+        mPeriod[j] = period;
+        mNormalized = false;
+    }
+
+    /**
+     * After adding point every thing must be normalized
+     */
+    public void normalize() {
+        double totalArea = 0;
+        double totalCount = 0;
+        for (int i = 0; i < mPeriod.length; i++) {
+            totalCount += mPeriod[i];
+        }
+        for (int i = 1; i < mPeriod.length; i++) {
+            float h = (mPeriod[i - 1] + mPeriod[i]) / 2;
+            double w = mPosition[i] - mPosition[i - 1];
+            totalArea = totalArea + w * h;
+        }
+        // scale periods to normalize it
+        for (int i = 0; i < mPeriod.length; i++) {
+            mPeriod[i] *= (float) (totalCount / totalArea);
+        }
+        mArea[0] = 0;
+        for (int i = 1; i < mPeriod.length; i++) {
+            float h = (mPeriod[i - 1] + mPeriod[i]) / 2;
+            double w = mPosition[i] - mPosition[i - 1];
+            mArea[i] = mArea[i - 1] + w * h;
+        }
+        mNormalized = true;
+    }
+
+    double getP(double time) {
+        if (time <= 0.0) {
+            return 0.0;
+        } else if (time >= 1.0) {
+            return 1.0;
+        }
+        // At this point, `index` is guaranteed to be != 0 for any time value (assuming mPosition
+        // includes 0.0)
+        int index = Arrays.binarySearch(mPosition, time);
+        if (index < 0) {
+            index = -index - 1;
+        }
+
+        double m = (mPeriod[index] - mPeriod[index - 1])
+                / (mPosition[index] - mPosition[index - 1]);
+        return mArea[index - 1]
+                + (mPeriod[index - 1] - m * mPosition[index - 1]) * (time - mPosition[index - 1])
+                + m * (time * time - mPosition[index - 1] * mPosition[index - 1]) / 2;
+    }
+
+    // @TODO: add description
+    public double getValue(double time, double phase) {
+        double angle = phase + getP(time); // angle is / by 360
+        switch (mType) {
+            default:
+            case SIN_WAVE:
+                return Math.sin(mPI2 * angle);
+            case SQUARE_WAVE:
+                return Math.signum(0.5 - angle % 1);
+            case TRIANGLE_WAVE:
+                return 1 - Math.abs((angle * 4 + 1) % 4 - 2);
+            case SAW_WAVE:
+                return ((angle * 2 + 1) % 2) - 1;
+            case REVERSE_SAW_WAVE:
+                return (1 - ((angle * 2 + 1) % 2));
+            case COS_WAVE:
+                return Math.cos(mPI2 * (phase + angle));
+            case BOUNCE:
+                double x = 1 - Math.abs((angle * 4) % 4 - 2);
+                return 1 - x * x;
+            case CUSTOM:
+                return mCustomCurve.getPos(angle % 1, 0);
+        }
+    }
+
+    double getDP(double time) {
+        if (time <= 0.0) {
+            return 0.0;
+        } else if (time >= 1.0) {
+            return 1.0;
+        }
+        // At this point, `index` is guaranteed to be != 0 for any time value (assuming mPosition
+        // includes 0.0)
+        int index = Arrays.binarySearch(mPosition, time);
+        if (index < 0) {
+            index = -index - 1;
+        }
+        double m = (mPeriod[index] - mPeriod[index - 1])
+                / (mPosition[index] - mPosition[index - 1]);
+        return m * time + (mPeriod[index - 1] - m * mPosition[index - 1]);
+    }
+
+    // @TODO: add description
+    public double getSlope(double time, double phase, double dphase) {
+        double angle = phase + getP(time);
+
+        double dangle_dtime = getDP(time) + dphase;
+        switch (mType) {
+            default:
+            case SIN_WAVE:
+                return mPI2 * dangle_dtime * Math.cos(mPI2 * angle);
+            case SQUARE_WAVE:
+                return 0;
+            case TRIANGLE_WAVE:
+                return 4 * dangle_dtime * Math.signum((angle * 4 + 3) % 4 - 2);
+            case SAW_WAVE:
+                return dangle_dtime * 2;
+            case REVERSE_SAW_WAVE:
+                return -dangle_dtime * 2;
+            case COS_WAVE:
+                return -mPI2 * dangle_dtime * Math.sin(mPI2 * angle);
+            case BOUNCE:
+                return 4 * dangle_dtime * ((angle * 4 + 2) % 4 - 2);
+            case CUSTOM:
+                return mCustomCurve.getSlope(angle % 1, 0);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Rect.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Rect.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+public class Rect {
+    public int bottom;
+    public int left;
+    public int right;
+    public int top;
+
+    // @TODO: add description
+    public int width() {
+        return right - left;
+    }
+
+    // @TODO: add description
+    public int height() {
+        return bottom - top;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Schlick.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Schlick.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * Schlick's bias and gain functions
+ * curve for use in an easing function including quantize functions
+ */
+public class Schlick extends Easing {
+    @SuppressWarnings("unused") private static final boolean DEBUG = false;
+    double mS, mT;
+    double mEps;
+
+    Schlick(String configString) {
+        // done this way for efficiency
+
+        mStr = configString;
+        int start = configString.indexOf('(');
+        int off1 = configString.indexOf(',', start);
+        mS = Double.parseDouble(configString.substring(start + 1, off1).trim());
+        int off2 = configString.indexOf(',', off1 + 1);
+        mT = Double.parseDouble(configString.substring(off1 + 1, off2).trim());
+    }
+
+    private double func(double x) {
+        if (x < mT) {
+            return mT * x / (x + mS * (mT - x));
+        }
+        return ((1 - mT) * (x - 1)) / (1 - x - mS * (mT - x));
+    }
+
+    private double dfunc(double x) {
+        if (x < mT) {
+            return (mS * mT * mT) / ((mS * (mT - x) + x) * (mS * (mT - x) + x));
+        }
+        return (mS * (mT - 1) * (mT - 1)) / ((-mS * (mT - x) - x + 1) * (-mS * (mT - x) - x + 1));
+    }
+
+    // @TODO: add description
+    @Override
+    public double getDiff(double x) {
+        return dfunc(x);
+    }
+
+    // @TODO: add description
+    @Override
+    public double get(double x) {
+        return func(x);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/SplineSet.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/SplineSet.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import androidx.constraintlayout.core.motion.CustomAttribute;
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.MotionWidget;
+import androidx.constraintlayout.core.state.WidgetFrame;
+
+import java.text.DecimalFormat;
+import java.util.Arrays;
+
+/**
+ * This engine allows manipulation of attributes by Curves
+ *
+ *
+ */
+
+public abstract class SplineSet {
+    private static final String TAG = "SplineSet";
+    protected CurveFit mCurveFit;
+    protected int[] mTimePoints = new int[10];
+    protected float[] mValues = new float[10];
+    private int mCount;
+    private String mType;
+
+    // @TODO: add description
+    public void setProperty(TypedValues widget, float t) {
+        widget.setValue(TypedValues.AttributesType.getId(mType), get(t));
+    }
+
+    @Override
+    public String toString() {
+        String str = mType;
+        DecimalFormat df = new DecimalFormat("##.##");
+        for (int i = 0; i < mCount; i++) {
+            str += "[" + mTimePoints[i] + " , " + df.format(mValues[i]) + "] ";
+
+        }
+        return str;
+    }
+
+    public void setType(String type) {
+        mType = type;
+    }
+
+    // @TODO: add description
+    public float get(float t) {
+        return (float) mCurveFit.getPos(t, 0);
+    }
+
+    // @TODO: add description
+    public float getSlope(float t) {
+        return (float) mCurveFit.getSlope(t, 0);
+    }
+
+    public CurveFit getCurveFit() {
+        return mCurveFit;
+    }
+
+    // @TODO: add description
+    public void setPoint(int position, float value) {
+        if (mTimePoints.length < mCount + 1) {
+            mTimePoints = Arrays.copyOf(mTimePoints, mTimePoints.length * 2);
+            mValues = Arrays.copyOf(mValues, mValues.length * 2);
+        }
+        mTimePoints[mCount] = position;
+        mValues[mCount] = value;
+        mCount++;
+    }
+
+    // @TODO: add description
+    public void setup(int curveType) {
+        if (mCount == 0) {
+            return;
+        }
+
+        Sort.doubleQuickSort(mTimePoints, mValues, 0, mCount - 1);
+
+        int unique = 1;
+
+        for (int i = 1; i < mCount; i++) {
+            if (mTimePoints[i - 1] != mTimePoints[i]) {
+                unique++;
+            }
+        }
+
+        double[] time = new double[unique];
+        double[][] values = new double[unique][1];
+        int k = 0;
+        for (int i = 0; i < mCount; i++) {
+            if (i > 0 && mTimePoints[i] == mTimePoints[i - 1]) {
+                continue;
+            }
+
+            time[k] = mTimePoints[i] * 1E-2;
+            values[k][0] = mValues[i];
+            k++;
+        }
+        mCurveFit = CurveFit.get(curveType, time, values);
+    }
+
+    // @TODO: add description
+    public static SplineSet makeCustomSpline(String str, KeyFrameArray.CustomArray attrList) {
+        return new CustomSet(str, attrList);
+    }
+
+    // @TODO: add description
+    public static SplineSet makeCustomSplineSet(String str, KeyFrameArray.CustomVar attrList) {
+        return new CustomSpline(str, attrList);
+    }
+
+    // @TODO: add description
+    public static SplineSet makeSpline(String str, long currentTime) {
+
+        return new CoreSpline(str, currentTime);
+    }
+
+    private static class Sort {
+
+        static void doubleQuickSort(int[] key, float[] value, int low, int hi) {
+            int[] stack = new int[key.length + 10];
+            int count = 0;
+            stack[count++] = hi;
+            stack[count++] = low;
+            while (count > 0) {
+                low = stack[--count];
+                hi = stack[--count];
+                if (low < hi) {
+                    int p = partition(key, value, low, hi);
+                    stack[count++] = p - 1;
+                    stack[count++] = low;
+                    stack[count++] = hi;
+                    stack[count++] = p + 1;
+                }
+            }
+        }
+
+        private static int partition(int[] array, float[] value, int low, int hi) {
+            int pivot = array[hi];
+            int i = low;
+            for (int j = low; j < hi; j++) {
+                if (array[j] <= pivot) {
+                    swap(array, value, i, j);
+                    i++;
+                }
+            }
+            swap(array, value, i, hi);
+            return i;
+        }
+
+        private static void swap(int[] array, float[] value, int a, int b) {
+            int tmp = array[a];
+            array[a] = array[b];
+            array[b] = tmp;
+            float tmpv = value[a];
+            value[a] = value[b];
+            value[b] = tmpv;
+        }
+    }
+
+
+    public static class CustomSet extends SplineSet {
+        String mAttributeName;
+        KeyFrameArray.CustomArray mConstraintAttributeList;
+        float[] mTempValues;
+
+        @SuppressWarnings("StringSplitter")
+        public CustomSet(String attribute, KeyFrameArray.CustomArray attrList) {
+            mAttributeName = attribute.split(",")[1];
+            mConstraintAttributeList = attrList;
+        }
+
+        // @TODO: add description
+        @Override
+        public void setup(int curveType) {
+            int size = mConstraintAttributeList.size();
+            int dimensionality = mConstraintAttributeList.valueAt(0).numberOfInterpolatedValues();
+            double[] time = new double[size];
+            mTempValues = new float[dimensionality];
+            double[][] values = new double[size][dimensionality];
+            for (int i = 0; i < size; i++) {
+
+                int key = mConstraintAttributeList.keyAt(i);
+                CustomAttribute ca = mConstraintAttributeList.valueAt(i);
+
+                time[i] = key * 1E-2;
+                ca.getValuesToInterpolate(mTempValues);
+                for (int k = 0; k < mTempValues.length; k++) {
+                    values[i][k] = mTempValues[k];
+                }
+
+            }
+            mCurveFit = CurveFit.get(curveType, time, values);
+        }
+
+        // @TODO: add description
+        @Override
+        public void setPoint(int position, float value) {
+            throw new RuntimeException("don't call for custom "
+                    + "attribute call setPoint(pos, ConstraintAttribute)");
+        }
+
+        // @TODO: add description
+        public void setPoint(int position, CustomAttribute value) {
+            mConstraintAttributeList.append(position, value);
+        }
+
+        // @TODO: add description
+        public void setProperty(WidgetFrame view, float t) {
+            mCurveFit.getPos(t, mTempValues);
+            view.setCustomValue(mConstraintAttributeList.valueAt(0), mTempValues);
+        }
+    }
+
+
+    private static class CoreSpline extends SplineSet {
+        String mType;
+        @SuppressWarnings("unused") long mStart;
+
+        CoreSpline(String str, long currentTime) {
+            mType = str;
+            mStart = currentTime;
+        }
+
+        @Override
+        public void setProperty(TypedValues widget, float t) {
+            int id = widget.getId(mType);
+            widget.setValue(id, get(t));
+        }
+    }
+
+    public static class CustomSpline extends SplineSet {
+        String mAttributeName;
+        KeyFrameArray.CustomVar mConstraintAttributeList;
+        float[] mTempValues;
+
+        @SuppressWarnings("StringSplitter")
+        public CustomSpline(String attribute, KeyFrameArray.CustomVar attrList) {
+            mAttributeName = attribute.split(",")[1];
+            mConstraintAttributeList = attrList;
+        }
+
+        // @TODO: add description
+        @Override
+        public void setup(int curveType) {
+            int size = mConstraintAttributeList.size();
+            int dimensionality = mConstraintAttributeList.valueAt(0).numberOfInterpolatedValues();
+            double[] time = new double[size];
+            mTempValues = new float[dimensionality];
+            double[][] values = new double[size][dimensionality];
+            for (int i = 0; i < size; i++) {
+
+                int key = mConstraintAttributeList.keyAt(i);
+                CustomVariable ca = mConstraintAttributeList.valueAt(i);
+
+                time[i] = key * 1E-2;
+                ca.getValuesToInterpolate(mTempValues);
+                for (int k = 0; k < mTempValues.length; k++) {
+                    values[i][k] = mTempValues[k];
+                }
+
+            }
+            mCurveFit = CurveFit.get(curveType, time, values);
+        }
+
+        // @TODO: add description
+        @Override
+        public void setPoint(int position, float value) {
+            throw new RuntimeException("don't call for custom attribute"
+                    + " call setPoint(pos, ConstraintAttribute)");
+        }
+
+        // @TODO: add description
+        @Override
+        public void setProperty(TypedValues widget, float t) {
+            setProperty((MotionWidget) widget, t);
+        }
+
+        // @TODO: add description
+        public void setPoint(int position, CustomVariable value) {
+            mConstraintAttributeList.append(position, value);
+        }
+
+        // @TODO: add description
+        public void setProperty(MotionWidget view, float t) {
+            mCurveFit.getPos(t, mTempValues);
+            mConstraintAttributeList.valueAt(0).setInterpolatedValue(view, mTempValues);
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/SpringStopEngine.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/SpringStopEngine.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * This contains the class to provide the logic for an animation to come to a stop using a spring
+ * model.
+ *
+ *
+ */
+public class SpringStopEngine implements StopEngine {
+    double mDamping = 0.5f;
+    @SuppressWarnings("unused") private static final double UNSET = Double.MAX_VALUE;
+    @SuppressWarnings("unused") private boolean mInitialized = false;
+    private double mStiffness;
+    private double mTargetPos;
+    @SuppressWarnings("unused") private double mLastVelocity;
+    private float mLastTime;
+    private float mPos;
+    private float mV;
+    private float mMass;
+    private float mStopThreshold;
+    private int mBoundaryMode = 0;
+
+    @Override
+    public String debug(String desc, float time) {
+        return null;
+    }
+
+    void log(String str) {
+        StackTraceElement s = new Throwable().getStackTrace()[1];
+        String line = ".(" + s.getFileName() + ":"
+                + s.getLineNumber() + ") " + s.getMethodName() + "() ";
+        System.out.println(line + str);
+    }
+
+    // @TODO: add description
+    public void springConfig(float currentPos,
+            float target,
+            float currentVelocity,
+            float mass,
+            float stiffness,
+            float damping,
+            float stopThreshold,
+            int boundaryMode) {
+        mTargetPos = target;
+        mDamping = damping;
+        mInitialized = false;
+        mPos = currentPos;
+        mLastVelocity = currentVelocity;
+        mStiffness = stiffness;
+        mMass = mass;
+        mStopThreshold = stopThreshold;
+        mBoundaryMode = boundaryMode;
+        mLastTime = 0;
+    }
+
+    @Override
+    public float getVelocity(float time) {
+        return (float) mV;
+    }
+
+    @Override
+    public float getInterpolation(float time) {
+        compute(time - mLastTime);
+        mLastTime = time;
+        if (isStopped()) {
+            mPos = (float) mTargetPos;
+        }
+        return (float) mPos;
+    }
+
+    // @TODO: add description
+    public float getAcceleration() {
+        double k = mStiffness;
+        double c = mDamping;
+        double x = (mPos - mTargetPos);
+        return (float) (-k * x - c * mV) / mMass;
+    }
+
+    @Override
+    public float getVelocity() {
+        return 0;
+    }
+
+    @Override
+    public boolean isStopped() {
+        double x = (mPos - mTargetPos);
+        double k = mStiffness;
+        double v = mV;
+        double m = mMass;
+        double energy = v * v * m + k * x * x;
+        double max_def = Math.sqrt(energy / k);
+        return max_def <= mStopThreshold;
+    }
+
+    private void compute(double dt) {
+        if (dt <= 0) {
+            // Nothing to compute if there's no time difference
+            return;
+        }
+
+        double k = mStiffness;
+        double c = mDamping;
+        // Estimate how many time we should over sample based on the frequency and current sampling
+        int overSample = (int) (1 + 9 / (Math.sqrt(mStiffness / mMass) * dt * 4));
+        dt /= overSample;
+
+        for (int i = 0; i < overSample; i++) {
+            double x = (mPos - mTargetPos);
+            double a = (-k * x - c * mV) / mMass;
+            // This refinement of a simple coding of the acceleration increases accuracy
+            double avgV = mV + a * dt / 2; // pass 1 calculate the average velocity
+            double avgX = mPos + dt * avgV / 2 - mTargetPos; // pass 1 calculate the average pos
+            a = (-avgX * k - avgV * c) / mMass; //  calculate acceleration over that average pos
+
+            double dv = a * dt; //  calculate change in velocity
+            avgV = mV + dv / 2; //  average  velocity is current + half change
+            mV += (float) dv;
+            mPos += (float) (avgV * dt);
+            if (mBoundaryMode > 0) {
+                if (mPos < 0 && ((mBoundaryMode & 1) == 1)) {
+                    mPos = -mPos;
+                    mV = -mV;
+                }
+                if (mPos > 1 && ((mBoundaryMode & 2) == 2)) {
+                    mPos = 2 - mPos;
+                    mV = -mV;
+                }
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StepCurve.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StepCurve.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+import java.text.DecimalFormat;
+import java.util.Arrays;
+
+/**
+ * This class translates a series of floating point values into a continuous
+ * curve for use in an easing function including quantize functions
+ * it is used with the "spline(0,0.3,0.3,0.5,...0.9,1)" it should start at 0 and end at one 1
+ */
+public class StepCurve extends Easing {
+    private static final boolean DEBUG = false;
+    MonotonicCurveFit mCurveFit;
+
+    StepCurve(String configString) {
+        // done this way for efficiency
+        mStr = configString;
+        double[] values = new double[mStr.length() / 2];
+        int start = configString.indexOf('(') + 1;
+        int off1 = configString.indexOf(',', start);
+        int count = 0;
+        while (off1 != -1) {
+            String tmp = configString.substring(start, off1).trim();
+            values[count++] = Double.parseDouble(tmp);
+            off1 = configString.indexOf(',', start = off1 + 1);
+        }
+        off1 = configString.indexOf(')', start);
+        String tmp = configString.substring(start, off1).trim();
+        values[count++] = Double.parseDouble(tmp);
+
+        mCurveFit = genSpline(Arrays.copyOf(values, count));
+    }
+
+    @SuppressWarnings("unused")
+    private static MonotonicCurveFit genSpline(String str) {
+        String wave = str;
+        String[] sp = wave.split("\\s+");
+        double[] values = new double[sp.length];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = Double.parseDouble(sp[i]);
+        }
+        return genSpline(values);
+    }
+
+    private static MonotonicCurveFit genSpline(double[] values) {
+        int length = values.length * 3 - 2;
+        int len = values.length - 1;
+        double gap = 1.0 / len;
+        double[][] points = new double[length][1];
+        double[] time = new double[length];
+        for (int i = 0; i < values.length; i++) {
+            double v = values[i];
+            points[i + len][0] = v;
+            time[i + len] = i * gap;
+            if (i > 0) {
+                points[i + len * 2][0] = v + 1;
+                time[i + len * 2] = i * gap + 1;
+
+                points[i - 1][0] = v - 1 - gap;
+                time[i - 1] = i * gap + -1 - gap;
+            }
+        }
+        if (DEBUG) {
+            String t = "t ";
+            String v = "v ";
+            DecimalFormat df = new DecimalFormat("#.00");
+            for (int i = 0; i < time.length; i++) {
+                t += df.format(time[i]) + " ";
+                v += df.format(points[i][0]) + " ";
+            }
+            System.out.println(t);
+            System.out.println(v);
+        }
+        MonotonicCurveFit ms = new MonotonicCurveFit(time, points);
+        System.out.println(" 0 " + ms.getPos(0, 0));
+        System.out.println(" 1 " + ms.getPos(1, 0));
+        return ms;
+    }
+
+    // @TODO: add description
+    @Override
+    public double getDiff(double x) {
+        return mCurveFit.getSlope(x, 0);
+    }
+
+    // @TODO: add description
+    @Override
+    public double get(double x) {
+        return mCurveFit.getPos(x, 0);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StopEngine.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StopEngine.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+public interface StopEngine {
+    // @TODO: add description
+    String debug(String desc, float time);
+
+    // @TODO: add description
+    float getVelocity(float time);
+
+    // @TODO: add description
+    float getInterpolation(float time);
+
+    // @TODO: add description
+    float getVelocity();
+
+    // @TODO: add description
+    boolean isStopped();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StopLogicEngine.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/StopLogicEngine.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * This contains the class to provide the logic for an animation to come to a stop.
+ * The setup defines a series of velocity gradients that gets to the desired position
+ * ending at 0 velocity.
+ * The path is computed such that the velocities are continuous
+ *
+ *
+ */
+public class StopLogicEngine implements StopEngine {
+    // the velocity at the start of each period
+    private float mStage1Velocity, mStage2Velocity, mStage3Velocity;
+    private float mStage1Duration, mStage2Duration, mStage3Duration; // the time for each period
+    private float mStage1EndPosition, mStage2EndPosition, mStage3EndPosition; // ending position
+    private int mNumberOfStages;
+    private String mType;
+    private boolean mBackwards = false;
+    private float mStartPosition;
+    private float mLastPosition;
+    private float mLastTime;
+    @SuppressWarnings("unused")
+    private boolean mDone = false;
+    private static final float EPSILON = 0.00001f;
+
+    /**
+     * Debugging logic to log the state.
+     *
+     * @param desc Description to pre append
+     * @param time Time during animation
+     * @return string useful for debugging the state of the StopLogic
+     */
+    @Override
+    public String debug(String desc, float time) {
+        String ret = desc + " ===== " + mType + "\n";
+        ret += desc + (mBackwards ? "backwards" : "forward ")
+                + " time = " + time + "  stages " + mNumberOfStages + "\n";
+        ret += desc + " dur " + mStage1Duration + " vel "
+                + mStage1Velocity + " pos " + mStage1EndPosition + "\n";
+
+        if (mNumberOfStages > 1) {
+            ret += desc + " dur " + mStage2Duration + " vel "
+                    + mStage2Velocity + " pos " + mStage2EndPosition + "\n";
+
+        }
+        if (mNumberOfStages > 2) {
+            ret += desc + " dur " + mStage3Duration + " vel "
+                    + mStage3Velocity + " pos " + mStage3EndPosition + "\n";
+        }
+
+        if (time <= mStage1Duration) {
+            ret += desc + "stage 0" + "\n";
+            return ret;
+        }
+        if (mNumberOfStages == 1) {
+            ret += desc + "end stage 0" + "\n";
+            return ret;
+        }
+        time -= mStage1Duration;
+        if (time < mStage2Duration) {
+
+            ret += desc + " stage 1" + "\n";
+            return ret;
+        }
+        if (mNumberOfStages == 2) {
+            ret += desc + "end stage 1" + "\n";
+            return ret;
+        }
+        time -= mStage2Duration;
+        if (time < mStage3Duration) {
+
+            ret += desc + " stage 2" + "\n";
+            return ret;
+        }
+        ret += desc + " end stage 2" + "\n";
+        return ret;
+    }
+
+    // @TODO: add description
+    @Override
+    public float getVelocity(float x) {
+        if (x <= mStage1Duration) {
+            return mStage1Velocity + (mStage2Velocity - mStage1Velocity) * x / mStage1Duration;
+        }
+        if (mNumberOfStages == 1) {
+            return 0;
+        }
+        x -= mStage1Duration;
+        if (x < mStage2Duration) {
+
+            return mStage2Velocity + (mStage3Velocity - mStage2Velocity) * x / mStage2Duration;
+        }
+        if (mNumberOfStages == 2) {
+            return 0;
+        }
+        x -= mStage2Duration;
+        if (x < mStage3Duration) {
+
+            return mStage3Velocity - mStage3Velocity * x / mStage3Duration;
+        }
+        return 0;
+    }
+
+    private float calcY(float time) {
+        mDone = false;
+        if (time <= mStage1Duration) {
+            return mStage1Velocity * time + (mStage2Velocity - mStage1Velocity)
+                    * time * time / (2 * mStage1Duration);
+        }
+        if (mNumberOfStages == 1) {
+            return mStage1EndPosition;
+        }
+        time -= mStage1Duration;
+        if (time < mStage2Duration) {
+
+            return mStage1EndPosition + mStage2Velocity * time
+                    + (mStage3Velocity - mStage2Velocity) * time * time / (2 * mStage2Duration);
+        }
+        if (mNumberOfStages == 2) {
+            return mStage2EndPosition;
+        }
+        time -= mStage2Duration;
+        if (time <= mStage3Duration) {
+
+            return mStage2EndPosition + mStage3Velocity
+                    * time - mStage3Velocity * time * time / (2 * mStage3Duration);
+        }
+        mDone = true;
+        return mStage3EndPosition;
+    }
+
+    // @TODO: add description
+    public void config(float currentPos, float destination, float currentVelocity,
+            float maxTime, float maxAcceleration, float maxVelocity) {
+        mDone = false;
+        mStartPosition = currentPos;
+        mBackwards = (currentPos > destination);
+        if (mBackwards) {
+            setup(-currentVelocity, currentPos - destination,
+                    maxAcceleration, maxVelocity, maxTime);
+        } else {
+            setup(currentVelocity, destination - currentPos, maxAcceleration, maxVelocity, maxTime);
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public float getInterpolation(float v) {
+        float y = calcY(v);
+        mLastPosition = y;
+        mLastTime = v;
+        return mBackwards ? mStartPosition - y : mStartPosition + y;
+    }
+
+    @Override
+    public float getVelocity() {
+        return mBackwards ? -getVelocity(mLastTime) : getVelocity(mLastTime);
+    }
+
+    @Override
+    public boolean isStopped() {
+        return getVelocity() < EPSILON && Math.abs(mStage3EndPosition - mLastPosition) < EPSILON;
+    }
+
+    private void setup(float velocity, float distance, float maxAcceleration, float maxVelocity,
+            float maxTime) {
+        mDone = false;
+        mStage3EndPosition = distance;
+        if (velocity == 0) {
+            velocity = 0.0001f;
+        }
+        float min_time_to_stop = velocity / maxAcceleration;
+        float stopDistance = min_time_to_stop * velocity / 2;
+
+        if (velocity < 0) { // backward
+            float timeToZeroVelocity = -velocity / maxAcceleration;
+            float reversDistanceTraveled = timeToZeroVelocity * velocity / 2;
+            float totalDistance = distance - reversDistanceTraveled;
+            float peak_v = (float) Math.sqrt(maxAcceleration * totalDistance);
+            if (peak_v < maxVelocity) { // accelerate then decelerate
+                mType = "backward accelerate, decelerate";
+                this.mNumberOfStages = 2;
+                this.mStage1Velocity = velocity;
+                this.mStage2Velocity = peak_v;
+                this.mStage3Velocity = 0;
+                this.mStage1Duration = (peak_v - velocity) / maxAcceleration;
+                this.mStage2Duration = peak_v / maxAcceleration;
+                this.mStage1EndPosition = (velocity + peak_v) * this.mStage1Duration / 2;
+                this.mStage2EndPosition = distance;
+                this.mStage3EndPosition = distance;
+                return;
+            }
+            mType = "backward accelerate cruse decelerate";
+            this.mNumberOfStages = 3;
+            this.mStage1Velocity = velocity;
+            this.mStage2Velocity = maxVelocity;
+            this.mStage3Velocity = maxVelocity;
+
+            this.mStage1Duration = (maxVelocity - velocity) / maxAcceleration;
+            this.mStage3Duration = maxVelocity / maxAcceleration;
+            float accDist = (velocity + maxVelocity) * this.mStage1Duration / 2;
+            float decDist = (maxVelocity * this.mStage3Duration) / 2;
+            this.mStage2Duration = (distance - accDist - decDist) / maxVelocity;
+            this.mStage1EndPosition = accDist;
+            this.mStage2EndPosition = (distance - decDist);
+            this.mStage3EndPosition = distance;
+            return;
+        }
+
+        if (stopDistance >= distance) { // we cannot make it hit the breaks.
+            // we do a force hard stop
+            mType = "hard stop";
+            float time = 2 * distance / velocity;
+            this.mNumberOfStages = 1;
+            this.mStage1Velocity = velocity;
+            this.mStage2Velocity = 0;
+            this.mStage1EndPosition = distance;
+            this.mStage1Duration = time;
+            return;
+        }
+
+        float distance_before_break = distance - stopDistance;
+        float cruseTime = distance_before_break / velocity; // do we just Cruse then stop?
+        if (cruseTime + min_time_to_stop < maxTime) { // close enough maintain v then break
+            mType = "cruse decelerate";
+            this.mNumberOfStages = 2;
+            this.mStage1Velocity = velocity;
+            this.mStage2Velocity = velocity;
+            this.mStage3Velocity = 0;
+            this.mStage1EndPosition = distance_before_break;
+            this.mStage2EndPosition = distance;
+            this.mStage1Duration = cruseTime;
+            this.mStage2Duration = velocity / maxAcceleration;
+            return;
+        }
+
+        float peak_v = (float) Math.sqrt(maxAcceleration * distance + velocity * velocity / 2);
+        this.mStage1Duration = (peak_v - velocity) / maxAcceleration;
+        this.mStage2Duration = peak_v / maxAcceleration;
+        if (peak_v < maxVelocity) { // accelerate then decelerate
+            mType = "accelerate decelerate";
+            this.mNumberOfStages = 2;
+            this.mStage1Velocity = velocity;
+            this.mStage2Velocity = peak_v;
+            this.mStage3Velocity = 0;
+            this.mStage1Duration = (peak_v - velocity) / maxAcceleration;
+            this.mStage2Duration = peak_v / maxAcceleration;
+            this.mStage1EndPosition = (velocity + peak_v) * this.mStage1Duration / 2;
+            this.mStage2EndPosition = distance;
+
+            return;
+        }
+        mType = "accelerate cruse decelerate";
+        // accelerate, cruse then decelerate
+        this.mNumberOfStages = 3;
+        this.mStage1Velocity = velocity;
+        this.mStage2Velocity = maxVelocity;
+        this.mStage3Velocity = maxVelocity;
+
+        this.mStage1Duration = (maxVelocity - velocity) / maxAcceleration;
+        this.mStage3Duration = maxVelocity / maxAcceleration;
+        float accDist = (velocity + maxVelocity) * this.mStage1Duration / 2;
+        float decDist = (maxVelocity * this.mStage3Duration) / 2;
+
+        this.mStage2Duration = (distance - accDist - decDist) / maxVelocity;
+        this.mStage1EndPosition = accDist;
+        this.mStage2EndPosition = (distance - decDist);
+        this.mStage3EndPosition = distance;
+    }
+
+    // Support the simple Decelerate use case
+    public static class Decelerate implements StopEngine {
+        private float mDestination;
+        private float mInitialVelocity;
+        private float mAcceleration;
+        private float mLastVelocity;
+        private float mDuration;
+        private float mInitialPos;
+        private boolean mDone = false;
+
+        @Override
+        public String debug(String desc, float time) {
+            return mDuration + " " + mLastVelocity;
+        }
+
+        @Override
+        public float getVelocity(float time) {
+            if (time > mDuration) {
+                return 0;
+            }
+            return mLastVelocity = mInitialVelocity + mAcceleration * time;
+        }
+
+        @Override
+        public float getInterpolation(float time) {
+            if (time > mDuration) {
+                mDone = true;
+                return mDestination;
+            }
+            getVelocity(time);
+            return mInitialPos + (mInitialVelocity + mAcceleration * time / 2) * time;
+        }
+
+        @Override
+        public float getVelocity() {
+            return mLastVelocity;
+        }
+
+        @Override
+        public boolean isStopped() {
+            return mDone;
+        }
+
+        /**
+         * Configure simple deceleration controller
+         *
+         * @param currentPos      the current position
+         * @param destination     the destination position
+         * @param currentVelocity the currentVelocity change in pos / second
+         */
+        public void config(float currentPos, float destination, float currentVelocity) {
+            mDone = false;
+            mDestination = destination;
+            mInitialVelocity = currentVelocity;
+            mInitialPos = currentPos;
+            float distance = mDestination - currentPos;
+            mDuration = distance / (currentVelocity / 2);
+            mAcceleration = -currentVelocity / mDuration;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TimeCycleSplineSet.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TimeCycleSplineSet.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import androidx.constraintlayout.core.motion.CustomAttribute;
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.MotionWidget;
+
+import java.text.DecimalFormat;
+
+/**
+ * This engine allows manipulation of attributes by wave shapes oscillating in time
+ *
+ *
+ */
+public abstract class TimeCycleSplineSet {
+    private static final String TAG = "SplineSet";
+    protected CurveFit mCurveFit;
+    protected int mWaveShape = 0;
+    protected int[] mTimePoints = new int[10];
+    protected float[][] mValues = new float[10][3];
+    protected int mCount;
+    protected String mType;
+    protected float[] mCache = new float[3];
+    protected static final int CURVE_VALUE = 0;
+    protected static final int CURVE_PERIOD = 1;
+    protected static final int CURVE_OFFSET = 2;
+    protected static float sVal2PI = (float) (2 * Math.PI);
+    protected boolean mContinue = false;
+    protected long mLastTime;
+    protected float mLastCycle = Float.NaN;
+
+    @Override
+    public String toString() {
+        String str = mType;
+        DecimalFormat df = new DecimalFormat("##.##");
+        for (int i = 0; i < mCount; i++) {
+            str += "[" + mTimePoints[i] + " , " + df.format(mValues[i]) + "] ";
+        }
+        return str;
+    }
+
+    public void setType(String type) {
+        mType = type;
+    }
+
+    /**
+     * @param period cycles per second
+     */
+    protected float calcWave(float period) {
+        float p = period;
+        switch (mWaveShape) {
+            default:
+            case Oscillator.SIN_WAVE:
+                return (float) Math.sin(p * sVal2PI);
+            case Oscillator.SQUARE_WAVE:
+                return (float) Math.signum(p * sVal2PI);
+            case Oscillator.TRIANGLE_WAVE:
+                return 1 - Math.abs(p);
+            case Oscillator.SAW_WAVE:
+                return ((p * 2 + 1) % 2) - 1;
+            case Oscillator.REVERSE_SAW_WAVE:
+                return (1 - ((p * 2 + 1) % 2));
+            case Oscillator.COS_WAVE:
+                return (float) Math.cos(p * sVal2PI);
+            case Oscillator.BOUNCE:
+                float x = 1 - Math.abs((p * 4) % 4 - 2);
+                return 1 - x * x;
+        }
+    }
+
+    public CurveFit getCurveFit() {
+        return mCurveFit;
+    }
+
+    protected void setStartTime(long currentTime) {
+        mLastTime = currentTime;
+    }
+
+    // @TODO: add description
+    public void setPoint(int position, float value, float period, int shape, float offset) {
+        mTimePoints[mCount] = position;
+        mValues[mCount][CURVE_VALUE] = value;
+        mValues[mCount][CURVE_PERIOD] = period;
+        mValues[mCount][CURVE_OFFSET] = offset;
+        mWaveShape = Math.max(mWaveShape, shape); // the highest value shape is chosen
+        mCount++;
+    }
+
+    public static class CustomSet extends TimeCycleSplineSet {
+        String mAttributeName;
+        KeyFrameArray.CustomArray mConstraintAttributeList;
+        KeyFrameArray.FloatArray mWaveProperties = new KeyFrameArray.FloatArray();
+        float[] mTempValues;
+        float[] mCustomCache;
+
+        public CustomSet(String attribute, KeyFrameArray.CustomArray attrList) {
+            mAttributeName = attribute.split(",")[1];
+            mConstraintAttributeList = attrList;
+        }
+
+        // @TODO: add description
+        @Override
+        public void setup(int curveType) {
+            int size = mConstraintAttributeList.size();
+            int dimensionality = mConstraintAttributeList.valueAt(0).numberOfInterpolatedValues();
+            double[] time = new double[size];
+            mTempValues = new float[dimensionality + 2];
+            mCustomCache = new float[dimensionality];
+            double[][] values = new double[size][dimensionality + 2];
+            for (int i = 0; i < size; i++) {
+                int key = mConstraintAttributeList.keyAt(i);
+                CustomAttribute ca = mConstraintAttributeList.valueAt(i);
+                float[] waveProp = mWaveProperties.valueAt(i);
+                time[i] = key * 1E-2;
+                ca.getValuesToInterpolate(mTempValues);
+                for (int k = 0; k < mTempValues.length; k++) {
+                    values[i][k] = mTempValues[k];
+                }
+                values[i][dimensionality] = waveProp[0];
+                values[i][dimensionality + 1] = waveProp[1];
+            }
+            mCurveFit = CurveFit.get(curveType, time, values);
+        }
+
+        // @TODO: add description
+        @Override
+        public void setPoint(int position, float value, float period, int shape, float offset) {
+            throw new RuntimeException("don't call for custom attribute "
+                    + "call setPoint(pos, ConstraintAttribute,...)");
+        }
+
+        // @TODO: add description
+        public void setPoint(int position,
+                CustomAttribute value,
+                float period,
+                int shape,
+                float offset) {
+            mConstraintAttributeList.append(position, value);
+            mWaveProperties.append(position, new float[]{period, offset});
+            mWaveShape = Math.max(mWaveShape, shape); // the highest value shape is chosen
+        }
+
+        // @TODO: add description
+        public boolean setProperty(MotionWidget view, float t, long time, KeyCache cache) {
+            mCurveFit.getPos(t, mTempValues);
+            float period = mTempValues[mTempValues.length - 2];
+            float offset = mTempValues[mTempValues.length - 1];
+            long delta_time = time - mLastTime;
+
+            if (Float.isNaN(mLastCycle)) { // it has not been set
+                mLastCycle = cache.getFloatValue(view, mAttributeName, 0); // check the cache
+                if (Float.isNaN(mLastCycle)) {  // not in cache so set to 0 (start)
+                    mLastCycle = 0;
+                }
+            }
+
+            mLastCycle = (float) ((mLastCycle + delta_time * 1E-9 * period) % 1.0);
+            mLastTime = time;
+            float wave = calcWave(mLastCycle);
+            mContinue = false;
+            for (int i = 0; i < mCustomCache.length; i++) {
+                mContinue |= mTempValues[i] != 0.0;
+                mCustomCache[i] = mTempValues[i] * wave + offset;
+            }
+            view.setInterpolatedValue(mConstraintAttributeList.valueAt(0), mCustomCache);
+            if (period != 0.0f) {
+                mContinue = true;
+            }
+            return mContinue;
+        }
+    }
+
+    // @TODO: add description
+    public void setup(int curveType) {
+        if (mCount == 0) {
+            System.err.println("Error no points added to " + mType);
+            return;
+        }
+        Sort.doubleQuickSort(mTimePoints, mValues, 0, mCount - 1);
+        int unique = 0;
+        for (int i = 1; i < mTimePoints.length; i++) {
+            if (mTimePoints[i] != mTimePoints[i - 1]) {
+                unique++;
+            }
+        }
+        if (unique == 0) {
+            unique = 1;
+        }
+        double[] time = new double[unique];
+        double[][] values = new double[unique][3];
+        int k = 0;
+
+        for (int i = 0; i < mCount; i++) {
+            if (i > 0 && mTimePoints[i] == mTimePoints[i - 1]) {
+                continue;
+            }
+            time[k] = mTimePoints[i] * 1E-2;
+            values[k][0] = mValues[i][0];
+            values[k][1] = mValues[i][1];
+            values[k][2] = mValues[i][2];
+            k++;
+        }
+        mCurveFit = CurveFit.get(curveType, time, values);
+    }
+
+    protected static class Sort {
+        static void doubleQuickSort(int[] key, float[][] value, int low, int hi) {
+            int[] stack = new int[key.length + 10];
+            int count = 0;
+            stack[count++] = hi;
+            stack[count++] = low;
+            while (count > 0) {
+                low = stack[--count];
+                hi = stack[--count];
+                if (low < hi) {
+                    int p = partition(key, value, low, hi);
+                    stack[count++] = p - 1;
+                    stack[count++] = low;
+                    stack[count++] = hi;
+                    stack[count++] = p + 1;
+                }
+            }
+        }
+
+        private static int partition(int[] array, float[][] value, int low, int hi) {
+            int pivot = array[hi];
+            int i = low;
+            for (int j = low; j < hi; j++) {
+                if (array[j] <= pivot) {
+                    swap(array, value, i, j);
+                    i++;
+                }
+            }
+            swap(array, value, i, hi);
+            return i;
+        }
+
+        private static void swap(int[] array, float[][] value, int a, int b) {
+            int tmp = array[a];
+            array[a] = array[b];
+            array[b] = tmp;
+            float[] tmpv = value[a];
+            value[a] = value[b];
+            value[b] = tmpv;
+        }
+    }
+
+
+    public static class CustomVarSet extends TimeCycleSplineSet {
+        String mAttributeName;
+        KeyFrameArray.CustomVar mConstraintAttributeList;
+        KeyFrameArray.FloatArray mWaveProperties = new KeyFrameArray.FloatArray();
+        float[] mTempValues;
+        float[] mCustomCache;
+
+        public CustomVarSet(String attribute, KeyFrameArray.CustomVar attrList) {
+            mAttributeName = attribute.split(",")[1];
+            mConstraintAttributeList = attrList;
+        }
+
+        // @TODO: add description
+        @Override
+        public void setup(int curveType) {
+            int size = mConstraintAttributeList.size();
+            int dimensionality = mConstraintAttributeList.valueAt(0).numberOfInterpolatedValues();
+            double[] time = new double[size];
+            mTempValues = new float[dimensionality + 2];
+            mCustomCache = new float[dimensionality];
+            double[][] values = new double[size][dimensionality + 2];
+            for (int i = 0; i < size; i++) {
+                int key = mConstraintAttributeList.keyAt(i);
+                CustomVariable ca = mConstraintAttributeList.valueAt(i);
+                float[] waveProp = mWaveProperties.valueAt(i);
+                time[i] = key * 1E-2;
+                ca.getValuesToInterpolate(mTempValues);
+                for (int k = 0; k < mTempValues.length; k++) {
+                    values[i][k] = mTempValues[k];
+                }
+                values[i][dimensionality] = waveProp[0];
+                values[i][dimensionality + 1] = waveProp[1];
+            }
+            mCurveFit = CurveFit.get(curveType, time, values);
+        }
+
+        // @TODO: add description
+        @Override
+        public void setPoint(int position, float value, float period, int shape, float offset) {
+            throw new RuntimeException("don't call for custom attribute "
+                    + "call setPoint(pos, ConstraintAttribute,...)");
+        }
+
+        // @TODO: add description
+        public void setPoint(int position,
+                CustomVariable value,
+                float period,
+                int shape,
+                float offset) {
+            mConstraintAttributeList.append(position, value);
+            mWaveProperties.append(position, new float[]{period, offset});
+            mWaveShape = Math.max(mWaveShape, shape); // the highest value shape is chosen
+        }
+
+        // @TODO: add description
+        public boolean setProperty(MotionWidget view, float t, long time, KeyCache cache) {
+            mCurveFit.getPos(t, mTempValues);
+            float period = mTempValues[mTempValues.length - 2];
+            float offset = mTempValues[mTempValues.length - 1];
+            long delta_time = time - mLastTime;
+
+            if (Float.isNaN(mLastCycle)) { // it has not been set
+                mLastCycle = cache.getFloatValue(view, mAttributeName, 0); // check the cache
+                if (Float.isNaN(mLastCycle)) {  // not in cache so set to 0 (start)
+                    mLastCycle = 0;
+                }
+            }
+
+            mLastCycle = (float) ((mLastCycle + delta_time * 1E-9 * period) % 1.0);
+            mLastTime = time;
+            float wave = calcWave(mLastCycle);
+            mContinue = false;
+            for (int i = 0; i < mCustomCache.length; i++) {
+                mContinue |= mTempValues[i] != 0.0;
+                mCustomCache[i] = mTempValues[i] * wave + offset;
+            }
+            mConstraintAttributeList.valueAt(0).setInterpolatedValue(view, mCustomCache);
+            if (period != 0.0f) {
+                mContinue = true;
+            }
+            return mContinue;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TypedBundle.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TypedBundle.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import java.util.Arrays;
+
+public class TypedBundle {
+
+    private static final int INITIAL_BOOLEAN = 4;
+    private static final int INITIAL_INT = 10;
+    private static final int INITIAL_FLOAT = 10;
+    private static final int INITIAL_STRING = 5;
+
+    int[] mTypeInt = new int[INITIAL_INT];
+    int[] mValueInt = new int[INITIAL_INT];
+    int mCountInt = 0;
+    int[] mTypeFloat = new int[INITIAL_FLOAT];
+    float[] mValueFloat = new float[INITIAL_FLOAT];
+    int mCountFloat = 0;
+    int[] mTypeString = new int[INITIAL_STRING];
+    String[] mValueString = new String[INITIAL_STRING];
+    int mCountString = 0;
+    int[] mTypeBoolean = new int[INITIAL_BOOLEAN];
+    boolean[] mValueBoolean = new boolean[INITIAL_BOOLEAN];
+    int mCountBoolean = 0;
+
+    // @TODO: add description
+    public int getInteger(int type) {
+        for (int i = 0; i < mCountInt; i++) {
+            if (mTypeInt[i] == type) {
+                return mValueInt[i];
+            }
+        }
+        return -1;
+    }
+
+    // @TODO: add description
+    public void add(int type, int value) {
+        if (mCountInt >= mTypeInt.length) {
+            mTypeInt = Arrays.copyOf(mTypeInt, mTypeInt.length * 2);
+            mValueInt = Arrays.copyOf(mValueInt, mValueInt.length * 2);
+        }
+        mTypeInt[mCountInt] = type;
+        mValueInt[mCountInt++] = value;
+    }
+
+    // @TODO: add description
+    public void add(int type, float value) {
+        if (mCountFloat >= mTypeFloat.length) {
+            mTypeFloat = Arrays.copyOf(mTypeFloat, mTypeFloat.length * 2);
+            mValueFloat = Arrays.copyOf(mValueFloat, mValueFloat.length * 2);
+        }
+        mTypeFloat[mCountFloat] = type;
+        mValueFloat[mCountFloat++] = value;
+    }
+
+    // @TODO: add description
+    public void addIfNotNull(int type, String value) {
+        if (value != null) {
+            add(type, value);
+        }
+    }
+
+    // @TODO: add description
+    public void add(int type, String value) {
+        if (mCountString >= mTypeString.length) {
+            mTypeString = Arrays.copyOf(mTypeString, mTypeString.length * 2);
+            mValueString = Arrays.copyOf(mValueString, mValueString.length * 2);
+        }
+        mTypeString[mCountString] = type;
+        mValueString[mCountString++] = value;
+    }
+
+    // @TODO: add description
+    public void add(int type, boolean value) {
+        if (mCountBoolean >= mTypeBoolean.length) {
+            mTypeBoolean = Arrays.copyOf(mTypeBoolean, mTypeBoolean.length * 2);
+            mValueBoolean = Arrays.copyOf(mValueBoolean, mValueBoolean.length * 2);
+        }
+        mTypeBoolean[mCountBoolean] = type;
+        mValueBoolean[mCountBoolean++] = value;
+    }
+
+    // @TODO: add description
+    public void applyDelta(TypedValues values) {
+        for (int i = 0; i < mCountInt; i++) {
+            values.setValue(mTypeInt[i], mValueInt[i]);
+        }
+        for (int i = 0; i < mCountFloat; i++) {
+            values.setValue(mTypeFloat[i], mValueFloat[i]);
+        }
+        for (int i = 0; i < mCountString; i++) {
+            values.setValue(mTypeString[i], mValueString[i]);
+        }
+        for (int i = 0; i < mCountBoolean; i++) {
+            values.setValue(mTypeBoolean[i], mValueBoolean[i]);
+        }
+    }
+
+    // @TODO: add description
+    public void applyDelta(TypedBundle values) {
+        for (int i = 0; i < mCountInt; i++) {
+            values.add(mTypeInt[i], mValueInt[i]);
+        }
+        for (int i = 0; i < mCountFloat; i++) {
+            values.add(mTypeFloat[i], mValueFloat[i]);
+        }
+        for (int i = 0; i < mCountString; i++) {
+            values.add(mTypeString[i], mValueString[i]);
+        }
+        for (int i = 0; i < mCountBoolean; i++) {
+            values.add(mTypeBoolean[i], mValueBoolean[i]);
+        }
+    }
+
+    // @TODO: add description
+    public void clear() {
+        mCountBoolean = 0;
+        mCountString = 0;
+        mCountFloat = 0;
+        mCountInt = 0;
+    }
+
+    @Override
+    public String toString() {
+        return "TypedBundle{" +
+                "mCountInt=" + mCountInt +
+                ", mCountFloat=" + mCountFloat +
+                ", mCountString=" + mCountString +
+                ", mCountBoolean=" + mCountBoolean +
+                '}';
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TypedValues.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/TypedValues.java
@@ -1,0 +1,834 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * Provides an interface to values used in KeyFrames and in
+ * Starting and Ending Widgets
+ */
+public interface TypedValues {
+    String S_CUSTOM = "CUSTOM";
+    int BOOLEAN_MASK = 1;
+    int INT_MASK = 2;
+    int FLOAT_MASK = 4;
+    int STRING_MASK = 8;
+
+    /**
+     * Used to set integer values
+     *
+     * @return true if it accepted the value
+     */
+    boolean setValue(int id, int value);
+
+    /**
+     * Used to set float values
+     *
+     * @return true if it accepted the value
+     */
+    boolean setValue(int id, float value);
+
+    /**
+     * Used to set String values
+     *
+     * @return true if it accepted the value
+     */
+    boolean setValue(int id, String value);
+
+    /**
+     * Used to set boolean values
+     *
+     * @return true if it accepted the value
+     */
+    boolean setValue(int id, boolean value);
+
+    // @TODO: add description
+    int getId(String name);
+
+    int TYPE_FRAME_POSITION = 100;
+    int TYPE_TARGET = 101;
+
+    interface AttributesType {
+        String NAME = "KeyAttributes";
+
+        int TYPE_CURVE_FIT = 301;
+        int TYPE_VISIBILITY = 302;
+        int TYPE_ALPHA = 303;
+        int TYPE_TRANSLATION_X = 304;
+        int TYPE_TRANSLATION_Y = 305;
+        int TYPE_TRANSLATION_Z = 306;
+        int TYPE_ELEVATION = 307;
+        int TYPE_ROTATION_X = 308;
+        int TYPE_ROTATION_Y = 309;
+        int TYPE_ROTATION_Z = 310;
+        int TYPE_SCALE_X = 311;
+        int TYPE_SCALE_Y = 312;
+        int TYPE_PIVOT_X = 313;
+        int TYPE_PIVOT_Y = 314;
+        int TYPE_PROGRESS = 315;
+        int TYPE_PATH_ROTATE = 316;
+        int TYPE_EASING = 317;
+        int TYPE_PIVOT_TARGET = 318;
+
+        String S_CURVE_FIT = "curveFit";
+        String S_VISIBILITY = "visibility";
+        String S_ALPHA = "alpha";
+
+        String S_TRANSLATION_X = "translationX";
+        String S_TRANSLATION_Y = "translationY";
+        String S_TRANSLATION_Z = "translationZ";
+        String S_ELEVATION = "elevation";
+        String S_ROTATION_X = "rotationX";
+        String S_ROTATION_Y = "rotationY";
+        String S_ROTATION_Z = "rotationZ";
+        String S_SCALE_X = "scaleX";
+        String S_SCALE_Y = "scaleY";
+        String S_PIVOT_X = "pivotX";
+        String S_PIVOT_Y = "pivotY";
+        String S_PROGRESS = "progress";
+        String S_PATH_ROTATE = "pathRotate";
+        String S_EASING = "easing";
+        String S_CUSTOM = "CUSTOM";
+        String S_FRAME = "frame";
+        String S_TARGET = "target";
+        String S_PIVOT_TARGET = "pivotTarget";
+
+        String[] KEY_WORDS = {
+                S_CURVE_FIT,
+                S_VISIBILITY,
+                S_ALPHA,
+                S_TRANSLATION_X,
+                S_TRANSLATION_Y,
+                S_TRANSLATION_Z,
+                S_ELEVATION,
+                S_ROTATION_X,
+                S_ROTATION_Y,
+                S_ROTATION_Z,
+                S_SCALE_X,
+                S_SCALE_Y,
+                S_PIVOT_X,
+                S_PIVOT_Y,
+                S_PROGRESS,
+                S_PATH_ROTATE,
+                S_EASING,
+                S_CUSTOM,
+                S_FRAME,
+                S_TARGET,
+                S_PIVOT_TARGET,
+        };
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_CURVE_FIT:
+                    return TYPE_CURVE_FIT;
+                case S_VISIBILITY:
+                    return TYPE_VISIBILITY;
+                case S_ALPHA:
+                    return TYPE_ALPHA;
+                case S_TRANSLATION_X:
+                    return TYPE_TRANSLATION_X;
+                case S_TRANSLATION_Y:
+                    return TYPE_TRANSLATION_Y;
+                case S_TRANSLATION_Z:
+                    return TYPE_TRANSLATION_Z;
+                case S_ELEVATION:
+                    return TYPE_ELEVATION;
+                case S_ROTATION_X:
+                    return TYPE_ROTATION_X;
+                case S_ROTATION_Y:
+                    return TYPE_ROTATION_Y;
+                case S_ROTATION_Z:
+                    return TYPE_ROTATION_Z;
+                case S_SCALE_X:
+                    return TYPE_SCALE_X;
+                case S_SCALE_Y:
+                    return TYPE_SCALE_Y;
+                case S_PIVOT_X:
+                    return TYPE_PIVOT_X;
+                case S_PIVOT_Y:
+                    return TYPE_PIVOT_Y;
+                case S_PROGRESS:
+                    return TYPE_PROGRESS;
+                case S_PATH_ROTATE:
+                    return TYPE_PATH_ROTATE;
+                case S_EASING:
+                    return TYPE_EASING;
+                case S_FRAME:
+                    return TYPE_FRAME_POSITION;
+                case S_TARGET:
+                    return TYPE_TARGET;
+                case S_PIVOT_TARGET:
+                    return TYPE_PIVOT_TARGET;
+            }
+            return -1;
+        }
+
+        static int getType(int name) {
+            switch (name) {
+                case TYPE_CURVE_FIT:
+                case TYPE_VISIBILITY:
+                case TYPE_FRAME_POSITION:
+                    return INT_MASK;
+                case TYPE_ALPHA:
+                case TYPE_TRANSLATION_X:
+                case TYPE_TRANSLATION_Y:
+                case TYPE_TRANSLATION_Z:
+                case TYPE_ELEVATION:
+                case TYPE_ROTATION_X:
+                case TYPE_ROTATION_Y:
+                case TYPE_ROTATION_Z:
+                case TYPE_SCALE_X:
+                case TYPE_SCALE_Y:
+                case TYPE_PIVOT_X:
+                case TYPE_PIVOT_Y:
+                case TYPE_PROGRESS:
+                case TYPE_PATH_ROTATE:
+                    return FLOAT_MASK;
+                case TYPE_EASING:
+                case TYPE_TARGET:
+                case TYPE_PIVOT_TARGET:
+                    return STRING_MASK;
+            }
+            return -1;
+        }
+    }
+
+    interface CycleType {
+        String NAME = "KeyCycle";
+        int TYPE_CURVE_FIT = 401;
+        int TYPE_VISIBILITY = 402;
+        int TYPE_ALPHA = 403;
+        int TYPE_TRANSLATION_X = AttributesType.TYPE_TRANSLATION_X;
+        int TYPE_TRANSLATION_Y = AttributesType.TYPE_TRANSLATION_Y;
+        int TYPE_TRANSLATION_Z = AttributesType.TYPE_TRANSLATION_Z;
+        int TYPE_ELEVATION = AttributesType.TYPE_ELEVATION;
+
+        int TYPE_ROTATION_X = AttributesType.TYPE_ROTATION_X;
+        int TYPE_ROTATION_Y = AttributesType.TYPE_ROTATION_Y;
+        int TYPE_ROTATION_Z = AttributesType.TYPE_ROTATION_Z;
+        int TYPE_SCALE_X = AttributesType.TYPE_SCALE_X;
+        int TYPE_SCALE_Y = AttributesType.TYPE_SCALE_Y;
+        int TYPE_PIVOT_X = AttributesType.TYPE_PIVOT_X;
+        int TYPE_PIVOT_Y = AttributesType.TYPE_PIVOT_Y;
+        int TYPE_PROGRESS = AttributesType.TYPE_PROGRESS;
+        int TYPE_PATH_ROTATE = 416;
+        int TYPE_EASING = 420;
+        int TYPE_WAVE_SHAPE = 421;
+        int TYPE_CUSTOM_WAVE_SHAPE = 422;
+        int TYPE_WAVE_PERIOD = 423;
+        int TYPE_WAVE_OFFSET = 424;
+        int TYPE_WAVE_PHASE = 425;
+
+        String S_CURVE_FIT = "curveFit";
+        String S_VISIBILITY = "visibility";
+        String S_ALPHA = AttributesType.S_ALPHA;
+        String S_TRANSLATION_X = AttributesType.S_TRANSLATION_X;
+        String S_TRANSLATION_Y = AttributesType.S_TRANSLATION_Y;
+        String S_TRANSLATION_Z = AttributesType.S_TRANSLATION_Z;
+        String S_ELEVATION = AttributesType.S_ELEVATION;
+        String S_ROTATION_X = AttributesType.S_ROTATION_X;
+        String S_ROTATION_Y = AttributesType.S_ROTATION_Y;
+        String S_ROTATION_Z = AttributesType.S_ROTATION_Z;
+        String S_SCALE_X = AttributesType.S_SCALE_X;
+        String S_SCALE_Y = AttributesType.S_SCALE_Y;
+        String S_PIVOT_X = AttributesType.S_PIVOT_X;
+        String S_PIVOT_Y = AttributesType.S_PIVOT_Y;
+        String S_PROGRESS = AttributesType.S_PROGRESS;
+
+        String S_PATH_ROTATE = "pathRotate";
+        String S_EASING = "easing";
+        String S_WAVE_SHAPE = "waveShape";
+        String S_CUSTOM_WAVE_SHAPE = "customWave";
+        String S_WAVE_PERIOD = "period";
+        String S_WAVE_OFFSET = "offset";
+        String S_WAVE_PHASE = "phase";
+        String[] KEY_WORDS = {
+                S_CURVE_FIT,
+                S_VISIBILITY,
+                S_ALPHA,
+                S_TRANSLATION_X,
+                S_TRANSLATION_Y,
+                S_TRANSLATION_Z,
+                S_ELEVATION,
+                S_ROTATION_X,
+                S_ROTATION_Y,
+                S_ROTATION_Z,
+                S_SCALE_X,
+                S_SCALE_Y,
+                S_PIVOT_X,
+                S_PIVOT_Y,
+                S_PROGRESS,
+
+                S_PATH_ROTATE,
+                S_EASING,
+                S_WAVE_SHAPE,
+                S_CUSTOM_WAVE_SHAPE,
+                S_WAVE_PERIOD,
+                S_WAVE_OFFSET,
+                S_WAVE_PHASE,
+        };
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_CURVE_FIT:
+                    return TYPE_CURVE_FIT;
+                case S_VISIBILITY:
+                    return TYPE_VISIBILITY;
+                case S_ALPHA:
+                    return TYPE_ALPHA;
+                case S_TRANSLATION_X:
+                    return TYPE_TRANSLATION_X;
+                case S_TRANSLATION_Y:
+                    return TYPE_TRANSLATION_Y;
+                case S_TRANSLATION_Z:
+                    return TYPE_TRANSLATION_Z;
+                case S_ROTATION_X:
+                    return TYPE_ROTATION_X;
+                case S_ROTATION_Y:
+                    return TYPE_ROTATION_Y;
+                case S_ROTATION_Z:
+                    return TYPE_ROTATION_Z;
+                case S_SCALE_X:
+                    return TYPE_SCALE_X;
+                case S_SCALE_Y:
+                    return TYPE_SCALE_Y;
+                case S_PIVOT_X:
+                    return TYPE_PIVOT_X;
+                case S_PIVOT_Y:
+                    return TYPE_PIVOT_Y;
+                case S_PROGRESS:
+                    return TYPE_PROGRESS;
+                case S_PATH_ROTATE:
+                    return TYPE_PATH_ROTATE;
+                case S_EASING:
+                    return TYPE_EASING;
+            }
+            return -1;
+        }
+
+        static int getType(int name) {
+            switch (name) {
+                case TYPE_CURVE_FIT:
+                case TYPE_VISIBILITY:
+                case TYPE_FRAME_POSITION:
+                    return INT_MASK;
+                case TYPE_ALPHA:
+                case TYPE_TRANSLATION_X:
+                case TYPE_TRANSLATION_Y:
+                case TYPE_TRANSLATION_Z:
+                case TYPE_ELEVATION:
+                case TYPE_ROTATION_X:
+                case TYPE_ROTATION_Y:
+                case TYPE_ROTATION_Z:
+                case TYPE_SCALE_X:
+                case TYPE_SCALE_Y:
+                case TYPE_PIVOT_X:
+                case TYPE_PIVOT_Y:
+                case TYPE_PROGRESS:
+                case TYPE_PATH_ROTATE:
+                case TYPE_WAVE_PERIOD:
+                case TYPE_WAVE_OFFSET:
+                case TYPE_WAVE_PHASE:
+                    return FLOAT_MASK;
+                case TYPE_EASING:
+                case TYPE_TARGET:
+                case TYPE_WAVE_SHAPE:
+                    return STRING_MASK;
+            }
+            return -1;
+        }
+    }
+
+    interface TriggerType {
+        String NAME = "KeyTrigger";
+        String VIEW_TRANSITION_ON_CROSS = "viewTransitionOnCross";
+        String VIEW_TRANSITION_ON_POSITIVE_CROSS = "viewTransitionOnPositiveCross";
+        String VIEW_TRANSITION_ON_NEGATIVE_CROSS = "viewTransitionOnNegativeCross";
+        String POST_LAYOUT = "postLayout";
+        String TRIGGER_SLACK = "triggerSlack";
+        String TRIGGER_COLLISION_VIEW = "triggerCollisionView";
+        String TRIGGER_COLLISION_ID = "triggerCollisionId";
+        String TRIGGER_ID = "triggerID";
+        String POSITIVE_CROSS = "positiveCross";
+        String NEGATIVE_CROSS = "negativeCross";
+        String TRIGGER_RECEIVER = "triggerReceiver";
+        String CROSS = "CROSS";
+        String[] KEY_WORDS = {
+                VIEW_TRANSITION_ON_CROSS,
+                VIEW_TRANSITION_ON_POSITIVE_CROSS,
+                VIEW_TRANSITION_ON_NEGATIVE_CROSS,
+                POST_LAYOUT,
+                TRIGGER_SLACK,
+                TRIGGER_COLLISION_VIEW,
+                TRIGGER_COLLISION_ID,
+                TRIGGER_ID,
+                POSITIVE_CROSS,
+                NEGATIVE_CROSS,
+                TRIGGER_RECEIVER,
+                CROSS,
+        };
+        int TYPE_VIEW_TRANSITION_ON_CROSS = 301;
+        int TYPE_VIEW_TRANSITION_ON_POSITIVE_CROSS = 302;
+        int TYPE_VIEW_TRANSITION_ON_NEGATIVE_CROSS = 303;
+        int TYPE_POST_LAYOUT = 304;
+        int TYPE_TRIGGER_SLACK = 305;
+        int TYPE_TRIGGER_COLLISION_VIEW = 306;
+        int TYPE_TRIGGER_COLLISION_ID = 307;
+        int TYPE_TRIGGER_ID = 308;
+        int TYPE_POSITIVE_CROSS = 309;
+        int TYPE_NEGATIVE_CROSS = 310;
+        int TYPE_TRIGGER_RECEIVER = 311;
+        int TYPE_CROSS = 312;
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case VIEW_TRANSITION_ON_CROSS:
+                    return TYPE_VIEW_TRANSITION_ON_CROSS;
+                case VIEW_TRANSITION_ON_POSITIVE_CROSS:
+                    return TYPE_VIEW_TRANSITION_ON_POSITIVE_CROSS;
+                case VIEW_TRANSITION_ON_NEGATIVE_CROSS:
+                    return TYPE_VIEW_TRANSITION_ON_NEGATIVE_CROSS;
+                case POST_LAYOUT:
+                    return TYPE_POST_LAYOUT;
+                case TRIGGER_SLACK:
+                    return TYPE_TRIGGER_SLACK;
+                case TRIGGER_COLLISION_VIEW:
+                    return TYPE_TRIGGER_COLLISION_VIEW;
+                case TRIGGER_COLLISION_ID:
+                    return TYPE_TRIGGER_COLLISION_ID;
+                case TRIGGER_ID:
+                    return TYPE_TRIGGER_ID;
+                case POSITIVE_CROSS:
+                    return TYPE_POSITIVE_CROSS;
+                case NEGATIVE_CROSS:
+                    return TYPE_NEGATIVE_CROSS;
+                case TRIGGER_RECEIVER:
+                    return TYPE_TRIGGER_RECEIVER;
+                case CROSS:
+                    return TYPE_CROSS;
+            }
+            return -1;
+        }
+    }
+
+    interface PositionType {
+        String NAME = "KeyPosition";
+        String S_TRANSITION_EASING = "transitionEasing";
+        String S_DRAWPATH = "drawPath";
+        String S_PERCENT_WIDTH = "percentWidth";
+        String S_PERCENT_HEIGHT = "percentHeight";
+        String S_SIZE_PERCENT = "sizePercent";
+        String S_PERCENT_X = "percentX";
+        String S_PERCENT_Y = "percentY";
+
+        int TYPE_TRANSITION_EASING = 501;
+        int TYPE_DRAWPATH = 502;
+        int TYPE_PERCENT_WIDTH = 503;
+        int TYPE_PERCENT_HEIGHT = 504;
+        int TYPE_SIZE_PERCENT = 505;
+        int TYPE_PERCENT_X = 506;
+        int TYPE_PERCENT_Y = 507;
+        int TYPE_CURVE_FIT = 508;
+        int TYPE_PATH_MOTION_ARC = 509;
+        int TYPE_POSITION_TYPE = 510;
+        String[] KEY_WORDS = {
+                S_TRANSITION_EASING,
+                S_DRAWPATH,
+                S_PERCENT_WIDTH,
+                S_PERCENT_HEIGHT,
+                S_SIZE_PERCENT,
+                S_PERCENT_X,
+                S_PERCENT_Y,
+        };
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_TRANSITION_EASING:
+                    return PositionType.TYPE_TRANSITION_EASING;
+                case S_DRAWPATH:
+                    return PositionType.TYPE_DRAWPATH;
+                case S_PERCENT_WIDTH:
+                    return PositionType.TYPE_PERCENT_WIDTH;
+                case S_PERCENT_HEIGHT:
+                    return PositionType.TYPE_PERCENT_HEIGHT;
+                case S_SIZE_PERCENT:
+                    return PositionType.TYPE_SIZE_PERCENT;
+                case S_PERCENT_X:
+                    return PositionType.TYPE_PERCENT_X;
+                case S_PERCENT_Y:
+                    return PositionType.TYPE_PERCENT_Y;
+            }
+            return -1;
+        }
+
+        static int getType(int name) {
+            switch (name) {
+                case TYPE_CURVE_FIT:
+                case TYPE_FRAME_POSITION:
+                    return INT_MASK;
+                case TYPE_PERCENT_WIDTH:
+                case TYPE_PERCENT_HEIGHT:
+                case TYPE_SIZE_PERCENT:
+                case TYPE_PERCENT_X:
+                case TYPE_PERCENT_Y:
+                    return FLOAT_MASK;
+                case TYPE_TRANSITION_EASING:
+                case TYPE_TARGET:
+                case TYPE_DRAWPATH:
+                    return STRING_MASK;
+            }
+            return -1;
+        }
+
+
+    }
+
+    interface MotionType {
+        String NAME = "Motion";
+
+        String S_STAGGER = "Stagger";
+        String S_PATH_ROTATE = "PathRotate";
+        String S_QUANTIZE_MOTION_PHASE = "QuantizeMotionPhase";
+        String S_EASING = "TransitionEasing";
+        String S_QUANTIZE_INTERPOLATOR = "QuantizeInterpolator";
+        String S_ANIMATE_RELATIVE_TO = "AnimateRelativeTo";
+        String S_ANIMATE_CIRCLEANGLE_TO = "AnimateCircleAngleTo";
+        String S_PATHMOTION_ARC = "PathMotionArc";
+        String S_DRAW_PATH = "DrawPath";
+        String S_POLAR_RELATIVETO = "PolarRelativeTo";
+        String S_QUANTIZE_MOTIONSTEPS = "QuantizeMotionSteps";
+        String S_QUANTIZE_INTERPOLATOR_TYPE = "QuantizeInterpolatorType";
+        String S_QUANTIZE_INTERPOLATOR_ID = "QuantizeInterpolatorID";
+        String[] KEY_WORDS = {
+                S_STAGGER,
+                S_PATH_ROTATE,
+                S_QUANTIZE_MOTION_PHASE,
+                S_EASING,
+                S_QUANTIZE_INTERPOLATOR,
+                S_ANIMATE_RELATIVE_TO,
+                S_ANIMATE_CIRCLEANGLE_TO,
+                S_PATHMOTION_ARC,
+                S_DRAW_PATH,
+                S_POLAR_RELATIVETO,
+                S_QUANTIZE_MOTIONSTEPS,
+                S_QUANTIZE_INTERPOLATOR_TYPE,
+                S_QUANTIZE_INTERPOLATOR_ID,
+        };
+        int TYPE_STAGGER = 600;
+        int TYPE_PATH_ROTATE = 601;
+        int TYPE_QUANTIZE_MOTION_PHASE = 602;
+        int TYPE_EASING = 603;
+        int TYPE_QUANTIZE_INTERPOLATOR = 604;
+        int TYPE_ANIMATE_RELATIVE_TO = 605;
+        int TYPE_ANIMATE_CIRCLEANGLE_TO = 606;
+        int TYPE_PATHMOTION_ARC = 607;
+        int TYPE_DRAW_PATH = 608;
+        int TYPE_POLAR_RELATIVETO = 609;
+        int TYPE_QUANTIZE_MOTIONSTEPS = 610;
+        int TYPE_QUANTIZE_INTERPOLATOR_TYPE = 611;
+        int TYPE_QUANTIZE_INTERPOLATOR_ID = 612;
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_STAGGER:
+                    return TYPE_STAGGER;
+                case S_PATH_ROTATE:
+                    return TYPE_PATH_ROTATE;
+                case S_QUANTIZE_MOTION_PHASE:
+                    return TYPE_QUANTIZE_MOTION_PHASE;
+                case S_EASING:
+                    return TYPE_EASING;
+                case S_QUANTIZE_INTERPOLATOR:
+                    return TYPE_QUANTIZE_INTERPOLATOR;
+                case S_ANIMATE_RELATIVE_TO:
+                    return TYPE_ANIMATE_RELATIVE_TO;
+                case S_ANIMATE_CIRCLEANGLE_TO:
+                    return TYPE_ANIMATE_CIRCLEANGLE_TO;
+                case S_PATHMOTION_ARC:
+                    return TYPE_PATHMOTION_ARC;
+                case S_DRAW_PATH:
+                    return TYPE_DRAW_PATH;
+                case S_POLAR_RELATIVETO:
+                    return TYPE_POLAR_RELATIVETO;
+                case S_QUANTIZE_MOTIONSTEPS:
+                    return TYPE_QUANTIZE_MOTIONSTEPS;
+                case S_QUANTIZE_INTERPOLATOR_TYPE:
+                    return TYPE_QUANTIZE_INTERPOLATOR_TYPE;
+                case S_QUANTIZE_INTERPOLATOR_ID:
+                    return TYPE_QUANTIZE_INTERPOLATOR_ID;
+            }
+            return -1;
+        }
+
+    }
+
+    interface Custom {
+        String NAME = "Custom";
+        String S_INT = "integer";
+        String S_FLOAT = "float";
+        String S_COLOR = "color";
+        String S_STRING = "string";
+        String S_BOOLEAN = "boolean";
+        String S_DIMENSION = "dimension";
+        String S_REFERENCE = "reference";
+        String[] KEY_WORDS = {
+                S_FLOAT,
+                S_COLOR,
+                S_STRING,
+                S_BOOLEAN,
+                S_DIMENSION,
+                S_REFERENCE,
+        };
+        int TYPE_INT = 900;
+        int TYPE_FLOAT = 901;
+        int TYPE_COLOR = 902;
+        int TYPE_STRING = 903;
+        int TYPE_BOOLEAN = 904;
+        int TYPE_DIMENSION = 905;
+        int TYPE_REFERENCE = 906;
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_INT:
+                    return TYPE_INT;
+                case S_FLOAT:
+                    return TYPE_FLOAT;
+                case S_COLOR:
+                    return TYPE_COLOR;
+                case S_STRING:
+                    return TYPE_STRING;
+                case S_BOOLEAN:
+                    return TYPE_BOOLEAN;
+                case S_DIMENSION:
+                    return TYPE_DIMENSION;
+                case S_REFERENCE:
+                    return TYPE_REFERENCE;
+            }
+            return -1;
+        }
+    }
+
+    interface MotionScene {
+        String NAME = "MotionScene";
+        String S_DEFAULT_DURATION = "defaultDuration";
+        String S_LAYOUT_DURING_TRANSITION = "layoutDuringTransition";
+        int TYPE_DEFAULT_DURATION = 600;
+        int TYPE_LAYOUT_DURING_TRANSITION = 601;
+
+        String[] KEY_WORDS = {
+                S_DEFAULT_DURATION,
+                S_LAYOUT_DURING_TRANSITION,
+        };
+
+        static int getType(int name) {
+            switch (name) {
+                case TYPE_DEFAULT_DURATION:
+                    return INT_MASK;
+                case TYPE_LAYOUT_DURING_TRANSITION:
+                    return BOOLEAN_MASK;
+            }
+            return -1;
+        }
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_DEFAULT_DURATION:
+                    return TYPE_DEFAULT_DURATION;
+                case S_LAYOUT_DURING_TRANSITION:
+                    return TYPE_LAYOUT_DURING_TRANSITION;
+            }
+            return -1;
+        }
+    }
+
+    interface TransitionType {
+        String NAME = "Transitions";
+        String S_DURATION = "duration";
+        String S_FROM = "from";
+        String S_TO = "to";
+        String S_PATH_MOTION_ARC = "pathMotionArc";
+        String S_AUTO_TRANSITION = "autoTransition";
+        String S_INTERPOLATOR = "motionInterpolator";
+        String S_STAGGERED = "staggered";
+        String S_TRANSITION_FLAGS = "transitionFlags";
+
+        int TYPE_DURATION = 700;
+        int TYPE_FROM = 701;
+        int TYPE_TO = 702;
+        int TYPE_PATH_MOTION_ARC = PositionType.TYPE_PATH_MOTION_ARC;
+        int TYPE_AUTO_TRANSITION = 704;
+        int TYPE_INTERPOLATOR = 705;
+        int TYPE_STAGGERED = 706;
+        int TYPE_TRANSITION_FLAGS = 707;
+
+
+        String[] KEY_WORDS = {
+                S_DURATION,
+                S_FROM,
+                S_TO,
+                S_PATH_MOTION_ARC,
+                S_AUTO_TRANSITION,
+                S_INTERPOLATOR,
+                S_STAGGERED,
+                S_FROM,
+                S_TRANSITION_FLAGS,
+        };
+
+        static int getType(int name) {
+            switch (name) {
+                case TYPE_DURATION:
+                case TYPE_PATH_MOTION_ARC:
+                    return INT_MASK;
+                case TYPE_FROM:
+                case TYPE_TO:
+                case TYPE_INTERPOLATOR:
+                case TYPE_TRANSITION_FLAGS:
+                    return STRING_MASK;
+
+                case TYPE_STAGGERED:
+                    return FLOAT_MASK;
+            }
+            return -1;
+        }
+
+        /**
+         * Method to go from String names of values to id of the values
+         * IDs are use for efficiency
+         *
+         * @param name the name of the value
+         * @return the id of the vlalue or -1 if no value exist
+         */
+        static int getId(String name) {
+            switch (name) {
+                case S_DURATION:
+                    return TYPE_DURATION;
+                case S_FROM:
+                    return TYPE_FROM;
+                case S_TO:
+                    return TYPE_TO;
+                case S_PATH_MOTION_ARC:
+                    return TYPE_PATH_MOTION_ARC;
+                case S_AUTO_TRANSITION:
+                    return TYPE_AUTO_TRANSITION;
+                case S_INTERPOLATOR:
+                    return TYPE_INTERPOLATOR;
+                case S_STAGGERED:
+                    return TYPE_STAGGERED;
+                case S_TRANSITION_FLAGS:
+                    return TYPE_TRANSITION_FLAGS;
+            }
+            return -1;
+        }
+    }
+
+    interface OnSwipe {
+        String DRAG_SCALE = "dragscale";
+        String DRAG_THRESHOLD = "dragthreshold";
+
+        String MAX_VELOCITY = "maxvelocity";
+        String MAX_ACCELERATION = "maxacceleration";
+        String SPRING_MASS = "springmass";
+        String SPRING_STIFFNESS = "springstiffness";
+        String SPRING_DAMPING = "springdamping";
+        String SPRINGS_TOP_THRESHOLD = "springstopthreshold";
+
+        String DRAG_DIRECTION = "dragdirection";
+        String TOUCH_ANCHOR_ID = "touchanchorid";
+        String TOUCH_ANCHOR_SIDE = "touchanchorside";
+        String ROTATION_CENTER_ID = "rotationcenterid";
+        String TOUCH_REGION_ID = "touchregionid";
+        String LIMIT_BOUNDS_TO = "limitboundsto";
+
+        String MOVE_WHEN_SCROLLAT_TOP = "movewhenscrollattop";
+        String ON_TOUCH_UP = "ontouchup";
+        String[] ON_TOUCH_UP_ENUM = {"autoComplete",
+                "autoCompleteToStart",
+                "autoCompleteToEnd",
+                "stop",
+                "decelerate",
+                "decelerateAndComplete",
+                "neverCompleteToStart",
+                "neverCompleteToEnd"};
+
+
+        String SPRING_BOUNDARY = "springboundary";
+        String[] SPRING_BOUNDARY_ENUM = {"overshoot",
+                "bounceStart",
+                "bounceEnd",
+                "bounceBoth"};
+
+        String AUTOCOMPLETE_MODE = "autocompletemode";
+        String[] AUTOCOMPLETE_MODE_ENUM = {
+                "continuousVelocity",
+                "spring"};
+
+        String NESTED_SCROLL_FLAGS = "nestedscrollflags";
+        String[] NESTED_SCROLL_FLAGS_ENUM = {"none",
+                "disablePostScroll",
+                "disableScroll",
+                "supportScrollUp"};
+
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Utils.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/Utils.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Arrays;
+
+public class Utils {
+    // @TODO: add description
+    public static void log(String tag, String value) {
+        System.out.println(tag + " : " + value);
+    }
+
+    // @TODO: add description
+    public static void loge(String tag, String value) {
+        System.err.println(tag + " : " + value);
+    }
+
+    // @TODO: add description
+    public static void socketSend(String str) {
+        try {
+            Socket socket = new Socket("127.0.0.1", 5327);
+            OutputStream out = socket.getOutputStream();
+            out.write(str.getBytes());
+            out.close();
+        } catch (IOException e) {
+            //TODO replace with something not equal to printStackTrace();
+            System.err.println(e.toString()+"\n"+ Arrays.toString(e.getStackTrace())
+                    .replace("[","   at ")
+                    .replace(",","\n   at")
+                    .replace("]",""));
+        }
+    }
+
+    private static int clamp(int c) {
+        int n = 255;
+        c &= ~(c >> 31);
+        c -= n;
+        c &= (c >> 31);
+        c += n;
+        return c;
+    }
+
+    // @TODO: add description
+    public int getInterpolatedColor(float[] value) {
+        int r = clamp((int) ((float) Math.pow(value[0], 1.0 / 2.2) * 255.0f));
+        int g = clamp((int) ((float) Math.pow(value[1], 1.0 / 2.2) * 255.0f));
+        int b = clamp((int) ((float) Math.pow(value[2], 1.0 / 2.2) * 255.0f));
+        int a = clamp((int) (value[3] * 255.0f));
+        int color = (a << 24) | (r << 16) | (g << 8) | b;
+        return color;
+    }
+
+    // @TODO: add description
+    public static int rgbaTocColor(float r, float g, float b, float a) {
+        int ir = clamp((int) (r * 255f));
+        int ig = clamp((int) (g * 255f));
+        int ib = clamp((int) (b * 255f));
+        int ia = clamp((int) (a * 255f));
+        int color = (ia << 24) | (ir << 16) | (ig << 8) | ib;
+        return color;
+    }
+
+    public interface DebugHandle {
+        // @TODO: add description
+        void message(String str);
+    }
+
+    static DebugHandle sOurHandle;
+
+    public static void setDebugHandle(DebugHandle handle) {
+        sOurHandle = handle;
+    }
+
+    // @TODO: add description
+    public static void logStack(String msg, int n) {
+        StackTraceElement[] st = new Throwable().getStackTrace();
+        String s = " ";
+        n = Math.min(n, st.length - 1);
+        for (int i = 1; i <= n; i++) {
+            StackTraceElement ste = st[i];
+            String stack = ".(" + ste.getFileName() + ":"
+                    + ste.getLineNumber() + ") " + ste.getMethodName();
+            s += " ";
+            System.out.println(msg + s + stack + s);
+        }
+    }
+
+    // @TODO: add description
+    public static void log(String str) {
+        StackTraceElement s = new Throwable().getStackTrace()[1];
+        String methodName = s.getMethodName();
+        methodName = (methodName + "                  ").substring(0, 17);
+        String npad = "    ".substring(Integer.toString(s.getLineNumber()).length());
+        String ss = ".(" + s.getFileName() + ":" + s.getLineNumber() + ")" + npad + methodName;
+        System.out.println(ss + " " + str);
+        if (sOurHandle != null) {
+            sOurHandle.message(ss + " " + str);
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/VelocityMatrix.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/VelocityMatrix.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.motion.utils;
+
+/**
+ * This is used to calculate the related velocity matrix for a post layout matrix
+ *
+ *
+ */
+public class VelocityMatrix {
+    float mDScaleX, mDScaleY, mDTranslateX, mDTranslateY, mDRotate;
+    float mRotate;
+    @SuppressWarnings("unused") private static String sTag = "VelocityMatrix";
+
+    // @TODO: add description
+    public void clear() {
+        mDScaleX = mDScaleY = mDTranslateX = mDTranslateY = mDRotate = 0;
+    }
+
+    // @TODO: add description
+    public void setRotationVelocity(SplineSet rot, float position) {
+        if (rot != null) {
+            mDRotate = rot.getSlope(position);
+            mRotate = rot.get(position);
+        }
+    }
+
+    // @TODO: add description
+    public void setTranslationVelocity(SplineSet transX, SplineSet transY, float position) {
+
+        if (transX != null) {
+            mDTranslateX = transX.getSlope(position);
+        }
+        if (transY != null) {
+            mDTranslateY = transY.getSlope(position);
+        }
+    }
+
+    // @TODO: add description
+    public void setScaleVelocity(SplineSet scaleX, SplineSet scaleY, float position) {
+
+        if (scaleX != null) {
+            mDScaleX = scaleX.getSlope(position);
+        }
+        if (scaleY != null) {
+            mDScaleY = scaleY.getSlope(position);
+        }
+    }
+
+    // @TODO: add description
+    public void setRotationVelocity(KeyCycleOscillator oscR, float position) {
+        if (oscR != null) {
+            mDRotate = oscR.getSlope(position);
+        }
+    }
+
+    // @TODO: add description
+    public void setTranslationVelocity(KeyCycleOscillator oscX,
+            KeyCycleOscillator oscY,
+            float position) {
+
+        if (oscX != null) {
+            mDTranslateX = oscX.getSlope(position);
+        }
+
+        if (oscY != null) {
+            mDTranslateY = oscY.getSlope(position);
+        }
+    }
+
+    // @TODO: add description
+    public void setScaleVelocity(KeyCycleOscillator oscSx,
+            KeyCycleOscillator oscSy,
+            float position) {
+        if (oscSx != null) {
+            mDScaleX = oscSx.getSlope(position);
+        }
+        if (oscSy != null) {
+            mDScaleY = oscSy.getSlope(position);
+        }
+    }
+
+    /**
+     * Apply the transform a velocity vector
+     *
+     *
+     */
+    public void applyTransform(float locationX,
+            float locationY,
+            int width,
+            int height,
+            float[] mAnchorDpDt) {
+        float dx = mAnchorDpDt[0];
+        float dy = mAnchorDpDt[1];
+        float offx = 2 * (locationX - 0.5f);
+        float offy = 2 * (locationY - 0.5f);
+        dx += mDTranslateX;
+        dy += mDTranslateY;
+        dx += offx * mDScaleX;
+        dy += offy * mDScaleY;
+        float r = (float) Math.toRadians(mRotate);
+        float dr = (float) Math.toRadians(mDRotate);
+        dx += dr * (float) (-width * offx * Math.sin(r) - height * offy * Math.cos(r));
+        dy += dr * (float) (width * offx * Math.cos(r) - height * offy * Math.sin(r));
+        mAnchorDpDt[0] = dx;
+        mAnchorDpDt[1] = dy;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/ViewState.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/motion/utils/ViewState.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.motion.utils;
+
+import androidx.constraintlayout.core.motion.MotionWidget;
+
+public class ViewState {
+    public float rotation;
+    public int left, top, right, bottom;
+
+    // @TODO: add description
+    public void getState(MotionWidget v) {
+        left = (int) v.getLeft();
+        top = (int) v.getTop();
+        right = (int) v.getRight();
+        bottom = (int) v.getBottom();
+        rotation = (int) v.getRotationZ();
+    }
+
+    // @TODO: add description
+    public int width() {
+        return right - left;
+    }
+
+    // @TODO: add description
+    public int height() {
+        return bottom - top;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/ConstraintReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/ConstraintReference.java
@@ -1,0 +1,1180 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.state.helpers.Facade;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ConstraintReference implements Reference {
+
+    private Object mKey;
+
+    @Override
+    public void setKey(Object key) {
+        this.mKey = key;
+    }
+
+    @Override
+    public Object getKey() {
+        return mKey;
+    }
+
+    public void setTag(String tag) {
+        mTag = tag;
+    }
+
+    public String getTag() {
+        return mTag;
+    }
+
+    public interface ConstraintReferenceFactory {
+        // @TODO: add description
+        ConstraintReference create(State state);
+    }
+
+    final State mState;
+
+    String mTag = null;
+
+    Facade mFacade = null;
+
+    int mHorizontalChainStyle = ConstraintWidget.CHAIN_SPREAD;
+    int mVerticalChainStyle = ConstraintWidget.CHAIN_SPREAD;
+
+    float mHorizontalChainWeight = UNKNOWN;
+    float mVerticalChainWeight = UNKNOWN;
+
+    protected float mHorizontalBias = 0.5f;
+    protected float mVerticalBias = 0.5f;
+
+    protected int mMarginLeft = 0;
+    protected int mMarginRight = 0;
+    protected int mMarginStart = 0;
+    protected int mMarginEnd = 0;
+    protected int mMarginTop = 0;
+    protected int mMarginBottom = 0;
+
+    protected int mMarginLeftGone = 0;
+    protected int mMarginRightGone = 0;
+    protected int mMarginStartGone = 0;
+    protected int mMarginEndGone = 0;
+    protected int mMarginTopGone = 0;
+    protected int mMarginBottomGone = 0;
+
+    int mMarginBaseline = 0;
+    int mMarginBaselineGone = 0;
+
+    float mPivotX = Float.NaN;
+    float mPivotY = Float.NaN;
+
+    float mRotationX = Float.NaN;
+    float mRotationY = Float.NaN;
+    float mRotationZ = Float.NaN;
+
+    float mTranslationX = Float.NaN;
+    float mTranslationY = Float.NaN;
+    float mTranslationZ = Float.NaN;
+
+    float mAlpha = Float.NaN;
+
+    float mScaleX = Float.NaN;
+    float mScaleY = Float.NaN;
+
+    int mVisibility = ConstraintWidget.VISIBLE;
+
+    protected Object mLeftToLeft = null;
+    protected Object mLeftToRight = null;
+    protected Object mRightToLeft = null;
+    protected Object mRightToRight = null;
+    protected Object mStartToStart = null;
+    protected Object mStartToEnd = null;
+    protected Object mEndToStart = null;
+    protected Object mEndToEnd = null;
+    protected Object mTopToTop = null;
+    protected Object mTopToBottom = null;
+    @Nullable Object mTopToBaseline = null;
+    protected Object mBottomToTop = null;
+    protected Object mBottomToBottom = null;
+    @Nullable Object mBottomToBaseline = null;
+    Object mBaselineToBaseline = null;
+    Object mBaselineToTop = null;
+    Object mBaselineToBottom = null;
+    Object mCircularConstraint = null;
+    private float mCircularAngle;
+    private float mCircularDistance;
+
+    State.Constraint mLast = null;
+
+    Dimension mHorizontalDimension = Dimension.createFixed(Dimension.WRAP_DIMENSION);
+    Dimension mVerticalDimension = Dimension.createFixed(Dimension.WRAP_DIMENSION);
+
+    private Object mView;
+    private ConstraintWidget mConstraintWidget;
+
+    private HashMap<String, Integer> mCustomColors = new HashMap<>();
+    private HashMap<String, Float> mCustomFloats = new HashMap<>();
+
+    TypedBundle mMotionProperties = null;
+
+    // @TODO: add description
+    public void setView(Object view) {
+        mView = view;
+        if (mConstraintWidget != null) {
+            mConstraintWidget.setCompanionWidget(mView);
+        }
+    }
+
+    public Object getView() {
+        return mView;
+    }
+
+    // @TODO: add description
+    public void setFacade(Facade facade) {
+        mFacade = facade;
+        if (facade != null) {
+            setConstraintWidget(facade.getConstraintWidget());
+        }
+    }
+
+    @Override
+    public Facade getFacade() {
+        return mFacade;
+    }
+
+    // @TODO: add description
+    @Override
+    public void setConstraintWidget(ConstraintWidget widget) {
+        if (widget == null) {
+            return;
+        }
+        mConstraintWidget = widget;
+        mConstraintWidget.setCompanionWidget(mView);
+    }
+
+    @Override
+    public ConstraintWidget getConstraintWidget() {
+        if (mConstraintWidget == null) {
+            mConstraintWidget = createConstraintWidget();
+            mConstraintWidget.setCompanionWidget(mView);
+        }
+        return mConstraintWidget;
+    }
+
+    // @TODO: add description
+    public ConstraintWidget createConstraintWidget() {
+        return new ConstraintWidget(
+                getWidth().getValue(),
+                getHeight().getValue());
+    }
+
+    static class IncorrectConstraintException extends Exception {
+
+        private final ArrayList<String> mErrors;
+
+        IncorrectConstraintException(ArrayList<String> errors) {
+            mErrors = errors;
+        }
+
+        public ArrayList<String> getErrors() {
+            return mErrors;
+        }
+
+        @Override
+        public String  getMessage() { return toString(); }
+
+        @Override
+        public String toString() {
+            return "IncorrectConstraintException: " + mErrors.toString();
+        }
+    }
+
+    /**
+     * Validate the constraints
+     */
+    public void validate() throws IncorrectConstraintException {
+        ArrayList<String> errors = new ArrayList<>();
+        if (mLeftToLeft != null && mLeftToRight != null) {
+            errors.add("LeftToLeft and LeftToRight both defined");
+        }
+        if (mRightToLeft != null && mRightToRight != null) {
+            errors.add("RightToLeft and RightToRight both defined");
+        }
+        if (mStartToStart != null && mStartToEnd != null) {
+            errors.add("StartToStart and StartToEnd both defined");
+        }
+        if (mEndToStart != null && mEndToEnd != null) {
+            errors.add("EndToStart and EndToEnd both defined");
+        }
+        if ((mLeftToLeft != null || mLeftToRight != null
+                || mRightToLeft != null || mRightToRight != null)
+                && (mStartToStart != null || mStartToEnd != null
+                || mEndToStart != null || mEndToEnd != null)) {
+            errors.add("Both left/right and start/end constraints defined");
+        }
+        if (errors.size() > 0) {
+            throw new IncorrectConstraintException(errors);
+        }
+    }
+
+    private Object get(Object reference) {
+        if (reference == null) {
+            return null;
+        }
+        if (!(reference instanceof ConstraintReference)) {
+            return mState.reference(reference);
+        }
+        return reference;
+    }
+
+    public ConstraintReference(State state) {
+        mState = state;
+    }
+
+    public void setHorizontalChainStyle(int chainStyle) {
+        mHorizontalChainStyle = chainStyle;
+    }
+
+    public int getHorizontalChainStyle() {
+        return mHorizontalChainStyle;
+    }
+
+    public void setVerticalChainStyle(int chainStyle) {
+        mVerticalChainStyle = chainStyle;
+    }
+
+    // @TODO: add description
+    public int getVerticalChainStyle(int chainStyle) {
+        return mVerticalChainStyle;
+    }
+
+    public float getHorizontalChainWeight() {
+        return mHorizontalChainWeight;
+    }
+
+    public void setHorizontalChainWeight(float weight) {
+        mHorizontalChainWeight = weight;
+    }
+
+    public float getVerticalChainWeight() {
+        return mVerticalChainWeight;
+    }
+
+    public void setVerticalChainWeight(float weight) {
+        mVerticalChainWeight = weight;
+    }
+
+    // @TODO: add description
+    public ConstraintReference clearVertical() {
+        top().clear();
+        baseline().clear();
+        bottom().clear();
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference clearHorizontal() {
+        start().clear();
+        end().clear();
+        left().clear();
+        right().clear();
+        return this;
+    }
+
+    public float getTranslationX() {
+        return mTranslationX;
+    }
+
+    public float getTranslationY() {
+        return mTranslationY;
+    }
+
+    public float getTranslationZ() {
+        return mTranslationZ;
+    }
+
+    public float getScaleX() {
+        return mScaleX;
+    }
+
+    public float getScaleY() {
+        return mScaleY;
+    }
+
+    public float getAlpha() {
+        return mAlpha;
+    }
+
+    public float getPivotX() {
+        return mPivotX;
+    }
+
+    public float getPivotY() {
+        return mPivotY;
+    }
+
+    public float getRotationX() {
+        return mRotationX;
+    }
+
+    public float getRotationY() {
+        return mRotationY;
+    }
+
+    public float getRotationZ() {
+        return mRotationZ;
+    }
+
+    // @TODO: add description
+    public ConstraintReference pivotX(float x) {
+        mPivotX = x;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference pivotY(float y) {
+        mPivotY = y;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference rotationX(float x) {
+        mRotationX = x;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference rotationY(float y) {
+        mRotationY = y;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference rotationZ(float z) {
+        mRotationZ = z;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference translationX(float x) {
+        mTranslationX = x;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference translationY(float y) {
+        mTranslationY = y;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference translationZ(float z) {
+        mTranslationZ = z;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference scaleX(float x) {
+        mScaleX = x;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference scaleY(float y) {
+        mScaleY = y;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference alpha(float alpha) {
+        mAlpha = alpha;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference visibility(int visibility) {
+        mVisibility = visibility;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference left() {
+        if (mLeftToLeft != null) {
+            mLast = State.Constraint.LEFT_TO_LEFT;
+        } else {
+            mLast = State.Constraint.LEFT_TO_RIGHT;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference right() {
+        if (mRightToLeft != null) {
+            mLast = State.Constraint.RIGHT_TO_LEFT;
+        } else {
+            mLast = State.Constraint.RIGHT_TO_RIGHT;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference start() {
+        if (mStartToStart != null) {
+            mLast = State.Constraint.START_TO_START;
+        } else {
+            mLast = State.Constraint.START_TO_END;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference end() {
+        if (mEndToStart != null) {
+            mLast = State.Constraint.END_TO_START;
+        } else {
+            mLast = State.Constraint.END_TO_END;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference top() {
+        if (mTopToTop != null) {
+            mLast = State.Constraint.TOP_TO_TOP;
+        } else {
+            mLast = State.Constraint.TOP_TO_BOTTOM;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference bottom() {
+        if (mBottomToTop != null) {
+            mLast = State.Constraint.BOTTOM_TO_TOP;
+        } else {
+            mLast = State.Constraint.BOTTOM_TO_BOTTOM;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference baseline() {
+        mLast = State.Constraint.BASELINE_TO_BASELINE;
+        return this;
+    }
+
+    // @TODO: add description
+    public void addCustomColor(String name, int color) {
+        mCustomColors.put(name, color);
+    }
+
+    // @TODO: add description
+    public void addCustomFloat(String name, float value) {
+        if (mCustomFloats == null) {
+            mCustomFloats = new HashMap<>();
+        }
+        mCustomFloats.put(name, value);
+    }
+
+    private void dereference() {
+        mLeftToLeft = get(mLeftToLeft);
+        mLeftToRight = get(mLeftToRight);
+        mRightToLeft = get(mRightToLeft);
+        mRightToRight = get(mRightToRight);
+        mStartToStart = get(mStartToStart);
+        mStartToEnd = get(mStartToEnd);
+        mEndToStart = get(mEndToStart);
+        mEndToEnd = get(mEndToEnd);
+        mTopToTop = get(mTopToTop);
+        mTopToBottom = get(mTopToBottom);
+        mBottomToTop = get(mBottomToTop);
+        mBottomToBottom = get(mBottomToBottom);
+        mBaselineToBaseline = get(mBaselineToBaseline);
+        mBaselineToTop = get(mBaselineToTop);
+        mBaselineToBottom = get(mBaselineToBottom);
+    }
+
+    // @TODO: add description
+    public ConstraintReference leftToLeft(Object reference) {
+        mLast = State.Constraint.LEFT_TO_LEFT;
+        mLeftToLeft = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference leftToRight(Object reference) {
+        mLast = State.Constraint.LEFT_TO_RIGHT;
+        mLeftToRight = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference rightToLeft(Object reference) {
+        mLast = State.Constraint.RIGHT_TO_LEFT;
+        mRightToLeft = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference rightToRight(Object reference) {
+        mLast = State.Constraint.RIGHT_TO_RIGHT;
+        mRightToRight = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference startToStart(Object reference) {
+        mLast = State.Constraint.START_TO_START;
+        mStartToStart = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference startToEnd(Object reference) {
+        mLast = State.Constraint.START_TO_END;
+        mStartToEnd = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference endToStart(Object reference) {
+        mLast = State.Constraint.END_TO_START;
+        mEndToStart = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference endToEnd(Object reference) {
+        mLast = State.Constraint.END_TO_END;
+        mEndToEnd = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference topToTop(Object reference) {
+        mLast = State.Constraint.TOP_TO_TOP;
+        mTopToTop = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference topToBottom(Object reference) {
+        mLast = State.Constraint.TOP_TO_BOTTOM;
+        mTopToBottom = reference;
+        return this;
+    }
+
+    ConstraintReference topToBaseline(Object reference) {
+        mLast = State.Constraint.TOP_TO_BASELINE;
+        mTopToBaseline = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference bottomToTop(Object reference) {
+        mLast = State.Constraint.BOTTOM_TO_TOP;
+        mBottomToTop = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference bottomToBottom(Object reference) {
+        mLast = State.Constraint.BOTTOM_TO_BOTTOM;
+        mBottomToBottom = reference;
+        return this;
+    }
+
+    ConstraintReference bottomToBaseline(Object reference) {
+        mLast = State.Constraint.BOTTOM_TO_BASELINE;
+        mBottomToBaseline = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference baselineToBaseline(Object reference) {
+        mLast = State.Constraint.BASELINE_TO_BASELINE;
+        mBaselineToBaseline = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference baselineToTop(Object reference) {
+        mLast = State.Constraint.BASELINE_TO_TOP;
+        mBaselineToTop = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference baselineToBottom(Object reference) {
+        mLast = State.Constraint.BASELINE_TO_BOTTOM;
+        mBaselineToBottom = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference centerHorizontally(Object reference) {
+        Object ref = get(reference);
+        mStartToStart = ref;
+        mEndToEnd = ref;
+        mLast = State.Constraint.CENTER_HORIZONTALLY;
+        mHorizontalBias = 0.5f;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference centerVertically(Object reference) {
+        Object ref = get(reference);
+        mTopToTop = ref;
+        mBottomToBottom = ref;
+        mLast = State.Constraint.CENTER_VERTICALLY;
+        mVerticalBias = 0.5f;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference circularConstraint(Object reference, float angle, float distance) {
+        Object ref = get(reference);
+        mCircularConstraint = ref;
+        mCircularAngle = angle;
+        mCircularDistance = distance;
+        mLast = State.Constraint.CIRCULAR_CONSTRAINT;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference width(Dimension dimension) {
+        return setWidth(dimension);
+    }
+
+    // @TODO: add description
+    public ConstraintReference height(Dimension dimension) {
+        return setHeight(dimension);
+    }
+
+    public Dimension getWidth() {
+        return mHorizontalDimension;
+    }
+
+    // @TODO: add description
+    public ConstraintReference setWidth(Dimension dimension) {
+        mHorizontalDimension = dimension;
+        return this;
+    }
+
+    public Dimension getHeight() {
+        return mVerticalDimension;
+    }
+
+    // @TODO: add description
+    public ConstraintReference setHeight(Dimension dimension) {
+        mVerticalDimension = dimension;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference margin(Object marginValue) {
+        return margin(mState.convertDimension(marginValue));
+    }
+
+    // @TODO: add description
+    public ConstraintReference marginGone(Object marginGoneValue) {
+        return marginGone(mState.convertDimension(marginGoneValue));
+    }
+
+    // @TODO: add description
+    public ConstraintReference margin(int value) {
+        if (mLast != null) {
+            switch (mLast) {
+                case LEFT_TO_LEFT:
+                case LEFT_TO_RIGHT: {
+                    mMarginLeft = value;
+                }
+                break;
+                case RIGHT_TO_LEFT:
+                case RIGHT_TO_RIGHT: {
+                    mMarginRight = value;
+                }
+                break;
+                case START_TO_START:
+                case START_TO_END: {
+                    mMarginStart = value;
+                }
+                break;
+                case END_TO_START:
+                case END_TO_END: {
+                    mMarginEnd = value;
+                }
+                break;
+                case TOP_TO_TOP:
+                case TOP_TO_BOTTOM:
+                case TOP_TO_BASELINE: {
+                    mMarginTop = value;
+                }
+                break;
+                case BOTTOM_TO_TOP:
+                case BOTTOM_TO_BOTTOM:
+                case BOTTOM_TO_BASELINE: {
+                    mMarginBottom = value;
+                }
+                break;
+                case BASELINE_TO_BOTTOM:
+                case BASELINE_TO_TOP:
+                case BASELINE_TO_BASELINE: {
+                    mMarginBaseline = value;
+                }
+                break;
+                case CIRCULAR_CONSTRAINT: {
+                    mCircularDistance = value;
+                }
+                break;
+                default:
+                    break;
+            }
+        } else {
+            mMarginLeft = value;
+            mMarginRight = value;
+            mMarginStart = value;
+            mMarginEnd = value;
+            mMarginTop = value;
+            mMarginBottom = value;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference marginGone(int value) {
+        if (mLast != null) {
+            switch (mLast) {
+                case LEFT_TO_LEFT:
+                case LEFT_TO_RIGHT: {
+                    mMarginLeftGone = value;
+                }
+                break;
+                case RIGHT_TO_LEFT:
+                case RIGHT_TO_RIGHT: {
+                    mMarginRightGone = value;
+                }
+                break;
+                case START_TO_START:
+                case START_TO_END: {
+                    mMarginStartGone = value;
+                }
+                break;
+                case END_TO_START:
+                case END_TO_END: {
+                    mMarginEndGone = value;
+                }
+                break;
+                case TOP_TO_TOP:
+                case TOP_TO_BOTTOM:
+                case TOP_TO_BASELINE: {
+                    mMarginTopGone = value;
+                }
+                break;
+                case BOTTOM_TO_TOP:
+                case BOTTOM_TO_BOTTOM:
+                case BOTTOM_TO_BASELINE: {
+                    mMarginBottomGone = value;
+                }
+                break;
+                case BASELINE_TO_TOP:
+                case BASELINE_TO_BOTTOM:
+                case BASELINE_TO_BASELINE: {
+                    mMarginBaselineGone = value;
+                }
+                break;
+                default:
+                    break;
+            }
+        } else {
+            mMarginLeftGone = value;
+            mMarginRightGone = value;
+            mMarginStartGone = value;
+            mMarginEndGone = value;
+            mMarginTopGone = value;
+            mMarginBottomGone = value;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference horizontalBias(float value) {
+        mHorizontalBias = value;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference verticalBias(float value) {
+        mVerticalBias = value;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference bias(float value) {
+        if (mLast == null) {
+            return this;
+        }
+        switch (mLast) {
+            case CENTER_HORIZONTALLY:
+            case LEFT_TO_LEFT:
+            case LEFT_TO_RIGHT:
+            case RIGHT_TO_LEFT:
+            case RIGHT_TO_RIGHT:
+            case START_TO_START:
+            case START_TO_END:
+            case END_TO_START:
+            case END_TO_END: {
+                mHorizontalBias = value;
+            }
+            break;
+            case CENTER_VERTICALLY:
+            case TOP_TO_TOP:
+            case TOP_TO_BOTTOM:
+            case TOP_TO_BASELINE:
+            case BOTTOM_TO_TOP:
+            case BOTTOM_TO_BOTTOM:
+            case BOTTOM_TO_BASELINE: {
+                mVerticalBias = value;
+            }
+            break;
+            default:
+                break;
+        }
+        return this;
+    }
+
+    /**
+     * Clears all constraints.
+     */
+    public ConstraintReference clearAll() {
+        mLeftToLeft = null;
+        mLeftToRight = null;
+        mMarginLeft = 0;
+        mRightToLeft = null;
+        mRightToRight = null;
+        mMarginRight = 0;
+        mStartToStart = null;
+        mStartToEnd = null;
+        mMarginStart = 0;
+        mEndToStart = null;
+        mEndToEnd = null;
+        mMarginEnd = 0;
+        mTopToTop = null;
+        mTopToBottom = null;
+        mMarginTop = 0;
+        mBottomToTop = null;
+        mBottomToBottom = null;
+        mMarginBottom = 0;
+        mBaselineToBaseline = null;
+        mCircularConstraint = null;
+        mHorizontalBias = 0.5f;
+        mVerticalBias = 0.5f;
+        mMarginLeftGone = 0;
+        mMarginRightGone = 0;
+        mMarginStartGone = 0;
+        mMarginEndGone = 0;
+        mMarginTopGone = 0;
+        mMarginBottomGone = 0;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference clear() {
+        if (mLast != null) {
+            switch (mLast) {
+                case LEFT_TO_LEFT:
+                case LEFT_TO_RIGHT: {
+                    mLeftToLeft = null;
+                    mLeftToRight = null;
+                    mMarginLeft = 0;
+                    mMarginLeftGone = 0;
+                }
+                break;
+                case RIGHT_TO_LEFT:
+                case RIGHT_TO_RIGHT: {
+                    mRightToLeft = null;
+                    mRightToRight = null;
+                    mMarginRight = 0;
+                    mMarginRightGone = 0;
+                }
+                break;
+                case START_TO_START:
+                case START_TO_END: {
+                    mStartToStart = null;
+                    mStartToEnd = null;
+                    mMarginStart = 0;
+                    mMarginStartGone = 0;
+                }
+                break;
+                case END_TO_START:
+                case END_TO_END: {
+                    mEndToStart = null;
+                    mEndToEnd = null;
+                    mMarginEnd = 0;
+                    mMarginEndGone = 0;
+                }
+                break;
+                case TOP_TO_TOP:
+                case TOP_TO_BOTTOM:
+                case TOP_TO_BASELINE: {
+                    mTopToTop = null;
+                    mTopToBottom = null;
+                    mTopToBaseline = null;
+                    mMarginTop = 0;
+                    mMarginTopGone = 0;
+                }
+                break;
+                case BOTTOM_TO_TOP:
+                case BOTTOM_TO_BOTTOM:
+                case BOTTOM_TO_BASELINE: {
+                    mBottomToTop = null;
+                    mBottomToBottom = null;
+                    mBottomToBaseline = null;
+                    mMarginBottom = 0;
+                    mMarginBottomGone = 0;
+                }
+                break;
+                case BASELINE_TO_BASELINE: {
+                    mBaselineToBaseline = null;
+                }
+                break;
+                case CIRCULAR_CONSTRAINT: {
+                    mCircularConstraint = null;
+                }
+                break;
+                default:
+                    break;
+            }
+        } else {
+            clearAll();
+        }
+        return this;
+    }
+
+    private ConstraintWidget getTarget(Object target) {
+        if (target instanceof Reference) {
+            Reference referenceTarget = (Reference) target;
+            return referenceTarget.getConstraintWidget();
+        }
+        return null;
+    }
+
+    private void applyConnection(ConstraintWidget widget,
+            Object opaqueTarget,
+            State.Constraint type) {
+        ConstraintWidget target = getTarget(opaqueTarget);
+        if (target == null) {
+            return;
+        }
+        switch (type) {
+            // TODO: apply RTL
+            default:
+                break;
+        }
+        switch (type) {
+            case START_TO_START: {
+                widget.getAnchor(ConstraintAnchor.Type.LEFT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.LEFT), mMarginStart, mMarginStartGone, false);
+            }
+            break;
+            case START_TO_END: {
+                widget.getAnchor(ConstraintAnchor.Type.LEFT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.RIGHT), mMarginStart, mMarginStartGone, false);
+            }
+            break;
+            case END_TO_START: {
+                widget.getAnchor(ConstraintAnchor.Type.RIGHT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.LEFT), mMarginEnd, mMarginEndGone, false);
+            }
+            break;
+            case END_TO_END: {
+                widget.getAnchor(ConstraintAnchor.Type.RIGHT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.RIGHT), mMarginEnd, mMarginEndGone, false);
+            }
+            break;
+            case LEFT_TO_LEFT: {
+                widget.getAnchor(ConstraintAnchor.Type.LEFT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.LEFT), mMarginLeft, mMarginLeftGone, false);
+            }
+            break;
+            case LEFT_TO_RIGHT: {
+                widget.getAnchor(ConstraintAnchor.Type.LEFT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.RIGHT), mMarginLeft, mMarginLeftGone, false);
+            }
+            break;
+            case RIGHT_TO_LEFT: {
+                widget.getAnchor(ConstraintAnchor.Type.RIGHT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.LEFT), mMarginRight, mMarginRightGone, false);
+            }
+            break;
+            case RIGHT_TO_RIGHT: {
+                widget.getAnchor(ConstraintAnchor.Type.RIGHT).connect(target.getAnchor(
+                        ConstraintAnchor.Type.RIGHT), mMarginRight, mMarginRightGone, false);
+            }
+            break;
+            case TOP_TO_TOP: {
+                widget.getAnchor(ConstraintAnchor.Type.TOP).connect(target.getAnchor(
+                        ConstraintAnchor.Type.TOP), mMarginTop, mMarginTopGone, false);
+            }
+            break;
+            case TOP_TO_BOTTOM: {
+                widget.getAnchor(ConstraintAnchor.Type.TOP).connect(target.getAnchor(
+                        ConstraintAnchor.Type.BOTTOM), mMarginTop, mMarginTopGone, false);
+            }
+            break;
+            case TOP_TO_BASELINE: {
+                widget.immediateConnect(ConstraintAnchor.Type.TOP, target,
+                        ConstraintAnchor.Type.BASELINE, mMarginTop, mMarginTopGone);
+            }
+            break;
+            case BOTTOM_TO_TOP: {
+                widget.getAnchor(ConstraintAnchor.Type.BOTTOM).connect(target.getAnchor(
+                        ConstraintAnchor.Type.TOP), mMarginBottom, mMarginBottomGone, false);
+            }
+            break;
+            case BOTTOM_TO_BOTTOM: {
+                widget.getAnchor(ConstraintAnchor.Type.BOTTOM).connect(target.getAnchor(
+                        ConstraintAnchor.Type.BOTTOM), mMarginBottom, mMarginBottomGone, false);
+            }
+            break;
+            case BOTTOM_TO_BASELINE: {
+                widget.immediateConnect(ConstraintAnchor.Type.BOTTOM, target,
+                        ConstraintAnchor.Type.BASELINE, mMarginBottom, mMarginBottomGone);
+            }
+            break;
+            case BASELINE_TO_BASELINE: {
+                widget.immediateConnect(ConstraintAnchor.Type.BASELINE, target,
+                        ConstraintAnchor.Type.BASELINE, mMarginBaseline, mMarginBaselineGone);
+            }
+            break;
+            case BASELINE_TO_TOP: {
+                widget.immediateConnect(ConstraintAnchor.Type.BASELINE,
+                        target, ConstraintAnchor.Type.TOP, mMarginBaseline, mMarginBaselineGone);
+            }
+            break;
+            case BASELINE_TO_BOTTOM: {
+                widget.immediateConnect(ConstraintAnchor.Type.BASELINE, target,
+                        ConstraintAnchor.Type.BOTTOM, mMarginBaseline, mMarginBaselineGone);
+            }
+            break;
+            case CIRCULAR_CONSTRAINT: {
+                widget.connectCircularConstraint(target, mCircularAngle, (int) mCircularDistance);
+            }
+            break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * apply all the constraints attributes of the mConstraintWidget
+     */
+    public void applyWidgetConstraints() {
+        applyConnection(mConstraintWidget, mLeftToLeft, State.Constraint.LEFT_TO_LEFT);
+        applyConnection(mConstraintWidget, mLeftToRight, State.Constraint.LEFT_TO_RIGHT);
+        applyConnection(mConstraintWidget, mRightToLeft, State.Constraint.RIGHT_TO_LEFT);
+        applyConnection(mConstraintWidget, mRightToRight, State.Constraint.RIGHT_TO_RIGHT);
+        applyConnection(mConstraintWidget, mStartToStart, State.Constraint.START_TO_START);
+        applyConnection(mConstraintWidget, mStartToEnd, State.Constraint.START_TO_END);
+        applyConnection(mConstraintWidget, mEndToStart, State.Constraint.END_TO_START);
+        applyConnection(mConstraintWidget, mEndToEnd, State.Constraint.END_TO_END);
+        applyConnection(mConstraintWidget, mTopToTop, State.Constraint.TOP_TO_TOP);
+        applyConnection(mConstraintWidget, mTopToBottom, State.Constraint.TOP_TO_BOTTOM);
+        applyConnection(mConstraintWidget, mTopToBaseline, State.Constraint.TOP_TO_BASELINE);
+        applyConnection(mConstraintWidget, mBottomToTop, State.Constraint.BOTTOM_TO_TOP);
+        applyConnection(mConstraintWidget, mBottomToBottom, State.Constraint.BOTTOM_TO_BOTTOM);
+        applyConnection(mConstraintWidget, mBottomToBaseline, State.Constraint.BOTTOM_TO_BASELINE);
+        applyConnection(mConstraintWidget, mBaselineToBaseline,
+                State.Constraint.BASELINE_TO_BASELINE);
+        applyConnection(mConstraintWidget, mBaselineToTop, State.Constraint.BASELINE_TO_TOP);
+        applyConnection(mConstraintWidget, mBaselineToBottom, State.Constraint.BASELINE_TO_BOTTOM);
+        applyConnection(mConstraintWidget, mCircularConstraint,
+                State.Constraint.CIRCULAR_CONSTRAINT);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        if (mConstraintWidget == null) {
+            return;
+        }
+        if (mFacade != null) {
+            mFacade.apply();
+        }
+        mHorizontalDimension.apply(mState, mConstraintWidget, HORIZONTAL);
+        mVerticalDimension.apply(mState, mConstraintWidget, VERTICAL);
+        dereference();
+
+        applyWidgetConstraints();
+
+        if (mHorizontalChainStyle != ConstraintWidget.CHAIN_SPREAD) {
+            mConstraintWidget.setHorizontalChainStyle(mHorizontalChainStyle);
+        }
+        if (mVerticalChainStyle != ConstraintWidget.CHAIN_SPREAD) {
+            mConstraintWidget.setVerticalChainStyle(mVerticalChainStyle);
+        }
+        if (mHorizontalChainWeight != UNKNOWN) {
+            mConstraintWidget.setHorizontalWeight(mHorizontalChainWeight);
+        }
+        if (mVerticalChainWeight != UNKNOWN) {
+            mConstraintWidget.setVerticalWeight(mVerticalChainWeight);
+        }
+
+        mConstraintWidget.setHorizontalBiasPercent(mHorizontalBias);
+        mConstraintWidget.setVerticalBiasPercent(mVerticalBias);
+
+        mConstraintWidget.frame.pivotX = mPivotX;
+        mConstraintWidget.frame.pivotY = mPivotY;
+        mConstraintWidget.frame.rotationX = mRotationX;
+        mConstraintWidget.frame.rotationY = mRotationY;
+        mConstraintWidget.frame.rotationZ = mRotationZ;
+        mConstraintWidget.frame.translationX = mTranslationX;
+        mConstraintWidget.frame.translationY = mTranslationY;
+        mConstraintWidget.frame.translationZ = mTranslationZ;
+        mConstraintWidget.frame.scaleX = mScaleX;
+        mConstraintWidget.frame.scaleY = mScaleY;
+        mConstraintWidget.frame.alpha = mAlpha;
+        mConstraintWidget.frame.visibility = mVisibility;
+        mConstraintWidget.setVisibility(mVisibility);
+        mConstraintWidget.frame.setMotionAttributes(mMotionProperties);
+        if (mCustomColors != null) {
+            for (String key : mCustomColors.keySet()) {
+                Integer color = mCustomColors.get(key);
+                mConstraintWidget.frame.setCustomAttribute(key,
+                        TypedValues.Custom.TYPE_COLOR, color);
+            }
+        }
+        if (mCustomFloats != null) {
+            for (String key : mCustomFloats.keySet()) {
+                float value = mCustomFloats.get(key);
+                mConstraintWidget.frame.setCustomAttribute(key,
+                        TypedValues.Custom.TYPE_FLOAT, value);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -1,0 +1,2094 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import static androidx.constraintlayout.core.motion.utils.TypedValues.MotionType.TYPE_QUANTIZE_INTERPOLATOR_TYPE;
+import static androidx.constraintlayout.core.motion.utils.TypedValues.MotionType.TYPE_QUANTIZE_MOTIONSTEPS;
+import static androidx.constraintlayout.core.motion.utils.TypedValues.MotionType.TYPE_QUANTIZE_MOTION_PHASE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.annotation.RestrictTo;
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.parser.CLArray;
+import androidx.constraintlayout.core.parser.CLElement;
+import androidx.constraintlayout.core.parser.CLKey;
+import androidx.constraintlayout.core.parser.CLNumber;
+import androidx.constraintlayout.core.parser.CLObject;
+import androidx.constraintlayout.core.parser.CLParser;
+import androidx.constraintlayout.core.parser.CLParsingException;
+import androidx.constraintlayout.core.parser.CLString;
+import androidx.constraintlayout.core.state.helpers.BarrierReference;
+import androidx.constraintlayout.core.state.helpers.ChainReference;
+import androidx.constraintlayout.core.state.helpers.FlowReference;
+import androidx.constraintlayout.core.state.helpers.GridReference;
+import androidx.constraintlayout.core.state.helpers.GuidelineReference;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.Flow;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ConstraintSetParser {
+
+    private static final boolean PARSER_DEBUG = false;
+
+    public static class DesignElement {
+        String mId;
+        String mType;
+        HashMap<String, String> mParams;
+
+        public String getId() {
+            return mId;
+        }
+
+        public String getType() {
+            return mType;
+        }
+
+        public HashMap<String, String> getParams() {
+            return mParams;
+        }
+
+        DesignElement(String id,
+                      String type,
+                      HashMap<String, String> params) {
+            mId = id;
+            mType = type;
+            mParams = params;
+        }
+    }
+
+    /**
+     * Provide the storage for managing Variables in the system.
+     * When the json has a variable:{   } section this is used.
+     */
+    public static class LayoutVariables {
+        HashMap<String, Integer> mMargins = new HashMap<>();
+        HashMap<String, GeneratedValue> mGenerators = new HashMap<>();
+        HashMap<String, ArrayList<String>> mArrayIds = new HashMap<>();
+
+        void put(String elementName, int element) {
+            mMargins.put(elementName, element);
+        }
+
+        void put(String elementName, float start, float incrementBy) {
+            if (mGenerators.containsKey(elementName)) {
+                if (mGenerators.get(elementName) instanceof OverrideValue) {
+                    return;
+                }
+            }
+            mGenerators.put(elementName, new Generator(start, incrementBy));
+        }
+
+        void put(String elementName,
+                 float from,
+                 float to,
+                 float step,
+                 String prefix,
+                 String postfix) {
+            if (mGenerators.containsKey(elementName)) {
+                if (mGenerators.get(elementName) instanceof OverrideValue) {
+                    return;
+                }
+            }
+            FiniteGenerator generator =
+                    new FiniteGenerator(from, to, step, prefix, postfix);
+            mGenerators.put(elementName, generator);
+            mArrayIds.put(elementName, generator.array());
+
+        }
+
+        /**
+         * insert an override variable
+         *
+         * @param elementName the name
+         * @param value       the value a float
+         */
+        public void putOverride(String elementName, float value) {
+            GeneratedValue generator = new OverrideValue(value);
+            mGenerators.put(elementName, generator);
+        }
+
+        float get(Object elementName) {
+            if (elementName instanceof CLString) {
+                String stringValue = ((CLString) elementName).content();
+                if (mGenerators.containsKey(stringValue)) {
+                    return mGenerators.get(stringValue).value();
+                }
+                if (mMargins.containsKey(stringValue)) {
+                    return mMargins.get(stringValue).floatValue();
+                }
+            } else if (elementName instanceof CLNumber) {
+                return ((CLNumber) elementName).getFloat();
+            }
+            return 0f;
+        }
+
+        ArrayList<String> getList(String elementName) {
+            if (mArrayIds.containsKey(elementName)) {
+                return mArrayIds.get(elementName);
+            }
+            return null;
+        }
+
+        void put(String elementName, ArrayList<String> elements) {
+            mArrayIds.put(elementName, elements);
+        }
+
+    }
+
+    interface GeneratedValue {
+        float value();
+    }
+
+    /**
+     * Generate a floating point value
+     */
+    static class Generator implements GeneratedValue {
+        float mStart = 0;
+        float mIncrementBy = 0;
+        float mCurrent = 0;
+        boolean mStop = false;
+
+        Generator(float start, float incrementBy) {
+            mStart = start;
+            mIncrementBy = incrementBy;
+            mCurrent = start;
+        }
+
+        @Override
+        public float value() {
+            if (!mStop) {
+                mCurrent += mIncrementBy;
+            }
+            return mCurrent;
+        }
+    }
+
+    /**
+     * Generate values like button1, button2 etc.
+     */
+    static class FiniteGenerator implements GeneratedValue {
+        float mFrom = 0;
+        float mTo = 0;
+        float mStep = 0;
+        boolean mStop = false;
+        String mPrefix;
+        String mPostfix;
+        float mCurrent = 0;
+        float mInitial;
+        float mMax;
+
+        FiniteGenerator(float from,
+                        float to,
+                        float step,
+                        String prefix,
+                        String postfix) {
+            mFrom = from;
+            mTo = to;
+            mStep = step;
+            mPrefix = (prefix == null) ? "" : prefix;
+            mPostfix = (postfix == null) ? "" : postfix;
+            mMax = to;
+            mInitial = from;
+        }
+
+        @Override
+        public float value() {
+            if (mCurrent >= mMax) {
+                mStop = true;
+            }
+            if (!mStop) {
+                mCurrent += mStep;
+            }
+            return mCurrent;
+        }
+
+        public ArrayList<String> array() {
+            ArrayList<String> array = new ArrayList<>();
+            int value = (int) mInitial;
+            int maxInt = (int) mMax;
+            for (int i = value; i <= maxInt; i++) {
+                array.add(mPrefix + value + mPostfix);
+                value += (int) mStep;
+            }
+            return array;
+
+        }
+
+    }
+
+    static class OverrideValue implements GeneratedValue {
+        float mValue;
+
+        OverrideValue(float value) {
+            mValue = value;
+        }
+
+        @Override
+        public float value() {
+            return mValue;
+        }
+    }
+//==================== end store variables =========================
+//==================== MotionScene =========================
+
+    public enum MotionLayoutDebugFlags {
+        NONE,
+        SHOW_ALL,
+        UNKNOWN
+    }
+
+    //==================== end Motion Scene =========================
+
+    /**
+     * Parse and populate a transition
+     *
+     * @param content    JSON string to parse
+     * @param transition The Transition to be populated
+     * @param state
+     */
+    public static void parseJSON(String content, Transition transition, int state) {
+        try {
+            CLObject json = CLParser.parse(content);
+            ArrayList<String> elements = json.names();
+            if (elements == null) {
+                return;
+            }
+            for (String elementName : elements) {
+                CLElement base_element = json.get(elementName);
+                if (base_element instanceof CLObject) {
+                    CLObject element = (CLObject) base_element;
+                    CLObject customProperties = element.getObjectOrNull("custom");
+                    if (customProperties != null) {
+                        ArrayList<String> properties = customProperties.names();
+                        for (String property : properties) {
+                            CLElement value = customProperties.get(property);
+                            if (value instanceof CLNumber) {
+                                transition.addCustomFloat(
+                                        state,
+                                        elementName,
+                                        property,
+                                        value.getFloat()
+                                );
+                            } else if (value instanceof CLString) {
+                                long color = parseColorString(value.content());
+                                if (color != -1) {
+                                    transition.addCustomColor(state,
+                                            elementName, property, (int) color);
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+        } catch (CLParsingException e) {
+            System.err.println("Error parsing JSON " + e);
+        }
+    }
+
+    /**
+     * Parse and build a motionScene
+     *
+     * this should be in a MotionScene / MotionSceneParser
+     */
+    public static void parseMotionSceneJSON(CoreMotionScene scene, String content) {
+        try {
+            CLObject json = CLParser.parse(content);
+            ArrayList<String> elements = json.names();
+            if (elements == null) {
+                return;
+            }
+            for (String elementName : elements) {
+                CLElement element = json.get(elementName);
+                if (element instanceof CLObject) {
+                    CLObject clObject = (CLObject) element;
+                    switch (elementName) {
+                        case "ConstraintSets":
+                            parseConstraintSets(scene, clObject);
+                            break;
+                        case "Transitions":
+                            parseTransitions(scene, clObject);
+                            break;
+                        case "Header":
+                            parseHeader(scene, clObject);
+                            break;
+                    }
+                }
+            }
+        } catch (CLParsingException e) {
+            System.err.println("Error parsing JSON " + e);
+        }
+    }
+
+    /**
+     * Parse ConstraintSets and populate MotionScene
+     */
+    static void parseConstraintSets(CoreMotionScene scene,
+                                    CLObject json) throws CLParsingException {
+        ArrayList<String> constraintSetNames = json.names();
+        if (constraintSetNames == null) {
+            return;
+        }
+
+        for (String csName : constraintSetNames) {
+            CLObject constraintSet = json.getObject(csName);
+            boolean added = false;
+            String ext = constraintSet.getStringOrNull("Extends");
+            if (ext != null && !ext.isEmpty()) {
+                String base = scene.getConstraintSet(ext);
+                if (base == null) {
+                    continue;
+                }
+
+                CLObject baseJson = CLParser.parse(base);
+                ArrayList<String> widgetsOverride = constraintSet.names();
+                if (widgetsOverride == null) {
+                    continue;
+                }
+
+                for (String widgetOverrideName : widgetsOverride) {
+                    CLElement value = constraintSet.get(widgetOverrideName);
+                    if (value instanceof CLObject) {
+                        override(baseJson, widgetOverrideName, (CLObject) value);
+                    }
+                }
+
+                scene.setConstraintSetContent(csName, baseJson.toJSON());
+                added = true;
+            }
+            if (!added) {
+                scene.setConstraintSetContent(csName, constraintSet.toJSON());
+            }
+        }
+
+    }
+
+    static void override(CLObject baseJson,
+                         String name, CLObject overrideValue) throws CLParsingException {
+        if (!baseJson.has(name)) {
+            baseJson.put(name, overrideValue);
+        } else {
+            CLObject base = baseJson.getObject(name);
+            ArrayList<String> keys = overrideValue.names();
+            for (String key : keys) {
+                if (!key.equals("clear")) {
+                    base.put(key, overrideValue.get(key));
+                    continue;
+                }
+                CLArray toClear = overrideValue.getArray("clear");
+                for (int i = 0; i < toClear.size(); i++) {
+                    String clearedKey = toClear.getStringOrNull(i);
+                    if (clearedKey == null) {
+                        continue;
+                    }
+                    switch (clearedKey) {
+                        case "dimensions":
+                            base.remove("width");
+                            base.remove("height");
+                            break;
+                        case "constraints":
+                            base.remove("start");
+                            base.remove("end");
+                            base.remove("top");
+                            base.remove("bottom");
+                            base.remove("baseline");
+                            base.remove("center");
+                            base.remove("centerHorizontally");
+                            base.remove("centerVertically");
+                            break;
+                        case "transforms":
+                            base.remove("visibility");
+                            base.remove("alpha");
+                            base.remove("pivotX");
+                            base.remove("pivotY");
+                            base.remove("rotationX");
+                            base.remove("rotationY");
+                            base.remove("rotationZ");
+                            base.remove("scaleX");
+                            base.remove("scaleY");
+                            base.remove("translationX");
+                            base.remove("translationY");
+                            break;
+                        default:
+                            base.remove(clearedKey);
+
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse the Transition
+     */
+    static void parseTransitions(CoreMotionScene scene, CLObject json) throws CLParsingException {
+        ArrayList<String> elements = json.names();
+        if (elements == null) {
+            return;
+        }
+        for (String elementName : elements) {
+            scene.setTransitionContent(elementName, json.getObject(elementName).toJSON());
+        }
+    }
+
+    /**
+     * Used to parse for "export"
+     */
+    static void parseHeader(CoreMotionScene scene, CLObject json) {
+        String name = json.getStringOrNull("export");
+        if (name != null) {
+            scene.setDebugName(name);
+        }
+    }
+
+    /**
+     * Top leve parsing of the json ConstraintSet supporting
+     * "Variables", "Helpers", "Generate", guidelines, and barriers
+     *
+     * @param content         the JSON string
+     * @param state           the state to populate
+     * @param layoutVariables the variables to override
+     */
+    public static void parseJSON(String content, State state,
+                                 LayoutVariables layoutVariables) throws CLParsingException {
+        try {
+            CLObject json = CLParser.parse(content);
+            populateState(json, state, layoutVariables);
+        } catch (CLParsingException e) {
+            System.err.println("Error parsing JSON " + e);
+        }
+    }
+
+    /**
+     * Populates the given {@link State} with the parameters from {@link CLObject}. Where the
+     * object represents a parsed JSONObject of a ConstraintSet.
+     *
+     * @param parsedJson CLObject of the parsed ConstraintSet
+     * @param state the state to populate
+     * @param layoutVariables the variables to override
+     * @throws CLParsingException when parsing fails
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static void populateState(
+            @NonNull CLObject parsedJson,
+            @NonNull State state,
+            @NonNull LayoutVariables layoutVariables
+    ) throws CLParsingException {
+        ArrayList<String> elements = parsedJson.names();
+        if (elements == null) {
+            return;
+        }
+        for (String elementName : elements) {
+            CLElement element = parsedJson.get(elementName);
+            if (PARSER_DEBUG) {
+                System.out.println("[" + elementName + "] = " + element
+                        + " > " + element.getContainer());
+            }
+            switch (elementName) {
+                case "Variables":
+                    if (element instanceof CLObject) {
+                        parseVariables(state, layoutVariables, (CLObject) element);
+                    }
+                    break;
+                case "Helpers":
+                    if (element instanceof CLArray) {
+                        parseHelpers(state, layoutVariables, (CLArray) element);
+                    }
+                    break;
+                case "Generate":
+                    if (element instanceof CLObject) {
+                        parseGenerate(state, layoutVariables, (CLObject) element);
+                    }
+                    break;
+                default:
+                    if (element instanceof CLObject) {
+                        String type = lookForType((CLObject) element);
+                        if (type != null) {
+                            switch (type) {
+                                case "hGuideline":
+                                    parseGuidelineParams(
+                                            ConstraintWidget.HORIZONTAL,
+                                            state,
+                                            elementName,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "vGuideline":
+                                    parseGuidelineParams(
+                                            ConstraintWidget.VERTICAL,
+                                            state,
+                                            elementName,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "barrier":
+                                    parseBarrier(state, elementName, (CLObject) element);
+                                    break;
+                                case "vChain":
+                                case "hChain":
+                                    parseChainType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "vFlow":
+                                case "hFlow":
+                                    parseFlowType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "grid":
+                                case "row":
+                                case "column":
+                                    parseGridType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                            }
+                        } else {
+                            parseWidget(state,
+                                    layoutVariables,
+                                    elementName,
+                                    (CLObject) element);
+                        }
+                    } else if (element instanceof CLNumber) {
+                        layoutVariables.put(elementName, element.getInt());
+                    }
+            }
+        }
+    }
+
+    private static void parseVariables(State state,
+                                       LayoutVariables layoutVariables,
+                                       CLObject json) throws CLParsingException {
+        ArrayList<String> elements = json.names();
+        if (elements == null) {
+            return;
+        }
+        for (String elementName : elements) {
+            CLElement element = json.get(elementName);
+            if (element instanceof CLNumber) {
+                layoutVariables.put(elementName, element.getInt());
+            } else if (element instanceof CLObject) {
+                CLObject obj = (CLObject) element;
+                ArrayList<String> arrayIds;
+                if (obj.has("from") && obj.has("to")) {
+                    float from = layoutVariables.get(obj.get("from"));
+                    float to = layoutVariables.get(obj.get("to"));
+                    String prefix = obj.getStringOrNull("prefix");
+                    String postfix = obj.getStringOrNull("postfix");
+                    layoutVariables.put(elementName, from, to, 1f, prefix, postfix);
+                } else if (obj.has("from") && obj.has("step")) {
+                    float start = layoutVariables.get(obj.get("from"));
+                    float increment = layoutVariables.get(obj.get("step"));
+                    layoutVariables.put(elementName, start, increment);
+
+                } else if (obj.has("ids")) {
+                    CLArray ids = obj.getArray("ids");
+                    arrayIds = new ArrayList<>();
+                    for (int i = 0; i < ids.size(); i++) {
+                        arrayIds.add(ids.getString(i));
+                    }
+                    layoutVariables.put(elementName, arrayIds);
+                } else if (obj.has("tag")) {
+                    arrayIds = state.getIdsForTag(obj.getString("tag"));
+                    layoutVariables.put(elementName, arrayIds);
+                }
+            }
+        }
+    }
+
+    /**
+     * parse the Design time elements.
+     *
+     * @param content the json
+     * @param list    output the list of design elements
+     */
+    public static void parseDesignElementsJSON(
+            String content, ArrayList<DesignElement> list) throws CLParsingException {
+        CLObject json = CLParser.parse(content);
+        ArrayList<String> elements = json.names();
+        if (elements == null) {
+            return;
+        }
+        for (int i = 0; i < elements.size(); i++) {
+            String elementName = elements.get(i);
+            CLElement element = json.get(elementName);
+            if (PARSER_DEBUG) {
+                System.out.println("[" + element + "] " + element.getClass());
+            }
+            switch (elementName) {
+                case "Design":
+                    if (!(element instanceof CLObject)) {
+                        return;
+                    }
+                    CLObject obj = (CLObject) element;
+                    elements = obj.names();
+                    for (int j = 0; j < elements.size(); j++) {
+                        String designElementName = elements.get(j);
+                        CLObject designElement =
+                                (CLObject) ((CLObject) element).get(designElementName);
+                        System.out.printf("element found " + designElementName + "");
+                        String type = designElement.getStringOrNull("type");
+                        if (type != null) {
+                            HashMap<String, String> parameters = new HashMap<String, String>();
+                            int size = designElement.size();
+                            for (int k = 0; k < size; k++) {
+
+                                CLKey key = (CLKey) designElement.get(j);
+                                String paramName = key.content();
+                                String paramValue = key.getValue().content();
+                                if (paramValue != null) {
+                                    parameters.put(paramName, paramValue);
+                                }
+                            }
+                            list.add(new DesignElement(elementName, type, parameters));
+                        }
+                    }
+            }
+            break;
+        }
+    }
+
+    static void parseHelpers(State state,
+                             LayoutVariables layoutVariables,
+                             CLArray element) throws CLParsingException {
+        for (int i = 0; i < element.size(); i++) {
+            CLElement helper = element.get(i);
+            if (helper instanceof CLArray) {
+                CLArray array = (CLArray) helper;
+                if (array.size() > 1) {
+                    switch (array.getString(0)) {
+                        case "hChain":
+                            parseChain(ConstraintWidget.HORIZONTAL, state, layoutVariables, array);
+                            break;
+                        case "vChain":
+                            parseChain(ConstraintWidget.VERTICAL, state, layoutVariables, array);
+                            break;
+                        case "hGuideline":
+                            parseGuideline(ConstraintWidget.HORIZONTAL, state, array);
+                            break;
+                        case "vGuideline":
+                            parseGuideline(ConstraintWidget.VERTICAL, state, array);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
+    static void parseGenerate(State state,
+                              LayoutVariables layoutVariables,
+                              CLObject json) throws CLParsingException {
+        ArrayList<String> elements = json.names();
+        if (elements == null) {
+            return;
+        }
+        for (String elementName : elements) {
+            CLElement element = json.get(elementName);
+            ArrayList<String> arrayIds = layoutVariables.getList(elementName);
+            if (arrayIds != null && element instanceof CLObject) {
+                for (String id : arrayIds) {
+                    parseWidget(state, layoutVariables, id, (CLObject) element);
+                }
+            }
+        }
+    }
+
+    static void parseChain(int orientation, State state,
+                           LayoutVariables margins, CLArray helper) throws CLParsingException {
+        ChainReference chain = (orientation == ConstraintWidget.HORIZONTAL)
+                ? state.horizontalChain() : state.verticalChain();
+        CLElement refs = helper.get(1);
+        if (!(refs instanceof CLArray) || ((CLArray) refs).size() < 1) {
+            return;
+        }
+        for (int i = 0; i < ((CLArray) refs).size(); i++) {
+            chain.add(((CLArray) refs).getString(i));
+        }
+
+        if (helper.size() > 2) { // we have additional parameters
+            CLElement params = helper.get(2);
+            if (!(params instanceof CLObject)) {
+                return;
+            }
+            CLObject obj = (CLObject) params;
+            ArrayList<String> constraints = obj.names();
+            for (String constraintName : constraints) {
+                switch (constraintName) {
+                    case "style":
+                        CLElement styleObject = ((CLObject) params).get(constraintName);
+                        String styleValue;
+                        if (styleObject instanceof CLArray && ((CLArray) styleObject).size() > 1) {
+                            styleValue = ((CLArray) styleObject).getString(0);
+                            float biasValue = ((CLArray) styleObject).getFloat(1);
+                            chain.bias(biasValue);
+                        } else {
+                            styleValue = styleObject.content();
+                        }
+                        switch (styleValue) {
+                            case "packed":
+                                chain.style(State.Chain.PACKED);
+                                break;
+                            case "spread_inside":
+                                chain.style(State.Chain.SPREAD_INSIDE);
+                                break;
+                            default:
+                                chain.style(State.Chain.SPREAD);
+                                break;
+                        }
+
+                        break;
+                    default:
+                        parseConstraint(
+                                state,
+                                margins,
+                                (CLObject) params,
+                                (ConstraintReference) chain,
+                                constraintName
+                        );
+                        break;
+                }
+            }
+        }
+    }
+
+    private static float toPix(State state, float dp) {
+        return state.getDpToPixel().toPixels(dp);
+    }
+
+    /**
+     * Support parsing Chain in the following manner
+     * chainId : {
+     *      type:'hChain'  // or vChain
+     *      contains: ['id1', 'id2', 'id3' ]
+     *      contains: [['id', weight, marginL ,marginR], 'id2', 'id3' ]
+     *      start: ['parent', 'start',0],
+     *      end: ['parent', 'end',0],
+     *      top: ['parent', 'top',0],
+     *      bottom: ['parent', 'bottom',0],
+     *      style: 'spread'
+     * }
+
+     * @throws CLParsingException
+     */
+    private static void parseChainType(String orientation,
+                                       State state,
+                                       String chainName,
+                                       LayoutVariables margins,
+                                       CLObject object) throws CLParsingException {
+
+        ChainReference chain = (orientation.charAt(0) == 'h')
+                ? state.horizontalChain() : state.verticalChain();
+        chain.setKey(chainName);
+
+        for (String params : object.names()) {
+            switch (params) {
+                case "contains":
+                    CLElement refs = object.get(params);
+                    if (!(refs instanceof CLArray) || ((CLArray) refs).size() < 1) {
+                        System.err.println(
+                                chainName + " contains should be an array \"" + refs.content()
+                                        + "\"");
+                        return;
+                    }
+                    for (int i = 0; i < ((CLArray) refs).size(); i++) {
+                        CLElement chainElement = ((CLArray) refs).get(i);
+                        if (chainElement instanceof CLArray) {
+                            CLArray array = (CLArray) chainElement;
+                            if (array.size() > 0) {
+                                String id = array.get(0).content();
+                                float weight = Float.NaN;
+                                float preMargin = Float.NaN;
+                                float postMargin = Float.NaN;
+                                float preGoneMargin = Float.NaN;
+                                float postGoneMargin = Float.NaN;
+                                switch (array.size()) {
+                                    case 2: // sets only the weight
+                                        weight = array.getFloat(1);
+                                        break;
+                                    case 3: // sets the pre and post margin to the 2 arg
+                                        weight = array.getFloat(1);
+                                        postMargin = preMargin = toPix(state, array.getFloat(2));
+                                        break;
+                                    case 4: // sets the pre and post margin
+                                        weight = array.getFloat(1);
+                                        preMargin = toPix(state, array.getFloat(2));
+                                        postMargin = toPix(state, array.getFloat(3));
+                                        break;
+                                    case 6: // weight, preMargin, postMargin, preGoneMargin,
+                                        // postGoneMargin
+                                        weight = array.getFloat(1);
+                                        preMargin = toPix(state, array.getFloat(2));
+                                        postMargin = toPix(state, array.getFloat(3));
+                                        preGoneMargin = toPix(state, array.getFloat(4));
+                                        postGoneMargin = toPix(state, array.getFloat(5));
+                                        break;
+                                }
+                                chain.addChainElement(id,
+                                        weight,
+                                        preMargin,
+                                        postMargin,
+                                        preGoneMargin,
+                                        postGoneMargin);
+                            }
+                        } else {
+                            chain.add(chainElement.content());
+                        }
+                    }
+                    break;
+                case "start":
+                case "end":
+                case "top":
+                case "bottom":
+                case "left":
+                case "right":
+                    parseConstraint(state, margins, object, chain, params);
+                    break;
+                case "style":
+
+                    CLElement styleObject = object.get(params);
+                    String styleValue;
+                    if (styleObject instanceof CLArray && ((CLArray) styleObject).size() > 1) {
+                        styleValue = ((CLArray) styleObject).getString(0);
+                        float biasValue = ((CLArray) styleObject).getFloat(1);
+                        chain.bias(biasValue);
+                    } else {
+                        styleValue = styleObject.content();
+                    }
+                    switch (styleValue) {
+                        case "packed":
+                            chain.style(State.Chain.PACKED);
+                            break;
+                        case "spread_inside":
+                            chain.style(State.Chain.SPREAD_INSIDE);
+                            break;
+                        default:
+                            chain.style(State.Chain.SPREAD);
+                            break;
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Support parsing Grid in the following manner
+     * chainId : {
+     *      height: "parent",
+     *      width: "parent",
+     *      type: "Grid",
+     *      vGap: 10,
+     *      hGap: 10,
+     *      orientation: 0,
+     *      rows: 0,
+     *      columns: 1,
+     *      columnWeights: "",
+     *      rowWeights: "",
+     *      contains: ["btn1", "btn2", "btn3", "btn4"],
+     *      top: ["parent", "top", 10],
+     *      bottom: ["parent", "bottom", 20],
+     *      right: ["parent", "right", 30],
+     *      left: ["parent", "left", 40],
+     * }
+     *
+     * @param gridType type of the Grid helper could be "Grid"|"Row"|"Column"
+     * @param state ConstraintLayout State
+     * @param name the name of the Grid Helper
+     * @param layoutVariables layout margins
+     * @param element the element to be parsed
+     * @throws CLParsingException
+     */
+    private static void parseGridType(String gridType,
+                                      State state,
+                                      String name,
+                                      LayoutVariables layoutVariables,
+                                      CLObject element) throws CLParsingException {
+        GridReference grid = state.getGrid(name, gridType);
+
+        for (String param : element.names()) {
+            switch (param) {
+                case "contains":
+                    CLArray list = element.getArrayOrNull(param);
+                    if (list != null) {
+                        for (int j = 0; j < list.size(); j++) {
+
+                            String elementNameReference = list.get(j).content();
+                            ConstraintReference elementReference =
+                                    state.constraints(elementNameReference);
+                            grid.add(elementReference);
+                        }
+                    }
+                    break;
+                case "orientation":
+                    int orientation = element.get(param).getInt();
+                    grid.setOrientation(orientation);
+                    break;
+                case "rows":
+                    int rows = element.get(param).getInt();
+                    if (rows > 0) {
+                        grid.setRowsSet(rows);
+                    }
+                    break;
+                case "columns":
+                    int columns = element.get(param).getInt();
+                    if (columns > 0) {
+                        grid.setColumnsSet(columns);
+                    }
+                    break;
+                case "hGap":
+                    float hGap = element.get(param).getFloat();
+                    grid.setHorizontalGaps(toPix(state, hGap));
+                    break;
+                case "vGap":
+                    float vGap = element.get(param).getFloat();
+                    grid.setVerticalGaps(toPix(state, vGap));
+                    break;
+                case "spans":
+                    String spans = element.get(param).content();
+                    if (spans != null && spans.contains(":")) {
+                        grid.setSpans(spans);
+                    }
+                    break;
+                case "skips":
+                    String skips = element.get(param).content();
+                    if (skips != null && skips.contains(":")) {
+                        grid.setSkips(skips);
+                    }
+                    break;
+                case "rowWeights":
+                    String rowWeights = element.get(param).content();
+                    if (rowWeights != null && rowWeights.contains(",")) {
+                        grid.setRowWeights(rowWeights);
+                    }
+                    break;
+                case "columnWeights":
+                    String columnWeights = element.get(param).content();
+                    if (columnWeights != null && columnWeights.contains(",")) {
+                        grid.setColumnWeights(columnWeights);
+                    }
+                    break;
+                case "padding":
+                    // Note that padding is currently not properly handled in GridCore
+                    CLElement paddingObject = element.get(param);
+                    float paddingStart = 0;
+                    float paddingTop = 0;
+                    float paddingEnd = 0;
+                    float paddingBottom = 0;
+                    if (paddingObject instanceof CLArray && ((CLArray) paddingObject).size() > 1) {
+                        paddingStart = ((CLArray) paddingObject).getInt(0);
+                        paddingEnd = paddingStart;
+                        paddingTop = ((CLArray) paddingObject).getInt(1);
+                        paddingBottom = paddingTop;
+                        if (((CLArray) paddingObject).size() > 2) {
+                            paddingEnd = ((CLArray) paddingObject).getInt(2);
+                            try {
+                                paddingBottom = ((CLArray) paddingObject).getInt(3);
+                            } catch (ArrayIndexOutOfBoundsException e) {
+                                paddingBottom = 0;
+                            }
+
+                        }
+                    } else {
+                        paddingStart = paddingObject.getInt();
+                        paddingTop = paddingStart;
+                        paddingEnd = paddingStart;
+                        paddingBottom = paddingStart;
+                    }
+                    grid.setPaddingStart(Math.round(toPix(state, paddingStart)));
+                    grid.setPaddingTop(Math.round(toPix(state, paddingTop)));
+                    grid.setPaddingEnd(Math.round(toPix(state, paddingEnd)));
+                    grid.setPaddingBottom(Math.round(toPix(state, paddingBottom)));
+                    break;
+                case "flags":
+                    int flagValue = 0;
+                    String flags = "";
+                    try {
+                        CLElement obj  = element.get(param);
+                        if (obj instanceof CLNumber) {
+                            flagValue = obj.getInt();
+                        } else {
+                            flags = obj.content();
+                        }
+                    } catch (Exception ex) {
+                        System.err.println("Error parsing grid flags " + ex);
+                    }
+
+                    if (flags != null && !flags.isEmpty()) {
+                        // In older APIs, the flags may still be defined as a String
+                        grid.setFlags(flags);
+                    } else {
+                        grid.setFlags(flagValue);
+                    }
+                    break;
+                default:
+                    ConstraintReference reference = state.constraints(name);
+                    applyAttribute(state, layoutVariables, reference, element, param);
+            }
+        }
+    }
+
+    /**
+     * It's used to parse the Flow type of Helper with the following format:
+     * flowID: {
+     *    type: 'hFlow'|'vFlow’
+     *    wrap: 'chain'|'none'|'aligned',
+     *    contains: ['id1', 'id2', 'id3' ] |
+     *              [['id1', weight, preMargin , postMargin], 'id2', 'id3'],
+     *    vStyle: 'spread'|'spread_inside'|'packed' | ['first', 'middle', 'last'],
+     *    hStyle: 'spread'|'spread_inside'|'packed' | ['first', 'middle', 'last'],
+     *    vAlign: 'top'|'bottom'|'baseline'|'center',
+     *    hAlign: 'start'|'end'|'center',
+     *    vGap: 32,
+     *    hGap: 23,
+     *    padding: 32,
+     *    maxElement: 5,
+     *    vBias: 0.3 | [0.0, 0.5, 0.5],
+     *    hBias: 0.4 | [0.0, 0.5, 0.5],
+     *    start: ['parent', 'start', 0],
+     *    end: ['parent', 'end', 0],
+     *    top: ['parent', 'top', 0],
+     *    bottom: ['parent', 'bottom', 0],
+     * }
+     *
+     * @param flowType orientation of the Flow Helper
+     * @param state ConstraintLayout State
+     * @param flowName the name of the Flow Helper
+     * @param layoutVariables layout margins
+     * @param element the element to be parsed
+     * @throws CLParsingException
+     */
+    private static void parseFlowType(String flowType,
+                                      State state,
+                                      String flowName,
+                                      LayoutVariables layoutVariables,
+                                      CLObject element) throws CLParsingException {
+        boolean isVertical = flowType.charAt(0) == 'v';
+        FlowReference flow = state.getFlow(flowName, isVertical);
+
+        for (String param : element.names()) {
+            switch (param) {
+                case "contains":
+                    CLElement refs = element.get(param);
+                    if (!(refs instanceof CLArray) || ((CLArray) refs).size() < 1) {
+                        System.err.println(
+                                flowName + " contains should be an array \"" + refs.content()
+                                        + "\"");
+                        return;
+                    }
+                    for (int i = 0; i < ((CLArray) refs).size(); i++) {
+                        CLElement chainElement = ((CLArray) refs).get(i);
+                        if (chainElement instanceof CLArray) {
+                            CLArray array = (CLArray) chainElement;
+                            if (array.size() > 0) {
+                                String id = array.get(0).content();
+                                float weight = Float.NaN;
+                                float preMargin = Float.NaN;
+                                float postMargin = Float.NaN;
+                                switch (array.size()) {
+                                    case 2: // sets only the weight
+                                        weight = array.getFloat(1);
+                                        break;
+                                    case 3: // sets the pre and post margin to the 2 arg
+                                        weight = array.getFloat(1);
+                                        postMargin = preMargin = toPix(state, array.getFloat(2));
+                                        break;
+                                    case 4: // sets the pre and post margin
+                                        weight = array.getFloat(1);
+                                        preMargin = toPix(state, array.getFloat(2));
+                                        postMargin = toPix(state, array.getFloat(3));
+                                        break;
+                                }
+                                flow.addFlowElement(id, weight, preMargin, postMargin);
+                            }
+                        } else {
+                            flow.add(chainElement.content());
+                        }
+                    }
+                    break;
+                case "type":
+                    if (element.get(param).content().equals("hFlow")) {
+                        flow.setOrientation(HORIZONTAL);
+                    } else {
+                        flow.setOrientation(VERTICAL);
+                    }
+                    break;
+                case "wrap":
+                    String wrapValue = element.get(param).content();
+                    flow.setWrapMode(State.Wrap.getValueByString(wrapValue));
+                    break;
+                case "vGap":
+                    int vGapValue = element.get(param).getInt();
+                    flow.setVerticalGap(vGapValue);
+                    break;
+                case "hGap":
+                    int hGapValue = element.get(param).getInt();
+                    flow.setHorizontalGap(hGapValue);
+                    break;
+                case "maxElement":
+                    int maxElementValue = element.get(param).getInt();
+                    flow.setMaxElementsWrap(maxElementValue);
+                    break;
+                case "padding":
+                    CLElement paddingObject = element.get(param);
+                    float paddingLeft = 0;
+                    float paddingTop = 0;
+                    float paddingRight = 0;
+                    float paddingBottom = 0;
+                    if (paddingObject instanceof CLArray && ((CLArray) paddingObject).size() > 1) {
+                        paddingLeft = ((CLArray) paddingObject).getInt(0);
+                        paddingRight = paddingLeft;
+                        paddingTop = ((CLArray) paddingObject).getInt(1);
+                        paddingBottom = paddingTop;
+                        if (((CLArray) paddingObject).size() > 2) {
+                            paddingRight = ((CLArray) paddingObject).getInt(2);
+                            try {
+                                paddingBottom = ((CLArray) paddingObject).getInt(3);
+                            } catch (ArrayIndexOutOfBoundsException e) {
+                                paddingBottom = 0;
+                            }
+
+                        }
+                    } else {
+                        paddingLeft = paddingObject.getInt();
+                        paddingTop = paddingLeft;
+                        paddingRight = paddingLeft;
+                        paddingBottom = paddingLeft;
+                    }
+                    flow.setPaddingLeft(Math.round(toPix(state, paddingLeft)));
+                    flow.setPaddingTop(Math.round(toPix(state, paddingTop)));
+                    flow.setPaddingRight(Math.round(toPix(state, paddingRight)));
+                    flow.setPaddingBottom(Math.round(toPix(state, paddingBottom)));
+                    break;
+                case "vAlign":
+                    String vAlignValue = element.get(param).content();
+                    switch (vAlignValue) {
+                        case "top":
+                            flow.setVerticalAlign(Flow.VERTICAL_ALIGN_TOP);
+                            break;
+                        case "bottom":
+                            flow.setVerticalAlign(Flow.VERTICAL_ALIGN_BOTTOM);
+                            break;
+                        case "baseline":
+                            flow.setVerticalAlign(Flow.VERTICAL_ALIGN_BASELINE);
+                            break;
+                        default:
+                            flow.setVerticalAlign(Flow.VERTICAL_ALIGN_CENTER);
+                            break;
+                    }
+                    break;
+                case "hAlign":
+                    String hAlignValue = element.get(param).content();
+                    switch (hAlignValue) {
+                        case "start":
+                            flow.setHorizontalAlign(Flow.HORIZONTAL_ALIGN_START);
+                            break;
+                        case "end":
+                            flow.setHorizontalAlign(Flow.HORIZONTAL_ALIGN_END);
+                            break;
+                        default:
+                            flow.setHorizontalAlign(Flow.HORIZONTAL_ALIGN_CENTER);
+                            break;
+                    }
+                    break;
+                case "vFlowBias":
+                    CLElement vBiasObject = element.get(param);
+                    Float vBiasValue = 0.5f;
+                    Float vFirstBiasValue = 0.5f;
+                    Float vLastBiasValue = 0.5f;
+                    if (vBiasObject instanceof CLArray && ((CLArray) vBiasObject).size() > 1) {
+                        vFirstBiasValue = ((CLArray) vBiasObject).getFloat(0);
+                        vBiasValue = ((CLArray) vBiasObject).getFloat(1);
+                        if (((CLArray) vBiasObject).size() > 2) {
+                            vLastBiasValue = ((CLArray) vBiasObject).getFloat(2);
+                        }
+                    } else {
+                        vBiasValue = vBiasObject.getFloat();
+                    }
+                    try {
+                        flow.verticalBias(vBiasValue);
+                        if (vFirstBiasValue != 0.5f) {
+                            flow.setFirstVerticalBias(vFirstBiasValue);
+                        }
+                        if (vLastBiasValue != 0.5f) {
+                            flow.setLastVerticalBias(vLastBiasValue);
+                        }
+                    } catch(NumberFormatException e) {
+
+                    }
+                    break;
+                case "hFlowBias":
+                    CLElement hBiasObject = element.get(param);
+                    Float hBiasValue = 0.5f;
+                    Float hFirstBiasValue = 0.5f;
+                    Float hLastBiasValue = 0.5f;
+                    if (hBiasObject instanceof CLArray && ((CLArray) hBiasObject).size() > 1) {
+                        hFirstBiasValue = ((CLArray) hBiasObject).getFloat(0);
+                        hBiasValue = ((CLArray) hBiasObject).getFloat(1);
+                        if (((CLArray) hBiasObject).size() > 2) {
+                            hLastBiasValue = ((CLArray) hBiasObject).getFloat(2);
+                        }
+                    } else {
+                        hBiasValue = hBiasObject.getFloat();
+                    }
+                    try {
+                        flow.horizontalBias(hBiasValue);
+                        if (hFirstBiasValue != 0.5f) {
+                            flow.setFirstHorizontalBias(hFirstBiasValue);
+                        }
+                        if (hLastBiasValue != 0.5f) {
+                            flow.setLastHorizontalBias(hLastBiasValue);
+                        }
+                    } catch(NumberFormatException e) {
+
+                    }
+                    break;
+                case "vStyle":
+                    CLElement vStyleObject = element.get(param);
+                    String vStyleValueStr = "";
+                    String vFirstStyleValueStr = "";
+                    String vLastStyleValueStr = "";
+                    if (vStyleObject instanceof CLArray && ((CLArray) vStyleObject).size() > 1) {
+                        vFirstStyleValueStr = ((CLArray) vStyleObject).getString(0);
+                        vStyleValueStr = ((CLArray) vStyleObject).getString(1);
+                        if (((CLArray) vStyleObject).size() > 2) {
+                            vLastStyleValueStr = ((CLArray) vStyleObject).getString(2);
+                        }
+                    } else {
+                        vStyleValueStr = vStyleObject.content();
+                    }
+
+                    if (!vStyleValueStr.equals("")) {
+                        flow.setVerticalStyle(State.Chain.getValueByString(vStyleValueStr));
+                    }
+                    if (!vFirstStyleValueStr.equals("")) {
+                        flow.setFirstVerticalStyle(
+                                State.Chain.getValueByString(vFirstStyleValueStr));
+                    }
+                    if (!vLastStyleValueStr.equals("")) {
+                        flow.setLastVerticalStyle(State.Chain.getValueByString(vLastStyleValueStr));
+                    }
+                    break;
+                case "hStyle":
+                    CLElement hStyleObject = element.get(param);
+                    String hStyleValueStr = "";
+                    String hFirstStyleValueStr = "";
+                    String hLastStyleValueStr = "";
+                    if (hStyleObject instanceof CLArray && ((CLArray) hStyleObject).size() > 1) {
+                        hFirstStyleValueStr = ((CLArray) hStyleObject).getString(0);
+                        hStyleValueStr = ((CLArray) hStyleObject).getString(1);
+                        if (((CLArray) hStyleObject).size() > 2) {
+                            hLastStyleValueStr = ((CLArray) hStyleObject).getString(2);
+                        }
+                    } else {
+                        hStyleValueStr = hStyleObject.content();
+                    }
+
+                    if (!hStyleValueStr.equals("")) {
+                        flow.setHorizontalStyle(State.Chain.getValueByString(hStyleValueStr));
+                    }
+                    if (!hFirstStyleValueStr.equals("")) {
+                        flow.setFirstHorizontalStyle(
+                                State.Chain.getValueByString(hFirstStyleValueStr));
+                    }
+                    if (!hLastStyleValueStr.equals("")) {
+                        flow.setLastHorizontalStyle(
+                                State.Chain.getValueByString(hLastStyleValueStr));
+                    }
+                    break;
+                default:
+                    // Get the underlying reference for the flow, apply the constraints
+                    // attributes to it
+                    ConstraintReference reference = state.constraints(flowName);
+                    applyAttribute(state, layoutVariables, reference, element, param);
+            }
+        }
+    }
+
+    static void parseGuideline(int orientation,
+                               State state, CLArray helper) throws CLParsingException {
+        CLElement params = helper.get(1);
+        if (!(params instanceof CLObject)) {
+            return;
+        }
+        String guidelineId = ((CLObject) params).getStringOrNull("id");
+        if (guidelineId == null) return;
+        parseGuidelineParams(orientation, state, guidelineId, (CLObject) params);
+    }
+
+    static void parseGuidelineParams(
+            int orientation,
+            State state,
+            String guidelineId,
+            CLObject params
+    ) throws CLParsingException {
+        ArrayList<String> constraints = params.names();
+        if (constraints == null) return;
+        ConstraintReference reference = state.constraints(guidelineId);
+
+        if (orientation == ConstraintWidget.HORIZONTAL) {
+            state.horizontalGuideline(guidelineId);
+        } else {
+            state.verticalGuideline(guidelineId);
+        }
+
+        // Layout direction may be ignored for Horizontal guidelines (placed along the Y axis),
+        // since `start` & `end` represent the `top` and `bottom` distances respectively.
+        boolean isLtr = !state.isRtl() || orientation == ConstraintWidget.HORIZONTAL;
+
+        GuidelineReference guidelineReference = (GuidelineReference) reference.getFacade();
+
+        // Whether the guideline is based on percentage or distance
+        boolean isPercent = false;
+
+        // Percent or distance value of the guideline
+        float value = 0f;
+
+        // Indicates if the value is considered from the "start" position,
+        // meaning "left" anchor for vertical guidelines and "top" anchor for
+        // horizontal guidelines
+        boolean fromStart = true;
+        for (String constraintName : constraints) {
+            switch (constraintName) {
+                // left and right are here just to support LTR independent vertical guidelines
+                case "left":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = true;
+                    break;
+                case "right":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = false;
+                    break;
+                case "start":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = isLtr;
+                    break;
+                case "end":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = !isLtr;
+                    break;
+                case "percent":
+                    isPercent = true;
+                    CLArray percentParams = params.getArrayOrNull(constraintName);
+                    if (percentParams == null) {
+                        fromStart = true;
+                        value = params.getFloat(constraintName);
+                    } else if (percentParams.size() > 1) {
+                        String origin = percentParams.getString(0);
+                        value = percentParams.getFloat(1);
+                        switch (origin) {
+                            case "left":
+                                fromStart = true;
+                                break;
+                            case "right":
+                                fromStart = false;
+                                break;
+                            case "start":
+                                fromStart = isLtr;
+                                break;
+                            case "end":
+                                fromStart = !isLtr;
+                                break;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        // Populate the guideline based on the resolved properties
+        if (isPercent) {
+            if (fromStart) {
+                guidelineReference.percent(value);
+            } else {
+                guidelineReference.percent(1f - value);
+            }
+        } else {
+            if (fromStart) {
+                guidelineReference.start(value);
+            } else {
+                guidelineReference.end(value);
+            }
+        }
+    }
+
+    static void parseBarrier(
+            State state,
+            String elementName, CLObject element
+    ) throws CLParsingException {
+        boolean isLtr = !state.isRtl();
+        BarrierReference reference = state.barrier(elementName, State.Direction.END);
+        ArrayList<String> constraints = element.names();
+        if (constraints == null) {
+            return;
+        }
+        for (String constraintName : constraints) {
+            switch (constraintName) {
+                case "direction": {
+                    switch (element.getString(constraintName)) {
+                        case "start":
+                            if (isLtr) {
+                                reference.setBarrierDirection(State.Direction.LEFT);
+                            } else {
+                                reference.setBarrierDirection(State.Direction.RIGHT);
+                            }
+                            break;
+                        case "end":
+                            if (isLtr) {
+                                reference.setBarrierDirection(State.Direction.RIGHT);
+                            } else {
+                                reference.setBarrierDirection(State.Direction.LEFT);
+                            }
+                            break;
+                        case "left":
+                            reference.setBarrierDirection(State.Direction.LEFT);
+                            break;
+                        case "right":
+                            reference.setBarrierDirection(State.Direction.RIGHT);
+                            break;
+                        case "top":
+                            reference.setBarrierDirection(State.Direction.TOP);
+                            break;
+                        case "bottom":
+                            reference.setBarrierDirection(State.Direction.BOTTOM);
+                            break;
+                    }
+                }
+                break;
+                case "margin":
+                    float margin = element.getFloatOrNaN(constraintName);
+                    if (!Float.isNaN(margin)) {
+                        reference.margin(toPix(state, margin));
+                    }
+                    break;
+                case "contains":
+                    CLArray list = element.getArrayOrNull(constraintName);
+                    if (list != null) {
+                        for (int j = 0; j < list.size(); j++) {
+
+                            String elementNameReference = list.get(j).content();
+                            ConstraintReference elementReference =
+                                    state.constraints(elementNameReference);
+                            if (PARSER_DEBUG) {
+                                System.out.println(
+                                        "Add REFERENCE "
+                                                + "($elementNameReference = $elementReference) "
+                                                + "TO BARRIER "
+                                );
+                            }
+                            reference.add(elementReference);
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    static void parseWidget(
+            State state,
+            LayoutVariables layoutVariables,
+            String elementName,
+            CLObject element
+    ) throws CLParsingException {
+        ConstraintReference reference = state.constraints(elementName);
+        parseWidget(state, layoutVariables, reference, element);
+    }
+
+    /**
+     * Set/apply attribute to a widget/helper reference
+     *
+     * @param state Constraint State
+     * @param layoutVariables layout variables
+     * @param reference widget/helper reference
+     * @param element the parsed CLObject
+     * @param attributeName Name of the attribute to be set/applied
+     * @throws CLParsingException
+     */
+    static void applyAttribute(
+            State state,
+            LayoutVariables layoutVariables,
+            ConstraintReference reference,
+            CLObject element,
+            String attributeName) throws CLParsingException {
+
+        float value;
+        switch (attributeName) {
+            case "width":
+                reference.setWidth(parseDimension(element,
+                        attributeName, state, state.getDpToPixel()));
+                break;
+            case "height":
+                reference.setHeight(parseDimension(element,
+                        attributeName, state, state.getDpToPixel()));
+                break;
+            case "center":
+                String target = element.getString(attributeName);
+
+                ConstraintReference targetReference;
+                if (target.equals("parent")) {
+                    targetReference = state.constraints(State.PARENT);
+                } else {
+                    targetReference = state.constraints(target);
+                }
+                reference.startToStart(targetReference);
+                reference.endToEnd(targetReference);
+                reference.topToTop(targetReference);
+                reference.bottomToBottom(targetReference);
+                break;
+            case "centerHorizontally":
+                target = element.getString(attributeName);
+                targetReference = target.equals("parent")
+                        ? state.constraints(State.PARENT) : state.constraints(target);
+
+                reference.startToStart(targetReference);
+                reference.endToEnd(targetReference);
+                break;
+            case "centerVertically":
+                target = element.getString(attributeName);
+                targetReference = target.equals("parent")
+                        ? state.constraints(State.PARENT) : state.constraints(target);
+
+                reference.topToTop(targetReference);
+                reference.bottomToBottom(targetReference);
+                break;
+            case "alpha":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.alpha(value);
+                break;
+            case "scaleX":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.scaleX(value);
+                break;
+            case "scaleY":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.scaleY(value);
+                break;
+            case "translationX":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.translationX(toPix(state, value));
+                break;
+            case "translationY":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.translationY(toPix(state, value));
+                break;
+            case "translationZ":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.translationZ(toPix(state, value));
+                break;
+            case "pivotX":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.pivotX(value);
+                break;
+            case "pivotY":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.pivotY(value);
+                break;
+            case "rotationX":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.rotationX(value);
+                break;
+            case "rotationY":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.rotationY(value);
+                break;
+            case "rotationZ":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.rotationZ(value);
+                break;
+            case "visibility":
+                switch (element.getString(attributeName)) {
+                    case "visible":
+                        reference.visibility(ConstraintWidget.VISIBLE);
+                        break;
+                    case "invisible":
+                        reference.visibility(ConstraintWidget.INVISIBLE);
+                        reference.alpha(0f);
+                        break;
+                    case "gone":
+                        reference.visibility(ConstraintWidget.GONE);
+                        break;
+                }
+                break;
+            case "vBias":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.verticalBias(value);
+                break;
+            case "hRtlBias":
+                // TODO: This is a temporary solution to support bias with start/end constraints,
+                //  where the bias needs to be reversed in RTL, we probably want a better or more
+                //  intuitive way to do this
+                value = layoutVariables.get(element.get(attributeName));
+                if (state.isRtl()) {
+                    value = 1f - value;
+                }
+                reference.horizontalBias(value);
+                break;
+            case "hBias":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.horizontalBias(value);
+                break;
+            case "vWeight":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.setVerticalChainWeight(value);
+                break;
+            case "hWeight":
+                value = layoutVariables.get(element.get(attributeName));
+                reference.setHorizontalChainWeight(value);
+                break;
+            case "custom":
+                parseCustomProperties(element, reference, attributeName);
+                break;
+            case "motion":
+                parseMotionProperties(element.get(attributeName), reference);
+                break;
+            default:
+                parseConstraint(state, layoutVariables, element, reference, attributeName);
+        }
+    }
+
+    static void parseWidget(
+            State state,
+            LayoutVariables layoutVariables,
+            ConstraintReference reference,
+            CLObject element
+    ) throws CLParsingException {
+        if (reference.getWidth() == null) {
+            // Default to Wrap when the Dimension has not been assigned
+            reference.setWidth(Dimension.createWrap());
+        }
+        if (reference.getHeight() == null) {
+            // Default to Wrap when the Dimension has not been assigned
+            reference.setHeight(Dimension.createWrap());
+        }
+        ArrayList<String> constraints = element.names();
+        if (constraints == null) {
+            return;
+        }
+        for (String constraintName : constraints) {
+            applyAttribute(state, layoutVariables, reference, element, constraintName);
+        }
+    }
+
+    static void parseCustomProperties(
+            CLObject element,
+            ConstraintReference reference,
+            String constraintName
+    ) throws CLParsingException {
+        CLObject json = element.getObjectOrNull(constraintName);
+        if (json == null) {
+            return;
+        }
+        ArrayList<String> properties = json.names();
+        if (properties == null) {
+            return;
+        }
+        for (String property : properties) {
+            CLElement value = json.get(property);
+            if (value instanceof CLNumber) {
+                reference.addCustomFloat(property, value.getFloat());
+            } else if (value instanceof CLString) {
+                long it = parseColorString(value.content());
+                if (it != -1) {
+                    reference.addCustomColor(property, (int) it);
+                }
+            }
+        }
+    }
+
+    private static int indexOf(String val, String... types) {
+        for (int i = 0; i < types.length; i++) {
+            if (types[i].equals(val)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * parse the motion section of a constraint
+     * <pre>
+     * csetName: {
+     *   idToConstrain : {
+     *       motion: {
+     *          pathArc : 'startVertical'
+     *          relativeTo: 'id'
+     *          easing: 'curve'
+     *          stagger: '2'
+     *          quantize: steps or [steps, 'interpolator' phase ]
+     *       }
+     *   }
+     * }
+     * </pre>
+     */
+    private static void parseMotionProperties(
+            CLElement element,
+            ConstraintReference reference
+    ) throws CLParsingException {
+        if (!(element instanceof CLObject)) {
+            return;
+        }
+        CLObject obj = (CLObject) element;
+        TypedBundle bundle = new TypedBundle();
+        ArrayList<String> constraints = obj.names();
+        if (constraints == null) {
+            return;
+        }
+        for (String constraintName : constraints) {
+
+            switch (constraintName) {
+                case "pathArc":
+                    String val = obj.getString(constraintName);
+                    int ord = indexOf(val, "none", "startVertical", "startHorizontal", "flip",
+                            "below", "above");
+                    if (ord == -1) {
+                        System.err.println(obj.getLine() + " pathArc = '" + val + "'");
+                        break;
+                    }
+                    bundle.add(TypedValues.MotionType.TYPE_PATHMOTION_ARC, ord);
+                    break;
+                case "relativeTo":
+                    bundle.add(TypedValues.MotionType.TYPE_ANIMATE_RELATIVE_TO,
+                            obj.getString(constraintName));
+                    break;
+                case "easing":
+                    bundle.add(TypedValues.MotionType.TYPE_EASING, obj.getString(constraintName));
+                    break;
+                case "stagger":
+                    bundle.add(TypedValues.MotionType.TYPE_STAGGER, obj.getFloat(constraintName));
+                    break;
+                case "quantize":
+                    CLElement quant = obj.get(constraintName);
+                    if (quant instanceof CLArray) {
+                        CLArray array = (CLArray) quant;
+                        int len = array.size();
+                        if (len > 0) {
+                            bundle.add(TYPE_QUANTIZE_MOTIONSTEPS, array.getInt(0));
+                            if (len > 1) {
+                                bundle.add(TYPE_QUANTIZE_INTERPOLATOR_TYPE, array.getString(1));
+                                if (len > 2) {
+                                    bundle.add(TYPE_QUANTIZE_MOTION_PHASE, array.getFloat(2));
+                                }
+                            }
+                        }
+                    } else {
+                        bundle.add(TYPE_QUANTIZE_MOTIONSTEPS, obj.getInt(constraintName));
+                    }
+                    break;
+            }
+        }
+        reference.mMotionProperties = bundle;
+    }
+
+    static void parseConstraint(
+            State state,
+            LayoutVariables layoutVariables,
+            CLObject element,
+            ConstraintReference reference,
+            String constraintName
+    ) throws CLParsingException {
+        boolean isLtr = !state.isRtl();
+        CLArray constraint = element.getArrayOrNull(constraintName);
+        if (constraint != null && constraint.size() > 1) {
+            // params: target, anchor
+            String target = constraint.getString(0);
+            String anchor = constraint.getStringOrNull(1);
+            float margin = 0f;
+            float marginGone = 0f;
+            if (constraint.size() > 2) {
+                // params: target, anchor, margin
+                CLElement arg2 = constraint.getOrNull(2);
+                margin = layoutVariables.get(arg2);
+                margin = toPix(state, margin);
+            }
+            if (constraint.size() > 3) {
+                // params: target, anchor, margin, marginGone
+                CLElement arg2 = constraint.getOrNull(3);
+                marginGone = layoutVariables.get(arg2);
+                marginGone = toPix(state, marginGone);
+            }
+
+            ConstraintReference targetReference = target.equals("parent")
+                    ? state.constraints(State.PARENT) :
+                    state.constraints(target);
+
+            // For simplicity, we'll apply horizontal constraints separately
+            boolean isHorizontalConstraint = false;
+            boolean isHorOriginLeft = true;
+            boolean isHorTargetLeft = true;
+
+            switch (constraintName) {
+                case "circular":
+                    float angle = layoutVariables.get(constraint.get(1));
+                    float distance = 0f;
+                    if (constraint.size() > 2) {
+                        CLElement distanceArg = constraint.getOrNull(2);
+                        distance = layoutVariables.get(distanceArg);
+                        distance = toPix(state, distance);
+                    }
+                    reference.circularConstraint(targetReference, angle, distance);
+                    break;
+                case "top":
+                    switch (anchor) {
+                        case "top":
+                            reference.topToTop(targetReference);
+                            break;
+                        case "bottom":
+                            reference.topToBottom(targetReference);
+                            break;
+                        case "baseline":
+                            state.baselineNeededFor(targetReference.getKey());
+                            reference.topToBaseline(targetReference);
+                            break;
+                    }
+                    break;
+                case "bottom":
+                    switch (anchor) {
+                        case "top":
+                            reference.bottomToTop(targetReference);
+                            break;
+                        case "bottom":
+                            reference.bottomToBottom(targetReference);
+                            break;
+                        case "baseline":
+                            state.baselineNeededFor(targetReference.getKey());
+                            reference.bottomToBaseline(targetReference);
+                    }
+                    break;
+                case "baseline":
+                    switch (anchor) {
+                        case "baseline":
+                            state.baselineNeededFor(reference.getKey());
+                            state.baselineNeededFor(targetReference.getKey());
+                            reference.baselineToBaseline(targetReference);
+                            break;
+                        case "top":
+                            state.baselineNeededFor(reference.getKey());
+                            reference.baselineToTop(targetReference);
+                            break;
+                        case "bottom":
+                            state.baselineNeededFor(reference.getKey());
+                            reference.baselineToBottom(targetReference);
+                            break;
+                    }
+                    break;
+                case "left":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = true;
+                    break;
+                case "right":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = false;
+                    break;
+                case "start":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = isLtr;
+                    break;
+                case "end":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = !isLtr;
+                    break;
+            }
+
+            if (isHorizontalConstraint) {
+                // Resolve horizontal target anchor
+                switch (anchor) {
+                    case "left":
+                        isHorTargetLeft = true;
+                        break;
+                    case "right":
+                        isHorTargetLeft = false;
+                        break;
+                    case "start":
+                        isHorTargetLeft = isLtr;
+                        break;
+                    case "end":
+                        isHorTargetLeft = !isLtr;
+                        break;
+                }
+
+                // Resolved anchors, apply corresponding constraint
+                if (isHorOriginLeft) {
+                    if (isHorTargetLeft) {
+                        reference.leftToLeft(targetReference);
+                    } else {
+                        reference.leftToRight(targetReference);
+                    }
+                } else {
+                    if (isHorTargetLeft) {
+                        reference.rightToLeft(targetReference);
+                    } else {
+                        reference.rightToRight(targetReference);
+                    }
+                }
+            }
+
+            reference.margin(margin).marginGone(marginGone);
+        } else {
+            String target = element.getStringOrNull(constraintName);
+            if (target != null) {
+                ConstraintReference targetReference = target.equals("parent")
+                        ? state.constraints(State.PARENT) :
+                        state.constraints(target);
+
+                switch (constraintName) {
+                    case "start":
+                        if (isLtr) {
+                            reference.leftToLeft(targetReference);
+                        } else {
+                            reference.rightToRight(targetReference);
+                        }
+                        break;
+                    case "end":
+                        if (isLtr) {
+                            reference.rightToRight(targetReference);
+                        } else {
+                            reference.leftToLeft(targetReference);
+                        }
+                        break;
+                    case "top":
+                        reference.topToTop(targetReference);
+                        break;
+                    case "bottom":
+                        reference.bottomToBottom(targetReference);
+                        break;
+                    case "baseline":
+                        state.baselineNeededFor(reference.getKey());
+                        state.baselineNeededFor(targetReference.getKey());
+                        reference.baselineToBaseline(targetReference);
+                        break;
+                }
+            }
+        }
+    }
+
+    static Dimension parseDimensionMode(String dimensionString) {
+        Dimension dimension = Dimension.createFixed(0);
+        switch (dimensionString) {
+            case "wrap":
+                dimension = Dimension.createWrap();
+                break;
+            case "preferWrap":
+                dimension = Dimension.createSuggested(Dimension.WRAP_DIMENSION);
+                break;
+            case "spread":
+                dimension = Dimension.createSuggested(Dimension.SPREAD_DIMENSION);
+                break;
+            case "parent":
+                dimension = Dimension.createParent();
+                break;
+            default: {
+                if (dimensionString.endsWith("%")) {
+                    // parent percent
+                    String percentString =
+                            dimensionString.substring(0, dimensionString.indexOf('%'));
+                    float percentValue = Float.parseFloat(percentString) / 100f;
+                    dimension = Dimension.createPercent(0, percentValue).suggested(0);
+                } else if (dimensionString.contains(":")) {
+                    dimension = Dimension.createRatio(dimensionString)
+                            .suggested(Dimension.SPREAD_DIMENSION);
+                }
+            }
+        }
+        return dimension;
+    }
+
+    static Dimension parseDimension(CLObject element,
+                                    String constraintName,
+                                    State state,
+                                    CorePixelDp dpToPixels) throws CLParsingException {
+        CLElement dimensionElement = element.get(constraintName);
+        Dimension dimension = Dimension.createFixed(0);
+        if (dimensionElement instanceof CLString) {
+            dimension = parseDimensionMode(dimensionElement.content());
+        } else if (dimensionElement instanceof CLNumber) {
+            dimension = Dimension.createFixed(
+                    state.convertDimension(dpToPixels.toPixels(element.getFloat(constraintName))));
+
+        } else if (dimensionElement instanceof CLObject) {
+            CLObject obj = (CLObject) dimensionElement;
+            String mode = obj.getStringOrNull("value");
+            if (mode != null) {
+                dimension = parseDimensionMode(mode);
+            }
+
+            CLElement minEl = obj.getOrNull("min");
+            if (minEl != null) {
+                if (minEl instanceof CLNumber) {
+                    float min = ((CLNumber) minEl).getFloat();
+                    dimension.min(state.convertDimension(dpToPixels.toPixels(min)));
+                } else if (minEl instanceof CLString) {
+                    dimension.min(Dimension.WRAP_DIMENSION);
+                }
+            }
+            CLElement maxEl = obj.getOrNull("max");
+            if (maxEl != null) {
+                if (maxEl instanceof CLNumber) {
+                    float max = ((CLNumber) maxEl).getFloat();
+                    dimension.max(state.convertDimension(dpToPixels.toPixels(max)));
+                } else if (maxEl instanceof CLString) {
+                    dimension.max(Dimension.WRAP_DIMENSION);
+                }
+            }
+        }
+        return dimension;
+    }
+
+    /**
+     * parse a color string
+     *
+     * @return -1 if it cannot parse unsigned long
+     */
+    static long parseColorString(String value) {
+        String str = value;
+        if (str.startsWith("#")) {
+            str = str.substring(1);
+            if (str.length() == 6) {
+                str = "FF" + str;
+            }
+            return Long.parseLong(str, 16);
+        } else {
+            return -1L;
+        }
+    }
+
+    static String lookForType(CLObject element) throws CLParsingException {
+        ArrayList<String> constraints = element.names();
+        for (String constraintName : constraints) {
+            if (constraintName.equals("type")) {
+                return element.getString("type");
+            }
+        }
+        return null;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/CoreMotionScene.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/CoreMotionScene.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+/**
+ * This defines the interface to motionScene functionality
+ */
+public interface CoreMotionScene {
+
+    /**
+     * set the Transitions string onto the MotionScene
+     *
+     * @param elementName the name of the element
+     * @param toJSON the json string of the transitioncontent
+     */
+    void setTransitionContent(String elementName, String toJSON);
+
+    /**
+     * Get the ConstraintSet as a string
+     */
+    String getConstraintSet(String ext);
+
+    /**
+     * set the constraintSet json string
+     *
+     * @param csName the name of the constraint set
+     * @param toJSON the json string of the constraintset
+     */
+    void setConstraintSetContent(String csName, String toJSON);
+
+    /**
+     * set the debug name for remote access
+     *
+     * @param name name to call this motion scene
+     */
+    void setDebugName(String name);
+
+    /**
+     * get a transition give the name
+     *
+     * @param str the name of the transition
+     * @return the json of the transition
+     */
+    String getTransition(String str);
+
+    /**
+     * get a constraintset
+     *
+     * @param index of the constraintset
+     */
+    String getConstraintSet(int index);
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/CorePixelDp.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/CorePixelDp.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+public interface CorePixelDp {
+    /**
+     * Convert dp to pixels
+     *
+     * @param dp the value in dip
+     * @return the value in pixels
+     */
+    float toPixels(float dp);
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/Dimension.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/Dimension.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+/**
+ * Represents a dimension (width or height) of a constrained widget
+ */
+public class Dimension {
+
+    public static final Object FIXED_DIMENSION = new String("FIXED_DIMENSION");
+    public static final Object WRAP_DIMENSION = new String("WRAP_DIMENSION");
+    public static final Object SPREAD_DIMENSION = new String("SPREAD_DIMENSION");
+    public static final Object PARENT_DIMENSION = new String("PARENT_DIMENSION");
+    public static final Object PERCENT_DIMENSION = new String("PERCENT_DIMENSION");
+    public static final Object RATIO_DIMENSION = new String("RATIO_DIMENSION");
+
+    private final int mWrapContent = -2;
+
+    int mMin = 0;
+    int mMax = Integer.MAX_VALUE;
+    float mPercent = 1f;
+    int mValue = 0;
+    String mRatioString = null;
+    Object mInitialValue = WRAP_DIMENSION;
+    boolean mIsSuggested = false;
+
+    /**
+     * Returns true if the dimension is a fixed dimension of
+     * the same given value
+     */
+    public boolean equalsFixedValue(int value) {
+        if (mInitialValue == null
+                && mValue == value) {
+            return true;
+        }
+        return false;
+    }
+
+    public enum Type {
+        FIXED,
+        WRAP,
+        MATCH_PARENT,
+        MATCH_CONSTRAINT
+    }
+
+    private Dimension() {
+    }
+
+    private Dimension(Object type) {
+        mInitialValue = type;
+    }
+
+    /**
+     * @deprecated Use {@link #createSuggested(int)} instead
+     */
+    @Deprecated
+    public static Dimension Suggested(int value) {
+        return createSuggested(value);
+    }
+
+    // @TODO: add description
+    public static Dimension createSuggested(int value) {
+        Dimension dimension = new Dimension();
+        dimension.suggested(value);
+        return dimension;
+    }
+
+    /**
+     * @deprecated Use {@link #createSuggested(Object)} instead
+     */
+    @Deprecated
+    public static Dimension Suggested(Object startValue) {
+        return createSuggested(startValue);
+    }
+
+    // @TODO: add description
+    public static Dimension createSuggested(Object startValue) {
+        Dimension dimension = new Dimension();
+        dimension.suggested(startValue);
+        return dimension;
+    }
+
+    /**
+     * @deprecated Use {@link #createFixed(int)} instead
+     */
+    @Deprecated
+    public static Dimension Fixed(int value) {
+        return createFixed(value);
+    }
+
+    // @TODO: add description
+    public static Dimension createFixed(int value) {
+        Dimension dimension = new Dimension(FIXED_DIMENSION);
+        dimension.fixed(value);
+        return dimension;
+    }
+
+    /**
+     * @deprecated Use {@link #createFixed(Object)} instead
+     */
+    @Deprecated
+    public static Dimension Fixed(Object value) {
+        Dimension dimension = new Dimension(FIXED_DIMENSION);
+        dimension.fixed(value);
+        return dimension;
+    }
+
+    // @TODO: add description
+    public static Dimension createFixed(Object value) {
+        Dimension dimension = new Dimension(FIXED_DIMENSION);
+        dimension.fixed(value);
+        return dimension;
+    }
+
+    /**
+     * @deprecated Use {@link #createPercent(Object, float)} instead
+     */
+    @Deprecated
+    public static Dimension Percent(Object key, float value) {
+        return createPercent(key, value);
+    }
+
+    // @TODO: add description
+    public static Dimension createPercent(Object key, float value) {
+        Dimension dimension = new Dimension(PERCENT_DIMENSION);
+        dimension.percent(key, value);
+        return dimension;
+    }
+
+    /**
+     * @deprecated Use {@link #createParent()} instead
+     */
+    @Deprecated
+    public static Dimension Parent() {
+        return createParent();
+    }
+
+    // @TODO: add description
+    public static Dimension createParent() {
+        return new Dimension(PARENT_DIMENSION);
+    }
+
+    /**
+     * @deprecated Use {@link #createWrap()} instead
+     */
+    @Deprecated
+    public static Dimension Wrap() {
+        return createWrap();
+    }
+
+    // @TODO: add description
+    public static Dimension createWrap() {
+        return new Dimension(WRAP_DIMENSION);
+    }
+
+    /**
+     * @deprecated Use {@link #createSpread()} instead
+     */
+    @Deprecated
+    public static Dimension Spread() {
+        return createSpread();
+    }
+
+    // @TODO: add description
+    public static Dimension createSpread() {
+        return new Dimension(SPREAD_DIMENSION);
+    }
+
+    /**
+     * @deprecated Use {@link #createRatio(String)} instead
+     */
+    @Deprecated
+    public static Dimension Ratio(String ratio) {
+        return createRatio(ratio);
+    }
+
+    // @TODO: add description
+    public static Dimension createRatio(String ratio) {
+        Dimension dimension = new Dimension(RATIO_DIMENSION);
+        dimension.ratio(ratio);
+        return dimension;
+    }
+
+    // @TODO: add description
+    public Dimension percent(Object key, float value) {
+        mPercent = value;
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension min(int value) {
+        if (value >= 0) {
+            mMin = value;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension min(Object value) {
+        if (value == WRAP_DIMENSION) {
+            mMin = mWrapContent;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension max(int value) {
+        if (mMax >= 0) {
+            mMax = value;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension max(Object value) {
+        if (value == WRAP_DIMENSION && mIsSuggested) {
+            mInitialValue = WRAP_DIMENSION;
+            mMax = Integer.MAX_VALUE;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension suggested(int value) {
+        mIsSuggested = true;
+        if (value >= 0) {
+            mMax = value;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension suggested(Object value) {
+        mInitialValue = value;
+        mIsSuggested = true;
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension fixed(Object value) {
+        mInitialValue = value;
+        if (value instanceof Integer) {
+            mValue = (Integer) value;
+            mInitialValue = null;
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension fixed(int value) {
+        mInitialValue = null;
+        mValue = value;
+        return this;
+    }
+
+    // @TODO: add description
+    public Dimension ratio(String ratio) { // WxH ratio
+        mRatioString = ratio;
+        return this;
+    }
+
+    void setValue(int value) {
+        mIsSuggested = false; // fixed value
+        mInitialValue = null;
+        mValue = value;
+    }
+
+    int getValue() {
+        return mValue;
+    }
+
+    /**
+     * Apply the dimension to the given constraint widget
+     */
+    public void apply(State state, ConstraintWidget constraintWidget, int orientation) {
+        if (mRatioString != null) {
+            constraintWidget.setDimensionRatio(mRatioString);
+        }
+        if (orientation == ConstraintWidget.HORIZONTAL) {
+            if (mIsSuggested) {
+                constraintWidget.setHorizontalDimensionBehaviour(
+                        ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT);
+                int type = MATCH_CONSTRAINT_SPREAD;
+                if (mInitialValue == WRAP_DIMENSION) {
+                    type = MATCH_CONSTRAINT_WRAP;
+                } else if (mInitialValue == PERCENT_DIMENSION) {
+                    type = MATCH_CONSTRAINT_PERCENT;
+                }
+                constraintWidget.setHorizontalMatchStyle(type, mMin, mMax, mPercent);
+            } else { // fixed
+                if (mMin > 0) {
+                    constraintWidget.setMinWidth(mMin);
+                }
+                if (mMax < Integer.MAX_VALUE) {
+                    constraintWidget.setMaxWidth(mMax);
+                }
+                if (mInitialValue == WRAP_DIMENSION) {
+                    constraintWidget.setHorizontalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.WRAP_CONTENT);
+                } else if (mInitialValue == PARENT_DIMENSION) {
+                    constraintWidget.setHorizontalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.MATCH_PARENT);
+                } else if (mInitialValue == null) {
+                    constraintWidget.setHorizontalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.FIXED);
+                    constraintWidget.setWidth(mValue);
+                }
+            }
+        } else {
+            if (mIsSuggested) {
+                constraintWidget.setVerticalDimensionBehaviour(
+                        ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT);
+                int type = MATCH_CONSTRAINT_SPREAD;
+                if (mInitialValue == WRAP_DIMENSION) {
+                    type = MATCH_CONSTRAINT_WRAP;
+                } else if (mInitialValue == PERCENT_DIMENSION) {
+                    type = MATCH_CONSTRAINT_PERCENT;
+                }
+                constraintWidget.setVerticalMatchStyle(type, mMin, mMax, mPercent);
+            } else { // fixed
+                if (mMin > 0) {
+                    constraintWidget.setMinHeight(mMin);
+                }
+                if (mMax < Integer.MAX_VALUE) {
+                    constraintWidget.setMaxHeight(mMax);
+                }
+                if (mInitialValue == WRAP_DIMENSION) {
+                    constraintWidget.setVerticalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.WRAP_CONTENT);
+                } else if (mInitialValue == PARENT_DIMENSION) {
+                    constraintWidget.setVerticalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.MATCH_PARENT);
+                } else if (mInitialValue == null) {
+                    constraintWidget.setVerticalDimensionBehaviour(
+                            ConstraintWidget.DimensionBehaviour.FIXED);
+                    constraintWidget.setHeight(mValue);
+                }
+            }
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/HelperReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/HelperReference.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import androidx.constraintlayout.core.state.helpers.Facade;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class HelperReference extends ConstraintReference implements Facade {
+    protected final State mHelperState;
+    final State.Helper mType;
+    protected ArrayList<Object> mReferences = new ArrayList<>();
+    private HelperWidget mHelperWidget;
+
+    public HelperReference(State state, State.Helper type) {
+        super(state);
+        mHelperState = state;
+        mType = type;
+    }
+
+    public State.Helper getType() {
+        return mType;
+    }
+
+    // @TODO: add description
+    public HelperReference add(Object... objects) {
+        Collections.addAll(mReferences, objects);
+        return this;
+    }
+
+    public void setHelperWidget(HelperWidget helperWidget) {
+        mHelperWidget = helperWidget;
+    }
+
+    public HelperWidget getHelperWidget() {
+        return mHelperWidget;
+    }
+
+    @Override
+    public ConstraintWidget getConstraintWidget() {
+        return getHelperWidget();
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        // nothing
+    }
+
+    /**
+     * Allows the derived classes to invoke the apply method in the ConstraintReference
+     */
+    public void applyBase() {
+        super.apply();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/Interpolator.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/Interpolator.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+public interface Interpolator {
+    // @TODO: add description
+    float getInterpolation(float input);
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/Reference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/Reference.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import androidx.constraintlayout.core.state.helpers.Facade;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+public interface Reference {
+    // @TODO: add description
+    ConstraintWidget getConstraintWidget();
+
+    // @TODO: add description
+    void setConstraintWidget(ConstraintWidget widget);
+
+    // @TODO: add description
+    void setKey(Object key);
+
+    // @TODO: add description
+    Object getKey();
+
+    // @TODO: add description
+    void apply();
+
+    // @TODO: add description
+    Facade getFacade();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/Registry.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/Registry.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class Registry {
+
+    private static final Registry sRegistry = new Registry();
+
+    public static Registry getInstance() {
+        return sRegistry;
+    }
+
+    private HashMap<String, RegistryCallback> mCallbacks = new HashMap<>();
+
+    // @TODO: add description
+    public void register(String name, RegistryCallback callback) {
+        mCallbacks.put(name, callback);
+    }
+
+    // @TODO: add description
+    public void unregister(String name, RegistryCallback callback) {
+        mCallbacks.remove(name);
+    }
+
+    // @TODO: add description
+    public void updateContent(String name, String content) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            callback.onNewMotionScene(content);
+        }
+    }
+
+    // @TODO: add description
+    public void updateProgress(String name, float progress) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            callback.onProgress(progress);
+        }
+    }
+
+    // @TODO: add description
+    public String currentContent(String name) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            return callback.currentMotionScene();
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public String currentLayoutInformation(String name) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            return callback.currentLayoutInformation();
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public void setDrawDebug(String name, int debugMode) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            callback.setDrawDebug(debugMode);
+        }
+    }
+
+    // @TODO: add description
+    public void setLayoutInformationMode(String name, int mode) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            callback.setLayoutInformationMode(mode);
+        }
+    }
+
+    public Set<String> getLayoutList() {
+        return mCallbacks.keySet();
+    }
+
+    // @TODO: add description
+    public long getLastModified(String name) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            return callback.getLastModified();
+        }
+        return Long.MAX_VALUE;
+    }
+
+    // @TODO: add description
+    public void updateDimensions(String name, int width, int height) {
+        RegistryCallback callback = mCallbacks.get(name);
+        if (callback != null) {
+            callback.onDimensions(width, height);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/RegistryCallback.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/RegistryCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state;
+
+public interface RegistryCallback {
+    // @TODO: add description
+    void onNewMotionScene(String content);
+
+    // @TODO: add description
+    void onProgress(float progress);
+
+    // @TODO: add description
+    void onDimensions(int width, int height);
+
+    // @TODO: add description
+    String currentMotionScene();
+
+    // @TODO: add description
+    void setDrawDebug(int debugMode);
+
+    // @TODO: add description
+    String currentLayoutInformation();
+
+    // @TODO: add description
+    void setLayoutInformationMode(int layoutInformationMode);
+
+    // @TODO: add description
+    long getLastModified();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/State.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/State.java
@@ -1,0 +1,711 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_PACKED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD_INSIDE;
+
+import androidx.constraintlayout.core.state.helpers.AlignHorizontallyReference;
+import androidx.constraintlayout.core.state.helpers.AlignVerticallyReference;
+import androidx.constraintlayout.core.state.helpers.BarrierReference;
+import androidx.constraintlayout.core.state.helpers.FlowReference;
+import androidx.constraintlayout.core.state.helpers.GridReference;
+import androidx.constraintlayout.core.state.helpers.GuidelineReference;
+import androidx.constraintlayout.core.state.helpers.HorizontalChainReference;
+import androidx.constraintlayout.core.state.helpers.VerticalChainReference;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a full state of a ConstraintLayout
+ */
+public class State {
+    private CorePixelDp mDpToPixel;
+    private boolean mIsLtr = true;
+    protected HashMap<Object, Reference> mReferences = new HashMap<>();
+    protected HashMap<Object, HelperReference> mHelperReferences = new HashMap<>();
+    HashMap<String, ArrayList<String>> mTags = new HashMap<>();
+
+    static final int UNKNOWN = -1;
+    static final int CONSTRAINT_SPREAD = 0;
+    static final int CONSTRAINT_WRAP = 1;
+    static final int CONSTRAINT_RATIO = 2;
+
+    public static final Integer PARENT = 0;
+
+    public final ConstraintReference mParent = new ConstraintReference(this);
+
+    public enum Constraint {
+        LEFT_TO_LEFT,
+        LEFT_TO_RIGHT,
+        RIGHT_TO_LEFT,
+        RIGHT_TO_RIGHT,
+        START_TO_START,
+        START_TO_END,
+        END_TO_START,
+        END_TO_END,
+        TOP_TO_TOP,
+        TOP_TO_BOTTOM,
+        TOP_TO_BASELINE,
+        BOTTOM_TO_TOP,
+        BOTTOM_TO_BOTTOM,
+        BOTTOM_TO_BASELINE,
+        BASELINE_TO_BASELINE,
+        BASELINE_TO_TOP,
+        BASELINE_TO_BOTTOM,
+        CENTER_HORIZONTALLY,
+        CENTER_VERTICALLY,
+        CIRCULAR_CONSTRAINT
+    }
+
+    public enum Direction {
+        LEFT,
+        RIGHT,
+        START,
+        END,
+        TOP,
+        BOTTOM
+    }
+
+    public enum Helper {
+        HORIZONTAL_CHAIN,
+        VERTICAL_CHAIN,
+        ALIGN_HORIZONTALLY,
+        ALIGN_VERTICALLY,
+        BARRIER,
+        LAYER,
+        HORIZONTAL_FLOW,
+        VERTICAL_FLOW,
+        GRID,
+        ROW,
+        COLUMN,
+        FLOW
+    }
+
+    public enum Chain {
+        SPREAD,
+        SPREAD_INSIDE,
+        PACKED;
+
+        public static Map<String, Chain> chainMap = new HashMap<>();
+        public static Map<String, Integer> valueMap = new HashMap<>();
+        static {
+            chainMap.put("packed", PACKED);
+            chainMap.put("spread_inside", SPREAD_INSIDE);
+            chainMap.put("spread", SPREAD);
+
+            valueMap.put("packed", CHAIN_PACKED);
+            valueMap.put("spread_inside", CHAIN_SPREAD_INSIDE);
+            valueMap.put("spread", CHAIN_SPREAD);
+        }
+
+        /**
+         * Get the Enum value with a String
+         * @param str a String representation of a Enum value
+         * @return a Enum value
+         */
+        public static int getValueByString(String str) {
+            if (valueMap.containsKey(str)) {
+                return valueMap.get(str);
+            }
+            return UNKNOWN;
+        }
+
+        /**
+         * Get the actual int value with a String
+         * @param str a String representation of a Enum value
+         * @return an actual int value
+         */
+        public static Chain getChainByString(String str) {
+            if (chainMap.containsKey(str)) {
+                return chainMap.get(str);
+            }
+            return null;
+        }
+
+    }
+
+    public enum Wrap {
+        NONE,
+        CHAIN,
+        ALIGNED;
+        public static Map<String, Wrap> wrapMap = new HashMap<>();
+        public static Map<String, Integer> valueMap = new HashMap<>();
+        static {
+            wrapMap.put("none", NONE);
+            wrapMap.put("chain", CHAIN);
+            wrapMap.put("aligned", ALIGNED);
+
+            valueMap.put("none", 0);
+            valueMap.put("chain", 3); // Corresponds to CHAIN_NEW
+            valueMap.put("aligned", 2);
+        }
+
+        /**
+         * Get the actual int value with a String
+         * @param str a String representation of a Enum value
+         * @return a actual int value
+         */
+        public static int getValueByString(String str) {
+            if (valueMap.containsKey(str)) {
+                return valueMap.get(str);
+            }
+            return UNKNOWN;
+        }
+
+        /**
+         * Get the Enum value with a String
+         * @param str a String representation of a Enum value
+         * @return a Enum value
+         */
+        public static Wrap getChainByString(String str) {
+            if (wrapMap.containsKey(str)) {
+                return wrapMap.get(str);
+            }
+            return null;
+        }
+    }
+
+    public State() {
+        mParent.setKey(PARENT);
+        mReferences.put(PARENT, mParent);
+    }
+
+    CorePixelDp getDpToPixel() {
+        return mDpToPixel;
+    }
+
+    /**
+     * Set the function that converts dp to Pixels
+     */
+    public void setDpToPixel(CorePixelDp dpToPixel) {
+        this.mDpToPixel = dpToPixel;
+    }
+
+    /**
+     * Set whether the layout direction is left to right (Ltr).
+     *
+     * @deprecated For consistency, use {@link #setRtl(boolean)} instead.
+     */
+    @Deprecated
+    public void setLtr(boolean isLtr) {
+        mIsLtr = isLtr;
+    }
+
+    /**
+     * Returns true if layout direction is left to right. False for right to left.
+     *
+     * @deprecated For consistency, use {@link #isRtl()} instead.
+     */
+    @Deprecated
+    public boolean isLtr() {
+        return mIsLtr;
+    }
+
+    /**
+     * Set whether the layout direction is right to left (Rtl).
+     */
+    public void setRtl(boolean isRtl) {
+        mIsLtr = !isRtl;
+    }
+
+    /**
+     * Returns true if layout direction is right to left. False for left to right.
+     */
+    public boolean isRtl() {
+        return !mIsLtr;
+    }
+
+    /**
+     * Clear the state
+     */
+    public void reset() {
+        for (Object ref : mReferences.keySet()) {
+            mReferences.get(ref).getConstraintWidget().reset();
+        }
+        mReferences.clear();
+        mReferences.put(PARENT, mParent);
+        mHelperReferences.clear();
+        mTags.clear();
+        mBaselineNeeded.clear();
+        mDirtyBaselineNeededWidgets = true;
+    }
+
+    /**
+     * Implements a conversion function for values, returning int.
+     * This can be used in case values (e.g. margins) are represented
+     * via an object, not directly an int.
+     *
+     * @param value the object to convert from
+     */
+    public int convertDimension(Object value) {
+        if (value instanceof Float) {
+            return Math.round((Float) value);
+        }
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+        return 0;
+    }
+
+    /**
+     * Create a new reference given a key.
+     */
+    public ConstraintReference createConstraintReference(Object key) {
+        return new ConstraintReference(this);
+    }
+
+    // @TODO: add description
+    public boolean sameFixedWidth(int width) {
+        return mParent.getWidth().equalsFixedValue(width);
+    }
+
+    // @TODO: add description
+    public boolean sameFixedHeight(int height) {
+        return mParent.getHeight().equalsFixedValue(height);
+    }
+
+    // @TODO: add description
+    public State width(Dimension dimension) {
+        return setWidth(dimension);
+    }
+
+    // @TODO: add description
+    public State height(Dimension dimension) {
+        return setHeight(dimension);
+    }
+
+    // @TODO: add description
+    public State setWidth(Dimension dimension) {
+        mParent.setWidth(dimension);
+        return this;
+    }
+
+    // @TODO: add description
+    public State setHeight(Dimension dimension) {
+        mParent.setHeight(dimension);
+        return this;
+    }
+
+    Reference reference(Object key) {
+        return mReferences.get(key);
+    }
+
+    // @TODO: add description
+    public ConstraintReference constraints(Object key) {
+        Reference reference = mReferences.get(key);
+
+        if (reference == null) {
+            reference = createConstraintReference(key);
+            mReferences.put(key, reference);
+            reference.setKey(key);
+        }
+        if (reference instanceof ConstraintReference) {
+            return (ConstraintReference) reference;
+        }
+        return null;
+    }
+
+    private int mNumHelpers = 0;
+
+    private String createHelperKey() {
+        return "__HELPER_KEY_" + mNumHelpers++ + "__";
+    }
+
+    // @TODO: add description
+    public HelperReference helper(Object key, State.Helper type) {
+        if (key == null) {
+            key = createHelperKey();
+        }
+        HelperReference reference = mHelperReferences.get(key);
+        if (reference == null) {
+            switch (type) {
+                case HORIZONTAL_CHAIN: {
+                    reference = new HorizontalChainReference(this);
+                }
+                break;
+                case VERTICAL_CHAIN: {
+                    reference = new VerticalChainReference(this);
+                }
+                break;
+                case ALIGN_HORIZONTALLY: {
+                    reference = new AlignHorizontallyReference(this);
+                }
+                break;
+                case ALIGN_VERTICALLY: {
+                    reference = new AlignVerticallyReference(this);
+                }
+                break;
+                case BARRIER: {
+                    reference = new BarrierReference(this);
+                }
+                break;
+                case VERTICAL_FLOW:
+                case HORIZONTAL_FLOW: {
+                    reference = new FlowReference(this, type);
+                }
+                break;
+                case GRID:
+                case ROW:
+                case COLUMN: {
+                    reference = new GridReference(this, type);
+                }
+                    break;
+                default: {
+                    reference = new HelperReference(this, type);
+                }
+            }
+            reference.setKey(key);
+            mHelperReferences.put(key, reference);
+        }
+        return reference;
+    }
+
+    // @TODO: add description
+    public GuidelineReference horizontalGuideline(Object key) {
+        return guideline(key, ConstraintWidget.HORIZONTAL);
+    }
+
+    // @TODO: add description
+    public GuidelineReference verticalGuideline(Object key) {
+        return guideline(key, ConstraintWidget.VERTICAL);
+    }
+
+    // @TODO: add description
+    public GuidelineReference guideline(Object key, int orientation) {
+        ConstraintReference reference = constraints(key);
+        if (reference.getFacade() == null
+                || !(reference.getFacade() instanceof GuidelineReference)) {
+            GuidelineReference guidelineReference = new GuidelineReference(this);
+            guidelineReference.setOrientation(orientation);
+            guidelineReference.setKey(key);
+            reference.setFacade(guidelineReference);
+        }
+        return (GuidelineReference) reference.getFacade();
+    }
+
+    // @TODO: add description
+    public BarrierReference barrier(Object key, Direction direction) {
+        ConstraintReference reference = constraints(key);
+        if (reference.getFacade() == null || !(reference.getFacade() instanceof BarrierReference)) {
+            BarrierReference barrierReference = new BarrierReference(this);
+            barrierReference.setBarrierDirection(direction);
+            reference.setFacade(barrierReference);
+        }
+        return (BarrierReference) reference.getFacade();
+    }
+
+    /**
+     * Get a Grid reference
+     *
+     * @param key name of the reference object
+     * @param gridType type of Grid pattern - Grid, Row, or Column
+     * @return a GridReference object
+     */
+    public @NonNull GridReference getGrid(@NonNull Object key, @NonNull String gridType) {
+        ConstraintReference reference = constraints(key);
+        if (reference.getFacade() == null || !(reference.getFacade() instanceof GridReference)) {
+            State.Helper Type = Helper.GRID;
+            if (gridType.charAt(0) == 'r') {
+                Type = Helper.ROW;
+            } else if (gridType.charAt(0) == 'c') {
+                Type = Helper.COLUMN;
+            }
+            GridReference gridReference = new GridReference(this, Type);
+            reference.setFacade(gridReference);
+        }
+        return (GridReference) reference.getFacade();
+    }
+
+    /**
+     * Gets a reference to a Flow object. Creating it if needed.
+     * @param key id of the reference
+     * @param vertical is it a vertical or horizontal flow
+     * @return a FlowReference
+     */
+    public FlowReference getFlow(Object key, boolean vertical) {
+        ConstraintReference reference = constraints(key);
+        if (reference.getFacade() == null || !(reference.getFacade() instanceof FlowReference)) {
+            FlowReference flowReference =
+                    vertical ? new FlowReference(this, Helper.VERTICAL_FLOW)
+                            : new FlowReference(this, Helper.HORIZONTAL_FLOW);
+
+            reference.setFacade(flowReference);
+        }
+        return (FlowReference) reference.getFacade();
+    }
+
+    // @TODO: add description
+    public VerticalChainReference verticalChain() {
+        return (VerticalChainReference) helper(null, Helper.VERTICAL_CHAIN);
+    }
+
+    // @TODO: add description
+    public VerticalChainReference verticalChain(Object... references) {
+        VerticalChainReference reference =
+                (VerticalChainReference) helper(null, State.Helper.VERTICAL_CHAIN);
+        reference.add(references);
+        return reference;
+    }
+
+    // @TODO: add description
+    public HorizontalChainReference horizontalChain() {
+        return (HorizontalChainReference) helper(null, Helper.HORIZONTAL_CHAIN);
+    }
+
+    // @TODO: add description
+    public HorizontalChainReference horizontalChain(Object... references) {
+        HorizontalChainReference reference =
+                (HorizontalChainReference) helper(null, Helper.HORIZONTAL_CHAIN);
+        reference.add(references);
+        return reference;
+    }
+
+    /**
+     * Get a VerticalFlowReference
+     *
+     * @return a VerticalFlowReference
+     */
+    public FlowReference getVerticalFlow() {
+        return (FlowReference) helper(null, Helper.VERTICAL_FLOW);
+    }
+
+    /**
+     * Get a VerticalFlowReference and add it to references
+     *
+     * @param references where we add the VerticalFlowReference
+     * @return a VerticalFlowReference
+     */
+    public FlowReference getVerticalFlow(Object... references) {
+        FlowReference reference =
+                (FlowReference) helper(null, State.Helper.VERTICAL_FLOW);
+        reference.add(references);
+        return reference;
+    }
+
+    /**
+     * Get a HorizontalFlowReference
+     *
+     * @return a HorizontalFlowReference
+     */
+    public FlowReference getHorizontalFlow() {
+        return (FlowReference) helper(null, Helper.HORIZONTAL_FLOW);
+    }
+
+    /**
+     * Get a HorizontalFlowReference and add it to references
+     *
+     * @param references references where we the HorizontalFlowReference
+     * @return a HorizontalFlowReference
+     */
+    public FlowReference getHorizontalFlow(Object... references) {
+        FlowReference reference =
+                (FlowReference) helper(null, Helper.HORIZONTAL_FLOW);
+        reference.add(references);
+        return reference;
+    }
+
+    // @TODO: add description
+    public AlignHorizontallyReference centerHorizontally(Object... references) {
+        AlignHorizontallyReference reference =
+                (AlignHorizontallyReference) helper(null, Helper.ALIGN_HORIZONTALLY);
+        reference.add(references);
+        return reference;
+    }
+
+    // @TODO: add description
+    public AlignVerticallyReference centerVertically(Object... references) {
+        AlignVerticallyReference reference =
+                (AlignVerticallyReference) helper(null, Helper.ALIGN_VERTICALLY);
+        reference.add(references);
+        return reference;
+    }
+
+    // @TODO: add description
+    public void directMapping() {
+        for (Object key : mReferences.keySet()) {
+            Reference ref = constraints(key);
+            if (!(ref instanceof ConstraintReference)) {
+                continue;
+            }
+            ConstraintReference reference = (ConstraintReference) ref;
+            reference.setView(key);
+        }
+    }
+
+    // @TODO: add description
+    public void map(Object key, Object view) {
+        ConstraintReference ref = constraints(key);
+        if (ref != null) {
+            ref.setView(view);
+        }
+    }
+
+    // @TODO: add description
+    public void setTag(String key, String tag) {
+        Reference ref = constraints(key);
+        if (ref instanceof ConstraintReference) {
+            ConstraintReference reference = (ConstraintReference) ref;
+            reference.setTag(tag);
+            ArrayList<String> list = null;
+            if (!mTags.containsKey(tag)) {
+                list = new ArrayList<>();
+                mTags.put(tag, list);
+            } else {
+                list = mTags.get(tag);
+            }
+            list.add(key);
+        }
+    }
+
+    // @TODO: add description
+    public ArrayList<String> getIdsForTag(String tag) {
+        if (mTags.containsKey(tag)) {
+            return mTags.get(tag);
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public void apply(ConstraintWidgetContainer container) {
+        container.removeAllChildren();
+        mParent.getWidth().apply(this, container, ConstraintWidget.HORIZONTAL);
+        mParent.getHeight().apply(this, container, ConstraintWidget.VERTICAL);
+        // add helper references
+        for (Object key : mHelperReferences.keySet()) {
+            HelperReference reference = mHelperReferences.get(key);
+            HelperWidget helperWidget = reference.getHelperWidget();
+            if (helperWidget != null) {
+                Reference constraintReference = mReferences.get(key);
+                if (constraintReference == null) {
+                    constraintReference = constraints(key);
+                }
+                constraintReference.setConstraintWidget(helperWidget);
+            }
+        }
+        for (Object key : mReferences.keySet()) {
+            Reference reference = mReferences.get(key);
+            if (reference != mParent && reference.getFacade() instanceof HelperReference) {
+                HelperWidget helperWidget =
+                        ((HelperReference) reference.getFacade()).getHelperWidget();
+                if (helperWidget != null) {
+                    Reference constraintReference = mReferences.get(key);
+                    if (constraintReference == null) {
+                        constraintReference = constraints(key);
+                    }
+                    constraintReference.setConstraintWidget(helperWidget);
+                }
+            }
+        }
+        for (Object key : mReferences.keySet()) {
+            Reference reference = mReferences.get(key);
+            if (reference != mParent) {
+                ConstraintWidget widget = reference.getConstraintWidget();
+                widget.setDebugName(reference.getKey().toString());
+                widget.setParent(null);
+                if (reference.getFacade() instanceof GuidelineReference) {
+                    // we apply Guidelines first to correctly setup their ConstraintWidget.
+                    reference.apply();
+                }
+                container.add(widget);
+            } else {
+                reference.setConstraintWidget(container);
+            }
+        }
+        for (Object key : mHelperReferences.keySet()) {
+            // We need this pass to apply chains properly
+            HelperReference reference = mHelperReferences.get(key);
+            HelperWidget helperWidget = reference.getHelperWidget();
+            if (helperWidget != null) {
+                for (Object keyRef : reference.mReferences) {
+                    Reference constraintReference = mReferences.get(keyRef);
+                    reference.getHelperWidget().add(constraintReference.getConstraintWidget());
+                }
+                reference.apply();
+            } else {
+                reference.apply();
+            }
+        }
+        for (Object key : mReferences.keySet()) {
+            Reference reference = mReferences.get(key);
+            if (reference != mParent && reference.getFacade() instanceof HelperReference) {
+                HelperReference helperReference = (HelperReference) reference.getFacade();
+                HelperWidget helperWidget = helperReference.getHelperWidget();
+                if (helperWidget != null) {
+                    for (Object keyRef : helperReference.mReferences) {
+                        Reference constraintReference = mReferences.get(keyRef);
+                        if (constraintReference != null) {
+                            helperWidget.add(constraintReference.getConstraintWidget());
+                        } else if (keyRef instanceof Reference) {
+                            helperWidget.add(((Reference) keyRef).getConstraintWidget());
+                        } else {
+                            System.out.println("couldn't find reference for " + keyRef);
+                        }
+                    }
+                    reference.apply();
+                }
+            }
+        }
+        for (Object key : mReferences.keySet()) {
+            Reference reference = mReferences.get(key);
+            reference.apply();
+            ConstraintWidget widget = reference.getConstraintWidget();
+            if (widget != null && key != null) {
+                widget.stringId = key.toString();
+            }
+        }
+    }
+
+    // ================= add baseline code================================
+    ArrayList<Object> mBaselineNeeded = new ArrayList<>();
+    ArrayList<ConstraintWidget> mBaselineNeededWidgets = new ArrayList<>();
+    boolean mDirtyBaselineNeededWidgets = true;
+
+    /**
+     * Baseline is needed for this object
+     */
+    public void baselineNeededFor(Object id) {
+        mBaselineNeeded.add(id);
+        mDirtyBaselineNeededWidgets = true;
+    }
+
+    /**
+     * Does this constraintWidget need a baseline
+     *
+     * @return true if the constraintWidget needs a baseline
+     */
+    public boolean isBaselineNeeded(ConstraintWidget constraintWidget) {
+        if (mDirtyBaselineNeededWidgets) {
+            mBaselineNeededWidgets.clear();
+            for (Object id : mBaselineNeeded) {
+                ConstraintWidget widget = mReferences.get(id).getConstraintWidget();
+                if (widget != null) mBaselineNeededWidgets.add(widget);
+            }
+
+            mDirtyBaselineNeededWidgets = false;
+        }
+        return mBaselineNeededWidgets.contains(constraintWidget);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/Transition.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/Transition.java
@@ -1,0 +1,1141 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import androidx.annotation.RestrictTo;
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.Motion;
+import androidx.constraintlayout.core.motion.MotionWidget;
+import androidx.constraintlayout.core.motion.key.MotionKeyAttributes;
+import androidx.constraintlayout.core.motion.key.MotionKeyCycle;
+import androidx.constraintlayout.core.motion.key.MotionKeyPosition;
+import androidx.constraintlayout.core.motion.utils.Easing;
+import androidx.constraintlayout.core.motion.utils.KeyCache;
+import androidx.constraintlayout.core.motion.utils.SpringStopEngine;
+import androidx.constraintlayout.core.motion.utils.StopEngine;
+import androidx.constraintlayout.core.motion.utils.StopLogicEngine;
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.motion.utils.Utils;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+public class Transition implements TypedValues {
+    private static final boolean DEBUG = false;
+    public static final int START = 0;
+    public static final int END = 1;
+    public static final int INTERPOLATED = 2;
+    static final int EASE_IN_OUT = 0;
+    static final int EASE_IN = 1;
+    static final int EASE_OUT = 2;
+    static final int LINEAR = 3;
+    static final int BOUNCE = 4;
+    static final int OVERSHOOT = 5;
+    static final int ANTICIPATE = 6;
+    private static final int SPLINE_STRING = -1;
+    @SuppressWarnings("unused")
+    private static final int INTERPOLATOR_REFERENCE_ID = -2;
+    private HashMap<Integer, HashMap<String, KeyPosition>> mKeyPositions = new HashMap<>();
+    private HashMap<String, WidgetState> mState = new HashMap<>();
+    private TypedBundle mBundle = new TypedBundle();
+    // Interpolation
+    private int mDefaultInterpolator = 0;
+    private String mDefaultInterpolatorString = null;
+    private Easing mEasing = null;
+    private int mAutoTransition = 0;
+    private int mDuration = 400;
+    private float mStagger = 0.0f;
+    private OnSwipe mOnSwipe = null;
+    final CorePixelDp mToPixel; // Todo placed here as a temp till the refactor is done
+    int mParentStartWidth, mParentStartHeight;
+    int mParentEndWidth, mParentEndHeight;
+    int mParentInterpolatedWidth, mParentInterpolateHeight;
+    boolean mWrap;
+
+    public Transition(@NonNull CorePixelDp dpToPixel) {
+        mToPixel = dpToPixel;
+    }
+
+    // @TODO: add description
+    @SuppressWarnings("HiddenTypeParameter")
+    OnSwipe createOnSwipe() {
+        return mOnSwipe = new OnSwipe();
+    }
+
+    // @TODO: add description
+    public boolean hasOnSwipe() {
+        return mOnSwipe != null;
+    }
+
+    static class OnSwipe {
+        String mAnchorId;
+        private int mAnchorSide;
+        private StopEngine mEngine;
+        public static final int ANCHOR_SIDE_TOP = 0;
+        public static final int ANCHOR_SIDE_LEFT = 1;
+        public static final int ANCHOR_SIDE_RIGHT = 2;
+        public static final int ANCHOR_SIDE_BOTTOM = 3;
+        public static final int ANCHOR_SIDE_MIDDLE = 4;
+        public static final int ANCHOR_SIDE_START = 5;
+        public static final int ANCHOR_SIDE_END = 6;
+        public static final String[] SIDES = {"top", "left", "right",
+                "bottom", "middle", "start", "end"};
+        private static final float[][] TOUCH_SIDES = {
+                {0.5f, 0.0f}, // top
+                {0.0f, 0.5f}, // left
+                {1.0f, 0.5f}, // right
+                {0.5f, 1.0f}, // bottom
+                {0.5f, 0.5f}, // middle
+                {0.0f, 0.5f}, // start TODO (dynamically updated)
+                {1.0f, 0.5f}, // end  TODO (dynamically updated)
+        };
+
+        @SuppressWarnings("unused")
+        private String mRotationCenterId;
+        String mLimitBoundsTo;
+        @SuppressWarnings("unused")
+        private boolean mDragVertical = true;
+        private int mDragDirection = 0;
+        public static final int DRAG_UP = 0;
+        public static final int DRAG_DOWN = 1;
+        public static final int DRAG_LEFT = 2;
+        public static final int DRAG_RIGHT = 3;
+        public static final int DRAG_START = 4;
+        public static final int DRAG_END = 5;
+        public static final int DRAG_CLOCKWISE = 6;
+        public static final int DRAG_ANTICLOCKWISE = 7;
+        public static final String[] DIRECTIONS = {"up", "down", "left", "right", "start",
+                "end", "clockwise", "anticlockwise"};
+
+        private float mDragScale = 1;
+        @SuppressWarnings("unused")
+        private float mDragThreshold = 10;
+        private int mAutoCompleteMode = 0;
+        public static final int MODE_CONTINUOUS_VELOCITY = 0;
+        public static final int MODE_SPRING = 1;
+        public static final String[] MODE = {"velocity", "spring"};
+        private float mMaxVelocity = 4.f;
+        private float mMaxAcceleration = 1.2f;
+
+        // On touch up what happens
+        private int mOnTouchUp = 0;
+        public static final int ON_UP_AUTOCOMPLETE = 0;
+        public static final int ON_UP_AUTOCOMPLETE_TO_START = 1;
+        public static final int ON_UP_AUTOCOMPLETE_TO_END = 2;
+        public static final int ON_UP_STOP = 3;
+        public static final int ON_UP_DECELERATE = 4;
+        public static final int ON_UP_DECELERATE_AND_COMPLETE = 5;
+        public static final int ON_UP_NEVER_COMPLETE_TO_START = 6;
+        public static final int ON_UP_NEVER_COMPLETE_TO_END = 7;
+        public static final String[] TOUCH_UP = {"autocomplete", "toStart",
+                "toEnd", "stop", "decelerate", "decelerateComplete",
+                "neverCompleteStart", "neverCompleteEnd"};
+
+        private float mSpringMass = 1;
+        private float mSpringStiffness = 400;
+        private float mSpringDamping = 10;
+        private float mSpringStopThreshold = 0.01f;
+        private float mDestination = 0.0f;
+
+        // In spring mode what happens at the boundary
+        private int mSpringBoundary = 0;
+        public static final int BOUNDARY_OVERSHOOT = 0;
+        public static final int BOUNDARY_BOUNCE_START = 1;
+        public static final int BOUNDARY_BOUNCE_END = 2;
+        public static final int BOUNDARY_BOUNCE_BOTH = 3;
+        public static final String[] BOUNDARY = {"overshoot", "bounceStart",
+                "bounceEnd", "bounceBoth"};
+
+        private static final float[][] TOUCH_DIRECTION = {
+                {0.0f, -1.0f}, // up
+                {0.0f, 1.0f}, // down
+                {-1.0f, 0.0f}, // left
+                {1.0f, 0.0f}, // right
+                {-1.0f, 0.0f}, // start (dynamically updated)
+                {1.0f, 0.0f}, // end  (dynamically updated)
+        };
+        private long mStart;
+
+        float getScale() {
+            return mDragScale;
+        }
+
+        float[] getDirection() {
+            return TOUCH_DIRECTION[mDragDirection];
+        }
+
+        float[] getSide() {
+            return TOUCH_SIDES[mAnchorSide];
+        }
+
+        void setAnchorId(String anchorId) {
+            this.mAnchorId = anchorId;
+        }
+
+        void setAnchorSide(int anchorSide) {
+            this.mAnchorSide = anchorSide;
+        }
+
+        void setRotationCenterId(String rotationCenterId) {
+            this.mRotationCenterId = rotationCenterId;
+        }
+
+        void setLimitBoundsTo(String limitBoundsTo) {
+            this.mLimitBoundsTo = limitBoundsTo;
+        }
+
+        void setDragDirection(int dragDirection) {
+            this.mDragDirection = dragDirection;
+            mDragVertical = (mDragDirection < 2);
+        }
+
+        void setDragScale(float dragScale) {
+            if (Float.isNaN(dragScale)) {
+                return;
+            }
+            this.mDragScale = dragScale;
+        }
+
+        void setDragThreshold(float dragThreshold) {
+            if (Float.isNaN(dragThreshold)) {
+                return;
+            }
+            this.mDragThreshold = dragThreshold;
+        }
+
+        void setAutoCompleteMode(int mAutoCompleteMode) {
+            this.mAutoCompleteMode = mAutoCompleteMode;
+        }
+
+        void setMaxVelocity(float maxVelocity) {
+            if (Float.isNaN(maxVelocity)) {
+                return;
+            }
+            this.mMaxVelocity = maxVelocity;
+        }
+
+        void setMaxAcceleration(float maxAcceleration) {
+            if (Float.isNaN(maxAcceleration)) {
+                return;
+            }
+            this.mMaxAcceleration = maxAcceleration;
+        }
+
+        void setOnTouchUp(int onTouchUp) {
+            this.mOnTouchUp = onTouchUp;
+        }
+
+        void setSpringMass(float mSpringMass) {
+            if (Float.isNaN(mSpringMass)) {
+                return;
+            }
+            this.mSpringMass = mSpringMass;
+        }
+
+        void setSpringStiffness(float mSpringStiffness) {
+            if (Float.isNaN(mSpringStiffness)) {
+                return;
+            }
+            this.mSpringStiffness = mSpringStiffness;
+        }
+
+        void setSpringDamping(float mSpringDamping) {
+            if (Float.isNaN(mSpringDamping)) {
+                return;
+            }
+            this.mSpringDamping = mSpringDamping;
+        }
+
+        void setSpringStopThreshold(float mSpringStopThreshold) {
+            if (Float.isNaN(mSpringStopThreshold)) {
+                return;
+            }
+            this.mSpringStopThreshold = mSpringStopThreshold;
+        }
+
+        void setSpringBoundary(int mSpringBoundary) {
+            this.mSpringBoundary = mSpringBoundary;
+        }
+
+        float getDestinationPosition(float currentPosition, float velocity, float duration) {
+            float rest = currentPosition + 0.5f * Math.abs(velocity) * velocity / mMaxAcceleration;
+            switch (mOnTouchUp) {
+                case ON_UP_AUTOCOMPLETE_TO_START:
+                    if (currentPosition >= 1f) {
+                        return 1;
+                    }
+                    return 0;
+                case ON_UP_NEVER_COMPLETE_TO_END:
+                    return 0;
+                case ON_UP_AUTOCOMPLETE_TO_END:
+                    if (currentPosition <= 0f) {
+                        return 0;
+                    }
+                    return 1;
+                case ON_UP_NEVER_COMPLETE_TO_START:
+                    return 1;
+                case ON_UP_STOP:
+                    return Float.NaN;
+                case ON_UP_DECELERATE:
+                    return Math.max(0, Math.min(1, rest));
+                case ON_UP_DECELERATE_AND_COMPLETE: // complete if within 20% of edge #todo improve
+                    if (rest > 0.2f && rest < 0.8f) {
+                        return rest;
+                    } else {
+                        return rest > .5f ? 1 : 0;
+                    }
+                case ON_UP_AUTOCOMPLETE:
+            }
+
+            if (DEBUG) {
+                Utils.log(" currentPosition = " + currentPosition);
+                Utils.log("        velocity = " + velocity);
+                Utils.log("            peek = " + rest);
+                Utils.log("mMaxAcceleration = " + mMaxAcceleration);
+            }
+            return rest > .5 ? 1 : 0;
+        }
+
+        void config(float position, float velocity, long start, float duration) {
+            mStart = start;
+            if (Math.abs(velocity) > mMaxVelocity) {
+                velocity = mMaxVelocity * Math.signum(velocity);
+            }
+            mDestination = getDestinationPosition(position, velocity, duration);
+            if (mDestination == position) {
+                mEngine = null;
+                return;
+            }
+            if ((mOnTouchUp == ON_UP_DECELERATE)
+                    && (mAutoCompleteMode == MODE_CONTINUOUS_VELOCITY)) {
+                StopLogicEngine.Decelerate sld;
+                if (mEngine instanceof StopLogicEngine.Decelerate) {
+                    sld = (StopLogicEngine.Decelerate) mEngine;
+                } else {
+                    mEngine = sld = new StopLogicEngine.Decelerate();
+                }
+                sld.config(position, mDestination, velocity);
+                return;
+            }
+
+
+            if (mAutoCompleteMode == MODE_CONTINUOUS_VELOCITY) {
+                StopLogicEngine sl;
+                if (mEngine instanceof StopLogicEngine) {
+                    sl = (StopLogicEngine) mEngine;
+                } else {
+                    mEngine = sl = new StopLogicEngine();
+                }
+
+                sl.config(position, mDestination, velocity,
+                        duration, mMaxAcceleration,
+                        mMaxVelocity);
+                return;
+            }
+            SpringStopEngine sl;
+            if (mEngine instanceof SpringStopEngine) {
+                sl = (SpringStopEngine) mEngine;
+            } else {
+                mEngine = sl = new SpringStopEngine();
+            }
+
+            sl.springConfig(position, mDestination, velocity,
+                    mSpringMass,
+                    mSpringStiffness,
+                    mSpringDamping,
+                    mSpringStopThreshold, mSpringBoundary);
+        }
+
+        /**
+         * @param currentTime time in nanoseconds
+         * @return new values of progress
+         */
+        public float getTouchUpProgress(long currentTime) {
+            float time = (currentTime - mStart) * 1E-9f;
+            float pos = mEngine.getInterpolation(time);
+            if (mEngine.isStopped()) {
+                pos = mDestination;
+            }
+            return pos;
+        }
+
+        public void printInfo() {
+            if (mAutoCompleteMode == MODE_CONTINUOUS_VELOCITY) {
+                System.out.println("velocity = " + mEngine.getVelocity());
+                System.out.println("mMaxAcceleration = " + mMaxAcceleration);
+                System.out.println("mMaxVelocity = " + mMaxVelocity);
+            } else {
+                System.out.println("mSpringMass          = " + mSpringMass);
+                System.out.println("mSpringStiffness     = " + mSpringStiffness);
+                System.out.println("mSpringDamping       = " + mSpringDamping);
+                System.out.println("mSpringStopThreshold = " + mSpringStopThreshold);
+                System.out.println("mSpringBoundary      = " + mSpringBoundary);
+            }
+        }
+
+        public boolean isNotDone(float progress) {
+            if (mOnTouchUp == ON_UP_STOP) {
+                return false;
+            }
+            return mEngine != null && !mEngine.isStopped();
+        }
+    }
+
+    /**
+     * For the given position (in the MotionLayout coordinate space) determine whether we accept
+     * the first down for on swipe.
+     * <p>
+     * This is based off {@link OnSwipe#mLimitBoundsTo}. If null, we accept the drag at any
+     * position, otherwise, we only accept it if it's within its bounds.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public boolean isFirstDownAccepted(float posX, float posY) {
+        if (mOnSwipe == null) {
+            return false;
+        }
+
+        if (mOnSwipe.mLimitBoundsTo != null) {
+            WidgetState targetWidget = mState.get(mOnSwipe.mLimitBoundsTo);
+            if (targetWidget == null) {
+                System.err.println("mLimitBoundsTo target is null");
+                return false;
+            }
+            // Calculate against the interpolated/current frame
+            WidgetFrame frame = targetWidget.getFrame(2);
+            return posX >= frame.left && posX < frame.right && posY >= frame.top
+                    && posY < frame.bottom;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Converts from xy drag to progress
+     * This should be used till touch up
+     *
+     * @param currentProgress 0...1 progress in
+     * @param baseW           parent width
+     * @param baseH           parent height
+     * @param dx              change in x
+     * @param dy              change in y
+     * @return the change in progress
+     */
+    public float dragToProgress(float currentProgress, int baseW, int baseH, float dx, float dy) {
+        Collection<WidgetState> widgets = mState.values();
+        WidgetState childWidget = null;
+        for (WidgetState widget : widgets) {
+            childWidget = widget;
+            break;
+        }
+        if (mOnSwipe == null || childWidget == null) {
+            if (childWidget != null) {
+                return -dy / childWidget.mParentHeight;
+            }
+            return 1.0f;
+        }
+        if (mOnSwipe.mAnchorId == null) {
+
+            float[] dir = mOnSwipe.getDirection();
+            float motionDpDtX = childWidget.mParentHeight;
+            float motionDpDtY = childWidget.mParentHeight;
+
+            float drag = (dir[0] != 0) ? dx * Math.abs(dir[0]) / motionDpDtX
+                    : dy * Math.abs(dir[1]) / motionDpDtY;
+            return drag * mOnSwipe.getScale();
+        }
+        WidgetState base = mState.get(mOnSwipe.mAnchorId);
+        float[] dir = mOnSwipe.getDirection();
+        float[] side = mOnSwipe.getSide();
+        float[] motionDpDt = new float[2];
+
+        base.interpolate(baseW, baseH, currentProgress, this);
+        base.mMotionControl.getDpDt(currentProgress, side[0], side[1], motionDpDt);
+        float drag = (dir[0] != 0) ? dx * Math.abs(dir[0]) / motionDpDt[0]
+                : dy * Math.abs(dir[1]) / motionDpDt[1];
+        if (DEBUG) {
+            Utils.log(" drag " + drag);
+        }
+        return drag * mOnSwipe.getScale();
+    }
+
+    /**
+     * Set the start of the touch up
+     *
+     * @param currentProgress 0...1 progress in
+     * @param currentTime     time in nanoseconds
+     * @param velocityX       pixels per millisecond
+     * @param velocityY       pixels per millisecond
+     */
+    public void setTouchUp(float currentProgress,
+            long currentTime,
+            float velocityX,
+            float velocityY) {
+        if (mOnSwipe != null) {
+            if (DEBUG) {
+                Utils.log(" >>> velocity x,y = " + velocityX + " , " + velocityY);
+            }
+            WidgetState base = mState.get(mOnSwipe.mAnchorId);
+            float[] motionDpDt = new float[2];
+            float[] dir = mOnSwipe.getDirection();
+            float[] side = mOnSwipe.getSide();
+            base.mMotionControl.getDpDt(currentProgress, side[0], side[1], motionDpDt);
+            float movementInDir = dir[0] * motionDpDt[0] + dir[1] * motionDpDt[1];
+            if (Math.abs(movementInDir) < 0.01) {
+                if (DEBUG) {
+                    Utils.log(" >>> cap minimum v!! ");
+                }
+                motionDpDt[0] = .01f;
+                motionDpDt[1] = .01f;
+            }
+
+            float drag = (dir[0] != 0) ? velocityX / motionDpDt[0] : velocityY / motionDpDt[1];
+            drag *= mOnSwipe.getScale();
+            if (DEBUG) {
+                Utils.log(" >>> velocity        " + drag);
+                Utils.log(" >>> mDuration       " + mDuration);
+                Utils.log(" >>> currentProgress " + currentProgress);
+            }
+            mOnSwipe.config(currentProgress, drag, currentTime, mDuration * 1E-3f);
+            if (DEBUG) {
+                mOnSwipe.printInfo();
+            }
+        }
+    }
+
+    /**
+     * get the current touch up progress current time in nanoseconds
+     * (ideally coming from an animation clock)
+     *
+     * @param currentTime in nanoseconds
+     * @return progress
+     */
+    public float getTouchUpProgress(long currentTime) {
+        if (mOnSwipe != null) {
+            return mOnSwipe.getTouchUpProgress(currentTime);
+        }
+        return 0;
+    }
+
+    /**
+     * Are we still animating
+     *
+     * @param currentProgress motion progress
+     * @return true to continue moving
+     */
+    public boolean isTouchNotDone(float currentProgress) {
+        return mOnSwipe.isNotDone(currentProgress);
+    }
+
+    /**
+     * get the interpolater based on a constant or a string
+     */
+    public static Interpolator getInterpolator(int interpolator, String interpolatorString) {
+        switch (interpolator) {
+            case SPLINE_STRING:
+                return v -> (float) Easing.getInterpolator(interpolatorString).get(v);
+            case EASE_IN_OUT:
+                return v -> (float) Easing.getInterpolator("standard").get(v);
+            case EASE_IN:
+                return v -> (float) Easing.getInterpolator("accelerate").get(v);
+            case EASE_OUT:
+                return v -> (float) Easing.getInterpolator("decelerate").get(v);
+            case LINEAR:
+                return v -> (float) Easing.getInterpolator("linear").get(v);
+            case ANTICIPATE:
+                return v -> (float) Easing.getInterpolator("anticipate").get(v);
+            case OVERSHOOT:
+                return v -> (float) Easing.getInterpolator("overshoot").get(v);
+            case BOUNCE: // TODO make a better bounce
+                return v -> (float) Easing.getInterpolator("spline(0.0, 0.2, 0.4, 0.6, "
+                        + "0.8 ,1.0, 0.8, 1.0, 0.9, 1.0)").get(v);
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    @SuppressWarnings("HiddenTypeParameter")
+    public KeyPosition findPreviousPosition(String target, int frameNumber) {
+        while (frameNumber >= 0) {
+            HashMap<String, KeyPosition> map = mKeyPositions.get(frameNumber);
+            if (map != null) {
+                KeyPosition keyPosition = map.get(target);
+                if (keyPosition != null) {
+                    return keyPosition;
+                }
+            }
+            frameNumber--;
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    @SuppressWarnings("HiddenTypeParameter")
+    public KeyPosition findNextPosition(String target, int frameNumber) {
+        while (frameNumber <= 100) {
+            HashMap<String, KeyPosition> map = mKeyPositions.get(frameNumber);
+            if (map != null) {
+                KeyPosition keyPosition = map.get(target);
+                if (keyPosition != null) {
+                    return keyPosition;
+                }
+            }
+            frameNumber++;
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public int getNumberKeyPositions(WidgetFrame frame) {
+        int numKeyPositions = 0;
+        int frameNumber = 0;
+        while (frameNumber <= 100) {
+            HashMap<String, KeyPosition> map = mKeyPositions.get(frameNumber);
+            if (map != null) {
+                KeyPosition keyPosition = map.get(frame.widget.stringId);
+                if (keyPosition != null) {
+                    numKeyPositions++;
+                }
+            }
+            frameNumber++;
+        }
+        return numKeyPositions;
+    }
+
+    // @TODO: add description
+    public Motion getMotion(String id) {
+        return getWidgetState(id, null, 0).mMotionControl;
+    }
+
+    // @TODO: add description
+    public void fillKeyPositions(WidgetFrame frame, float[] x, float[] y, float[] pos) {
+        int numKeyPositions = 0;
+        int frameNumber = 0;
+        while (frameNumber <= 100) {
+            HashMap<String, KeyPosition> map = mKeyPositions.get(frameNumber);
+            if (map != null) {
+                KeyPosition keyPosition = map.get(frame.widget.stringId);
+                if (keyPosition != null) {
+                    x[numKeyPositions] = keyPosition.mX;
+                    y[numKeyPositions] = keyPosition.mY;
+                    pos[numKeyPositions] = keyPosition.mFrame;
+                    numKeyPositions++;
+                }
+            }
+            frameNumber++;
+        }
+    }
+
+    // @TODO: add description
+    public boolean hasPositionKeyframes() {
+        return mKeyPositions.size() > 0;
+    }
+
+    // @TODO: add description
+    public void setTransitionProperties(TypedBundle bundle) {
+        bundle.applyDelta(mBundle);
+        bundle.applyDelta(this);
+    }
+
+    @Override
+    public boolean setValue(int id, int value) {
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, float value) {
+        if (id == TypedValues.TransitionType.TYPE_STAGGERED) {
+            mStagger = value;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, String value) {
+        if (id == TransitionType.TYPE_INTERPOLATOR) {
+            mEasing = Easing.getInterpolator(mDefaultInterpolatorString = value);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean setValue(int id, boolean value) {
+        return false;
+    }
+
+    @Override
+    public int getId(String name) {
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return mState.isEmpty();
+    }
+
+    // @TODO: add description
+    public void clear() {
+        mState.clear();
+    }
+
+    /**
+     * Reset animation properties of the Transition.
+     * <p>
+     * This will not affect the internal model of the widgets (a.k.a. {@link #mState}).
+     */
+    void resetProperties() {
+        mOnSwipe = null;
+        mBundle.clear();
+    }
+
+    // @TODO: add description
+    public boolean contains(String key) {
+        return mState.containsKey(key);
+    }
+
+    // @TODO: add description
+    public void addKeyPosition(String target, TypedBundle bundle) {
+        getWidgetState(target, null, 0).setKeyPosition(bundle);
+    }
+
+    // @TODO: add description
+    public void addKeyAttribute(String target, TypedBundle bundle) {
+        getWidgetState(target, null, 0).setKeyAttribute(bundle);
+    }
+
+    /**
+     * Add a key attribute and the custom variables into the
+     * @param target the id of the target
+     * @param bundle the key attributes bundle containing position etc.
+     * @param custom the customVariables to add at that position
+     */
+    public void addKeyAttribute(String target, TypedBundle bundle, CustomVariable[]custom) {
+        getWidgetState(target, null, 0).setKeyAttribute(bundle,custom);
+    }
+
+    // @TODO: add description
+    public void addKeyCycle(String target, TypedBundle bundle) {
+        getWidgetState(target, null, 0).setKeyCycle(bundle);
+    }
+
+    // @TODO: add description
+    public void addKeyPosition(String target, int frame, int type, float x, float y) {
+        TypedBundle bundle = new TypedBundle();
+        bundle.add(TypedValues.PositionType.TYPE_POSITION_TYPE, 2);
+        bundle.add(TypedValues.TYPE_FRAME_POSITION, frame);
+        bundle.add(TypedValues.PositionType.TYPE_PERCENT_X, x);
+        bundle.add(TypedValues.PositionType.TYPE_PERCENT_Y, y);
+        getWidgetState(target, null, 0).setKeyPosition(bundle);
+
+        KeyPosition keyPosition = new KeyPosition(target, frame, type, x, y);
+        HashMap<String, KeyPosition> map = mKeyPositions.get(frame);
+        if (map == null) {
+            map = new HashMap<>();
+            mKeyPositions.put(frame, map);
+        }
+        map.put(target, keyPosition);
+    }
+
+    // @TODO: add description
+    public void addCustomFloat(int state, String widgetId, String property, float value) {
+        WidgetState widgetState = getWidgetState(widgetId, null, state);
+        WidgetFrame frame = widgetState.getFrame(state);
+        frame.addCustomFloat(property, value);
+    }
+
+    // @TODO: add description
+    public void addCustomColor(int state, String widgetId, String property, int color) {
+        WidgetState widgetState = getWidgetState(widgetId, null, state);
+        WidgetFrame frame = widgetState.getFrame(state);
+        frame.addCustomColor(property, color);
+    }
+
+    private void calculateParentDimensions(float progress) {
+        mParentInterpolatedWidth = (int) (0.5f +
+                mParentStartWidth + (mParentEndWidth - mParentStartWidth) * progress);
+        mParentInterpolateHeight = (int) (0.5f +
+                mParentStartHeight + (mParentEndHeight - mParentStartHeight) * progress);
+    }
+
+    public int getInterpolatedWidth() {
+        return mParentInterpolatedWidth;
+    }
+
+    public int getInterpolatedHeight() {
+        return mParentInterpolateHeight;
+    }
+    /**
+     * Update container of parameters for the state
+     *
+     * @param container contains all the widget parameters
+     * @param state     starting or ending
+     */
+    public void updateFrom(ConstraintWidgetContainer container, int state) {
+        mWrap = container.mListDimensionBehaviors[0]
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+        mWrap |= container.mListDimensionBehaviors[1]
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+        if (state == START) {
+            mParentInterpolatedWidth = mParentStartWidth = container.getWidth();
+            mParentInterpolateHeight = mParentStartHeight = container.getHeight();
+        } else {
+            mParentEndWidth = container.getWidth();
+            mParentEndHeight = container.getHeight();
+        }
+        final ArrayList<ConstraintWidget> children = container.getChildren();
+        final int count = children.size();
+        WidgetState[] states = new WidgetState[count];
+
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            WidgetState widgetState = getWidgetState(child.stringId, null, state);
+            states[i] = widgetState;
+            widgetState.update(child, state);
+            String id = widgetState.getPathRelativeId();
+            if (id != null) {
+                widgetState.setPathRelative(getWidgetState(id, null, state));
+            }
+        }
+
+        calcStagger();
+    }
+
+    // @TODO: add description
+    public void interpolate(int parentWidth, int parentHeight, float progress) {
+        if (mWrap) {
+            calculateParentDimensions(progress);
+        }
+
+        if (mEasing != null) {
+            progress = (float) mEasing.get(progress);
+        }
+        for (String key : mState.keySet()) {
+            WidgetState widget = mState.get(key);
+            widget.interpolate(parentWidth, parentHeight, progress, this);
+        }
+    }
+
+    // @TODO: add description
+    public WidgetFrame getStart(String id) {
+        WidgetState widgetState = mState.get(id);
+        if (widgetState == null) {
+            return null;
+        }
+        return widgetState.mStart;
+    }
+
+    // @TODO: add description
+    public WidgetFrame getEnd(String id) {
+        WidgetState widgetState = mState.get(id);
+        if (widgetState == null) {
+            return null;
+        }
+        return widgetState.mEnd;
+    }
+
+    // @TODO: add description
+    public WidgetFrame getInterpolated(String id) {
+        WidgetState widgetState = mState.get(id);
+        if (widgetState == null) {
+            return null;
+        }
+        return widgetState.mInterpolated;
+    }
+
+    // @TODO: add description
+    public float[] getPath(String id) {
+        WidgetState widgetState = mState.get(id);
+        int duration = 1000;
+        int frames = duration / 16;
+        float[] mPoints = new float[frames * 2];
+        widgetState.mMotionControl.buildPath(mPoints, frames);
+        return mPoints;
+    }
+
+    // @TODO: add description
+    public int getKeyFrames(String id, float[] rectangles, int[] pathMode, int[] position) {
+        WidgetState widgetState = mState.get(id);
+        return widgetState.mMotionControl.buildKeyFrames(rectangles, pathMode, position);
+    }
+
+    @SuppressWarnings("unused")
+    private WidgetState getWidgetState(String widgetId) {
+        return this.mState.get(widgetId);
+    }
+
+    public WidgetState getWidgetState(String widgetId,
+            ConstraintWidget child,
+            int transitionState) {
+        WidgetState widgetState = this.mState.get(widgetId);
+        if (widgetState == null) {
+            widgetState = new WidgetState();
+            mBundle.applyDelta(widgetState.mMotionControl);
+            widgetState.mMotionWidgetStart.updateMotion(widgetState.mMotionControl);
+            mState.put(widgetId, widgetState);
+            if (child != null) {
+                widgetState.update(child, transitionState);
+            }
+        }
+        return widgetState;
+    }
+
+    /**
+     * Used in debug draw
+     */
+    public WidgetFrame getStart(ConstraintWidget child) {
+        return getWidgetState(child.stringId, null, Transition.START).mStart;
+    }
+
+    /**
+     * Used in debug draw
+     */
+    public WidgetFrame getEnd(ConstraintWidget child) {
+        return getWidgetState(child.stringId, null, Transition.END).mEnd;
+    }
+
+    /**
+     * Used after the interpolation
+     */
+    public WidgetFrame getInterpolated(ConstraintWidget child) {
+        return getWidgetState(child.stringId, null, Transition.INTERPOLATED).mInterpolated;
+    }
+
+    /**
+     * This gets the interpolator being used
+     */
+    public Interpolator getInterpolator() {
+        return getInterpolator(mDefaultInterpolator, mDefaultInterpolatorString);
+    }
+
+    /**
+     * This gets the auto transition mode being used
+     */
+    public int getAutoTransition() {
+        return mAutoTransition;
+    }
+
+    public static class WidgetState {
+        WidgetFrame mStart;
+        WidgetFrame mEnd;
+        WidgetFrame mInterpolated;
+        Motion mMotionControl;
+        boolean mNeedSetup = true;
+        MotionWidget mMotionWidgetStart;
+        MotionWidget mMotionWidgetEnd;
+        MotionWidget mMotionWidgetInterpolated;
+        KeyCache mKeyCache = new KeyCache();
+        int mParentHeight = -1;
+        int mParentWidth = -1;
+
+        public WidgetState() {
+            mStart = new WidgetFrame();
+            mEnd = new WidgetFrame();
+            mInterpolated = new WidgetFrame();
+            mMotionWidgetStart = new MotionWidget(mStart);
+            mMotionWidgetEnd = new MotionWidget(mEnd);
+            mMotionWidgetInterpolated = new MotionWidget(mInterpolated);
+            mMotionControl = new Motion(mMotionWidgetStart);
+            mMotionControl.setStart(mMotionWidgetStart);
+            mMotionControl.setEnd(mMotionWidgetEnd);
+        }
+
+        public void setKeyPosition(TypedBundle prop) {
+            MotionKeyPosition keyPosition = new MotionKeyPosition();
+            prop.applyDelta(keyPosition);
+            mMotionControl.addKey(keyPosition);
+        }
+
+        public void setKeyAttribute(TypedBundle prop) {
+            MotionKeyAttributes keyAttributes = new MotionKeyAttributes();
+            prop.applyDelta(keyAttributes);
+            mMotionControl.addKey(keyAttributes);
+        }
+
+        /**
+         * Set tge keyAttribute bundle and associated custom attributes
+         * @param prop
+         * @param custom
+         */
+        public void setKeyAttribute(TypedBundle prop, CustomVariable[] custom) {
+            MotionKeyAttributes keyAttributes = new MotionKeyAttributes();
+            prop.applyDelta(keyAttributes);
+            if (custom != null) {
+                for (int i = 0; i < custom.length; i++) {
+                    keyAttributes.mCustom.put( custom[i].getName(), custom[i]);
+                }
+            }
+            mMotionControl.addKey(keyAttributes);
+        }
+
+        public void setKeyCycle(TypedBundle prop) {
+            MotionKeyCycle keyAttributes = new MotionKeyCycle();
+            prop.applyDelta(keyAttributes);
+            mMotionControl.addKey(keyAttributes);
+        }
+
+        public void update(ConstraintWidget child, int state) {
+            if (state == START) {
+                mStart.update(child);
+                mMotionWidgetStart.updateMotion(mMotionWidgetStart);
+                mMotionControl.setStart(mMotionWidgetStart);
+                mNeedSetup = true;
+            } else if (state == END) {
+                mEnd.update(child);
+                mMotionControl.setEnd(mMotionWidgetEnd);
+                mNeedSetup = true;
+            }
+            mParentWidth = -1;
+        }
+
+        /**
+         * Return the id of the widget to animate relative to
+         *
+         * @return id of widget or null
+         */
+        String getPathRelativeId() {
+            return mMotionControl.getAnimateRelativeTo();
+        }
+
+        public WidgetFrame getFrame(int type) {
+            if (type == START) {
+                return mStart;
+            } else if (type == END) {
+                return mEnd;
+            }
+            return mInterpolated;
+        }
+
+        public void interpolate(int parentWidth,
+                int parentHeight,
+                float progress,
+                Transition transition) {
+            // TODO  only update if parentHeight != mParentHeight || parentWidth != mParentWidth) {
+            mParentHeight = parentHeight;
+            mParentWidth = parentWidth;
+            if (mNeedSetup) {
+                mMotionControl.setup(parentWidth, parentHeight, 1, System.nanoTime());
+                mNeedSetup = false;
+            }
+            WidgetFrame.interpolate(parentWidth, parentHeight,
+                    mInterpolated, mStart, mEnd, transition, progress);
+            mInterpolated.interpolatedPos = progress;
+            mMotionControl.interpolate(mMotionWidgetInterpolated,
+                    progress, System.nanoTime(), mKeyCache);
+        }
+
+        public void setPathRelative(WidgetState widgetState) {
+            mMotionControl.setupRelative(widgetState.mMotionControl);
+        }
+    }
+
+    static class KeyPosition {
+        int mFrame;
+        String mTarget;
+        int mType;
+        float mX;
+        float mY;
+
+        KeyPosition(String target, int frame, int type, float x, float y) {
+            this.mTarget = target;
+            this.mFrame = frame;
+            this.mType = type;
+            this.mX = x;
+            this.mY = y;
+        }
+    }
+
+    public void calcStagger() {
+        if (mStagger == 0.0f) {
+            return;
+        }
+        boolean flip = mStagger < 0.0;
+
+        float stagger = Math.abs(mStagger);
+        float min = Float.MAX_VALUE, max = -Float.MAX_VALUE;
+        boolean useMotionStagger = false;
+
+        for (String widgetId : mState.keySet()) {
+            WidgetState widgetState = mState.get(widgetId);
+            Motion f = widgetState.mMotionControl;
+            if (!Float.isNaN(f.getMotionStagger())) {
+                useMotionStagger = true;
+                break;
+            }
+        }
+        if (useMotionStagger) {
+            for (String widgetId : mState.keySet()) {
+                WidgetState widgetState = mState.get(widgetId);
+                Motion f = widgetState.mMotionControl;
+                float widgetStagger = f.getMotionStagger();
+                if (!Float.isNaN(widgetStagger)) {
+                    min = Math.min(min, widgetStagger);
+                    max = Math.max(max, widgetStagger);
+                }
+            }
+
+            for (String widgetId : mState.keySet()) {
+                WidgetState widgetState = mState.get(widgetId);
+                Motion f = widgetState.mMotionControl;
+
+                float widgetStagger = f.getMotionStagger();
+                if (!Float.isNaN(widgetStagger)) {
+                    float scale = 1 / (1 - stagger);
+
+                    float offset = stagger - stagger * (widgetStagger - min) / (max - min);
+                    if (flip) {
+                        offset = stagger - stagger
+                                * ((max - widgetStagger) / (max - min));
+                    }
+                    f.setStaggerScale(scale);
+                    f.setStaggerOffset(offset);
+                }
+            }
+
+        } else {
+            for (String widgetId : mState.keySet()) {
+                WidgetState widgetState = mState.get(widgetId);
+                Motion f = widgetState.mMotionControl;
+                float x = f.getFinalX();
+                float y = f.getFinalY();
+                float widgetStagger = x + y;
+                min = Math.min(min, widgetStagger);
+                max = Math.max(max, widgetStagger);
+            }
+
+            for (String widgetId : mState.keySet()) {
+                WidgetState widgetState = mState.get(widgetId);
+                Motion f = widgetState.mMotionControl;
+                float x = f.getFinalX();
+                float y = f.getFinalY();
+                float widgetStagger = x + y;
+                float offset = stagger - stagger * (widgetStagger - min) / (max - min);
+                if (flip) {
+                    offset = stagger - stagger
+                            * ((max - widgetStagger) / (max - min));
+                }
+
+                float scale = 1 / (1 - stagger);
+                f.setStaggerScale(scale);
+                f.setStaggerOffset(offset);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/TransitionParser.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/TransitionParser.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import static androidx.constraintlayout.core.state.ConstraintSetParser.parseColorString;
+
+import androidx.annotation.RestrictTo;
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.parser.CLArray;
+import androidx.constraintlayout.core.parser.CLContainer;
+import androidx.constraintlayout.core.parser.CLElement;
+import androidx.constraintlayout.core.parser.CLKey;
+import androidx.constraintlayout.core.parser.CLNumber;
+import androidx.constraintlayout.core.parser.CLObject;
+import androidx.constraintlayout.core.parser.CLParsingException;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Contains code for Parsing Transitions
+ */
+public class TransitionParser {
+    /**
+     * Parse a JSON string of a Transition and insert it into the Transition object
+     *
+     * @deprecated dpToPixel is not necessary, use {@link #parse(CLObject, Transition)} instead.
+     * @param json       Transition Object to parse.
+     * @param transition Transition Object to write transition to
+     */
+    @Deprecated
+    public static void parse(CLObject json, Transition transition, CorePixelDp dpToPixel)
+            throws CLParsingException {
+        parse(json, transition);
+    }
+
+    /**
+     * Parse a JSON string of a Transition and insert it into the Transition object
+     *
+     * @param json       Transition Object to parse.
+     * @param transition Transition Object to write transition to
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static void parse(@NonNull CLObject json, @NonNull Transition transition)
+            throws CLParsingException {
+        transition.resetProperties();
+        String pathMotionArc = json.getStringOrNull("pathMotionArc");
+        TypedBundle bundle = new TypedBundle();
+        boolean setBundle = false;
+        if (pathMotionArc != null) {
+            setBundle = true;
+            switch (pathMotionArc) {
+                // TODO use map
+                case "none":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 0);
+                    break;
+                case "startVertical":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 1);
+                    break;
+                case "startHorizontal":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 2);
+                    break;
+                case "flip":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 3);
+                    break;
+                case "below":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 4);
+                    break;
+                case "above":
+                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 5);
+            }
+
+        }
+        // TODO: Add duration
+        String interpolator = json.getStringOrNull("interpolator");
+        if (interpolator != null) {
+            setBundle = true;
+            bundle.add(TypedValues.TransitionType.TYPE_INTERPOLATOR, interpolator);
+        }
+
+        float staggered = json.getFloatOrNaN("staggered");
+        if (!Float.isNaN(staggered)) {
+            setBundle = true;
+            bundle.add(TypedValues.TransitionType.TYPE_STAGGERED, staggered);
+        }
+        if (setBundle) {
+            transition.setTransitionProperties(bundle);
+        }
+
+        CLContainer onSwipe = json.getObjectOrNull("onSwipe");
+
+        if (onSwipe != null) {
+            parseOnSwipe(onSwipe, transition);
+        }
+        parseKeyFrames(json, transition);
+    }
+
+    private static void parseOnSwipe(CLContainer onSwipe, Transition transition) {
+        String anchor = onSwipe.getStringOrNull("anchor");
+        int side = map(onSwipe.getStringOrNull("side"), Transition.OnSwipe.SIDES);
+        int direction = map(onSwipe.getStringOrNull("direction"),
+                Transition.OnSwipe.DIRECTIONS);
+        float scale = onSwipe.getFloatOrNaN("scale");
+        float threshold = onSwipe.getFloatOrNaN("threshold");
+        float maxVelocity = onSwipe.getFloatOrNaN("maxVelocity");
+        float maxAccel = onSwipe.getFloatOrNaN("maxAccel");
+        String limitBounds = onSwipe.getStringOrNull("limitBounds");
+        int autoCompleteMode = map(onSwipe.getStringOrNull("mode"), Transition.OnSwipe.MODE);
+        int touchUp = map(onSwipe.getStringOrNull("touchUp"), Transition.OnSwipe.TOUCH_UP);
+        float springMass = onSwipe.getFloatOrNaN("springMass");
+        float springStiffness = onSwipe.getFloatOrNaN("springStiffness");
+        float springDamping = onSwipe.getFloatOrNaN("springDamping");
+        float stopThreshold = onSwipe.getFloatOrNaN("stopThreshold");
+        int springBoundary = map(onSwipe.getStringOrNull("springBoundary"),
+                Transition.OnSwipe.BOUNDARY);
+        String around = onSwipe.getStringOrNull("around");
+
+        Transition.OnSwipe swipe = transition.createOnSwipe();
+        swipe.setAnchorId(anchor);
+        swipe.setAnchorSide(side);
+        swipe.setDragDirection(direction);
+        swipe.setDragScale(scale);
+        swipe.setDragThreshold(threshold);
+        swipe.setMaxVelocity(maxVelocity);
+        swipe.setMaxAcceleration(maxAccel);
+        swipe.setLimitBoundsTo(limitBounds);
+        swipe.setAutoCompleteMode(autoCompleteMode);
+        swipe.setOnTouchUp(touchUp);
+        swipe.setSpringMass(springMass);
+        swipe.setSpringStiffness(springStiffness);
+        swipe.setSpringDamping(springDamping);
+        swipe.setSpringStopThreshold(stopThreshold);
+        swipe.setSpringBoundary(springBoundary);
+        swipe.setRotationCenterId(around);
+    }
+
+
+    private static int map(String val, String... types) {
+        for (int i = 0; i < types.length; i++) {
+            if (types[i].equals(val)) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private static void map(TypedBundle bundle, int type, String val, String... types) {
+        for (int i = 0; i < types.length; i++) {
+            if (types[i].equals(val)) {
+                bundle.add(type, i);
+            }
+        }
+    }
+
+    /**
+     * Parses {@code KeyFrames} attributes from the {@link CLObject} into {@link  Transition}.
+     *
+     * @param transitionCLObject the CLObject for the root transition json
+     * @param transition         core object that holds the state of the Transition
+     */
+    public static void parseKeyFrames(CLObject transitionCLObject, Transition transition)
+            throws CLParsingException {
+        CLContainer keyframes = transitionCLObject.getObjectOrNull("KeyFrames");
+        if (keyframes == null) return;
+        CLArray keyPositions = keyframes.getArrayOrNull("KeyPositions");
+        if (keyPositions != null) {
+            for (int i = 0; i < keyPositions.size(); i++) {
+                CLElement keyPosition = keyPositions.get(i);
+                if (keyPosition instanceof CLObject) {
+                    parseKeyPosition((CLObject) keyPosition, transition);
+                }
+            }
+        }
+        CLArray keyAttributes = keyframes.getArrayOrNull("KeyAttributes");
+        if (keyAttributes != null) {
+            for (int i = 0; i < keyAttributes.size(); i++) {
+                CLElement keyAttribute = keyAttributes.get(i);
+                if (keyAttribute instanceof CLObject) {
+                    parseKeyAttribute((CLObject) keyAttribute, transition);
+                }
+            }
+        }
+        CLArray keyCycles = keyframes.getArrayOrNull("KeyCycles");
+        if (keyCycles != null) {
+            for (int i = 0; i < keyCycles.size(); i++) {
+                CLElement keyCycle = keyCycles.get(i);
+                if (keyCycle instanceof CLObject) {
+                    parseKeyCycle((CLObject) keyCycle, transition);
+                }
+            }
+        }
+    }
+
+
+    private static void parseKeyPosition(CLObject keyPosition,
+            Transition transition) throws CLParsingException {
+        TypedBundle bundle = new TypedBundle();
+        CLArray targets = keyPosition.getArray("target");
+        CLArray frames = keyPosition.getArray("frames");
+        CLArray percentX = keyPosition.getArrayOrNull("percentX");
+        CLArray percentY = keyPosition.getArrayOrNull("percentY");
+        CLArray percentWidth = keyPosition.getArrayOrNull("percentWidth");
+        CLArray percentHeight = keyPosition.getArrayOrNull("percentHeight");
+        String pathMotionArc = keyPosition.getStringOrNull("pathMotionArc");
+        String transitionEasing = keyPosition.getStringOrNull("transitionEasing");
+        String curveFit = keyPosition.getStringOrNull("curveFit");
+        String type = keyPosition.getStringOrNull("type");
+        if (type == null) {
+            type = "parentRelative";
+        }
+        if (percentX != null && frames.size() != percentX.size()) {
+            return;
+        }
+        if (percentY != null && frames.size() != percentY.size()) {
+            return;
+        }
+        for (int i = 0; i < targets.size(); i++) {
+            String target = targets.getString(i);
+            int pos_type = map(type, "deltaRelative", "pathRelative", "parentRelative");
+            bundle.clear();
+            bundle.add(TypedValues.PositionType.TYPE_POSITION_TYPE, pos_type);
+            if (curveFit != null) {
+                map(bundle, TypedValues.PositionType.TYPE_CURVE_FIT, curveFit,
+                        "spline", "linear");
+            }
+            bundle.addIfNotNull(TypedValues.PositionType.TYPE_TRANSITION_EASING, transitionEasing);
+
+            if (pathMotionArc != null) {
+                map(bundle, TypedValues.PositionType.TYPE_PATH_MOTION_ARC, pathMotionArc,
+                        "none", "startVertical", "startHorizontal", "flip", "below", "above");
+            }
+
+            for (int j = 0; j < frames.size(); j++) {
+                int frame = frames.getInt(j);
+                bundle.add(TypedValues.TYPE_FRAME_POSITION, frame);
+                set(bundle, TypedValues.PositionType.TYPE_PERCENT_X, percentX, j);
+                set(bundle, TypedValues.PositionType.TYPE_PERCENT_Y, percentY, j);
+                set(bundle, TypedValues.PositionType.TYPE_PERCENT_WIDTH, percentWidth, j);
+                set(bundle, TypedValues.PositionType.TYPE_PERCENT_HEIGHT, percentHeight, j);
+
+                transition.addKeyPosition(target, bundle);
+            }
+        }
+    }
+
+    private static void set(TypedBundle bundle, int type,
+            CLArray array, int index) throws CLParsingException {
+        if (array != null) {
+            bundle.add(type, array.getFloat(index));
+        }
+    }
+
+    private static void parseKeyAttribute(CLObject keyAttribute,
+            Transition transition) throws CLParsingException {
+        CLArray targets = keyAttribute.getArrayOrNull("target");
+        if (targets == null) {
+            return;
+        }
+        CLArray frames = keyAttribute.getArrayOrNull("frames");
+        if (frames == null) {
+            return;
+        }
+        String transitionEasing = keyAttribute.getStringOrNull("transitionEasing");
+        // These present an ordered list of attributes that might be used in a keyCycle
+        String[] attrNames = {
+                TypedValues.AttributesType.S_SCALE_X,
+                TypedValues.AttributesType.S_SCALE_Y,
+                TypedValues.AttributesType.S_TRANSLATION_X,
+                TypedValues.AttributesType.S_TRANSLATION_Y,
+                TypedValues.AttributesType.S_TRANSLATION_Z,
+                TypedValues.AttributesType.S_ROTATION_X,
+                TypedValues.AttributesType.S_ROTATION_Y,
+                TypedValues.AttributesType.S_ROTATION_Z,
+                TypedValues.AttributesType.S_ALPHA
+        };
+        int[] attrIds = {
+                TypedValues.AttributesType.TYPE_SCALE_X,
+                TypedValues.AttributesType.TYPE_SCALE_Y,
+                TypedValues.AttributesType.TYPE_TRANSLATION_X,
+                TypedValues.AttributesType.TYPE_TRANSLATION_Y,
+                TypedValues.AttributesType.TYPE_TRANSLATION_Z,
+                TypedValues.AttributesType.TYPE_ROTATION_X,
+                TypedValues.AttributesType.TYPE_ROTATION_Y,
+                TypedValues.AttributesType.TYPE_ROTATION_Z,
+                TypedValues.AttributesType.TYPE_ALPHA
+        };
+        // if true scale the values from pixels to dp
+        boolean[] scaleTypes = {
+                false,
+                false,
+                true,
+                true,
+                true,
+                false,
+                false,
+                false,
+                false,
+        };
+        TypedBundle[] bundles = new TypedBundle[frames.size()];
+        CustomVariable[][] customVars  = null;
+
+        for (int i = 0; i < frames.size(); i++) {
+            bundles[i] = new TypedBundle();
+        }
+
+        for (int k = 0; k < attrNames.length; k++) {
+
+            String attrName = attrNames[k];
+            int attrId = attrIds[k];
+            boolean scale = scaleTypes[k];
+            CLArray arrayValues = keyAttribute.getArrayOrNull(attrName);
+            // array must contain one per frame
+            if (arrayValues != null && arrayValues.size() != bundles.length) {
+                throw new CLParsingException(
+                        "incorrect size for " + attrName + " array, "
+                                + "not matching targets array!", keyAttribute);
+            }
+            if (arrayValues != null) {
+                for (int i = 0; i < bundles.length; i++) {
+                    float value = arrayValues.getFloat(i);
+                    if (scale) {
+                        value = transition.mToPixel.toPixels(value);
+                    }
+                    bundles[i].add(attrId, value);
+                }
+            } else {
+                float value = keyAttribute.getFloatOrNaN(attrName);
+                if (!Float.isNaN(value)) {
+                    if (scale) {
+                        value = transition.mToPixel.toPixels(value);
+                    }
+                    for (int i = 0; i < bundles.length; i++) {
+                        bundles[i].add(attrId, value);
+                    }
+                }
+            }
+        }
+        // Support for custom attributes in KeyAttributes
+        CLElement customElement = keyAttribute.getOrNull("custom");
+        if (customElement != null && customElement instanceof CLObject) {
+            CLObject customObj = ((CLObject) customElement);
+            int n = customObj.size();
+            customVars = new CustomVariable[frames.size()][n];
+            for (int i = 0; i < n; i++) {
+                CLKey key = (CLKey) customObj.get(i);
+                String customName = key.content();
+                if (key.getValue() instanceof CLArray) {
+                    CLArray arrayValues = (CLArray) key.getValue();
+                    int vSize = arrayValues.size();
+                    if (vSize == bundles.length && vSize > 0) {
+                        if (arrayValues.get(0) instanceof CLNumber) {
+                            for (int j = 0; j < bundles.length; j++) {
+                                customVars[j][i] = new CustomVariable(customName,
+                                        TypedValues.Custom.TYPE_FLOAT,
+                                        arrayValues.get(j).getFloat());
+                            }
+                        } else {  // since it is not a number switching to custom color parsing
+                            for (int j = 0; j < bundles.length; j++) {
+                                long color = parseColorString(arrayValues.get(j).content());
+                                if (color != -1) {
+                                    customVars[j][i] = new CustomVariable(customName,
+                                            TypedValues.Custom.TYPE_COLOR,
+                                            (int) color);
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    CLElement value = key.getValue();
+                    if (value instanceof CLNumber) {
+                        float fValue = value.getFloat();
+                        for (int j = 0; j < bundles.length; j++) {
+                            customVars[j][i] = new CustomVariable(customName,
+                                    TypedValues.Custom.TYPE_FLOAT,
+                                    fValue);
+                        }
+                    } else {
+                        long cValue = parseColorString(value.content());
+                        if (cValue != -1) {
+                            for (int j = 0; j < bundles.length; j++) {
+                                customVars[j][i] = new CustomVariable(customName,
+                                        TypedValues.Custom.TYPE_COLOR,
+                                        (int) cValue);
+
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+        String curveFit = keyAttribute.getStringOrNull("curveFit");
+        for (int i = 0; i < targets.size(); i++) {
+            for (int j = 0; j < bundles.length; j++) {
+                String target = targets.getString(i);
+                TypedBundle bundle = bundles[j];
+                if (curveFit != null) {
+                    bundle.add(TypedValues.PositionType.TYPE_CURVE_FIT,
+                            map(curveFit, "spline", "linear"));
+                }
+                bundle.addIfNotNull(TypedValues.PositionType.TYPE_TRANSITION_EASING,
+                        transitionEasing);
+                int frame = frames.getInt(j);
+                bundle.add(TypedValues.TYPE_FRAME_POSITION, frame);
+                transition.addKeyAttribute(target, bundle, (customVars != null) ? customVars[j] :
+                        null);
+            }
+        }
+    }
+
+    private static void parseKeyCycle(CLObject keyCycleData,
+            Transition transition) throws CLParsingException {
+        CLArray targets = keyCycleData.getArray("target");
+        CLArray frames = keyCycleData.getArray("frames");
+        String transitionEasing = keyCycleData.getStringOrNull("transitionEasing");
+        // These present an ordered list of attributes that might be used in a keyCycle
+        String[] attrNames = {
+                TypedValues.CycleType.S_SCALE_X,
+                TypedValues.CycleType.S_SCALE_Y,
+                TypedValues.CycleType.S_TRANSLATION_X,
+                TypedValues.CycleType.S_TRANSLATION_Y,
+                TypedValues.CycleType.S_TRANSLATION_Z,
+                TypedValues.CycleType.S_ROTATION_X,
+                TypedValues.CycleType.S_ROTATION_Y,
+                TypedValues.CycleType.S_ROTATION_Z,
+                TypedValues.CycleType.S_ALPHA,
+                TypedValues.CycleType.S_WAVE_PERIOD,
+                TypedValues.CycleType.S_WAVE_OFFSET,
+                TypedValues.CycleType.S_WAVE_PHASE,
+        };
+        int[] attrIds = {
+                TypedValues.CycleType.TYPE_SCALE_X,
+                TypedValues.CycleType.TYPE_SCALE_Y,
+                TypedValues.CycleType.TYPE_TRANSLATION_X,
+                TypedValues.CycleType.TYPE_TRANSLATION_Y,
+                TypedValues.CycleType.TYPE_TRANSLATION_Z,
+                TypedValues.CycleType.TYPE_ROTATION_X,
+                TypedValues.CycleType.TYPE_ROTATION_Y,
+                TypedValues.CycleType.TYPE_ROTATION_Z,
+                TypedValues.CycleType.TYPE_ALPHA,
+                TypedValues.CycleType.TYPE_WAVE_PERIOD,
+                TypedValues.CycleType.TYPE_WAVE_OFFSET,
+                TypedValues.CycleType.TYPE_WAVE_PHASE,
+        };
+        // type 0 the values are used as.
+        // type 1 the value is scaled from dp to pixels.
+        // type 2 are scaled if the system has another type 1.
+        int[] scaleTypes = {
+                0,
+                0,
+                1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                0,
+        };
+
+//  TODO S_WAVE_SHAPE S_CUSTOM_WAVE_SHAPE
+        TypedBundle[] bundles = new TypedBundle[frames.size()];
+        for (int i = 0; i < bundles.length; i++) {
+            bundles[i] = new TypedBundle();
+        }
+        boolean scaleOffset = false;
+        for (int k = 0; k < attrNames.length; k++) {
+            if (keyCycleData.has(attrNames[k]) && scaleTypes[k] == 1) {
+                scaleOffset = true;
+            }
+        }
+        for (int k = 0; k < attrNames.length; k++) {
+            String attrName = attrNames[k];
+            int attrId = attrIds[k];
+            int scale = scaleTypes[k];
+            CLArray arrayValues = keyCycleData.getArrayOrNull(attrName);
+            // array must contain one per frame
+            if (arrayValues != null && arrayValues.size() != bundles.length) {
+                throw new CLParsingException(
+                        "incorrect size for $attrName array, "
+                                + "not matching targets array!", keyCycleData
+                );
+            }
+            if (arrayValues != null) {
+                for (int i = 0; i < bundles.length; i++) {
+                    float value = arrayValues.getFloat(i);
+                    if (scale == 1) {
+                        value = transition.mToPixel.toPixels(value);
+                    } else if (scale == 2 && scaleOffset) {
+                        value = transition.mToPixel.toPixels(value);
+                    }
+                    bundles[i].add(attrId, value);
+                }
+            } else {
+                float value = keyCycleData.getFloatOrNaN(attrName);
+                if (!Float.isNaN(value)) {
+                    if (scale == 1) {
+                        value = transition.mToPixel.toPixels(value);
+                    } else if (scale == 2 && scaleOffset) {
+                        value = transition.mToPixel.toPixels(value);
+                    }
+                    for (int i = 0; i < bundles.length; i++) {
+                        bundles[i].add(attrId, value);
+                    }
+                }
+            }
+        }
+        String curveFit = keyCycleData.getStringOrNull(TypedValues.CycleType.S_CURVE_FIT);
+        String easing = keyCycleData.getStringOrNull(TypedValues.CycleType.S_EASING);
+        String waveShape = keyCycleData.getStringOrNull(TypedValues.CycleType.S_WAVE_SHAPE);
+        String customWave = keyCycleData.getStringOrNull(TypedValues.CycleType.S_CUSTOM_WAVE_SHAPE);
+        for (int i = 0; i < targets.size(); i++) {
+            for (int j = 0; j < bundles.length; j++) {
+                String target = targets.getString(i);
+                TypedBundle bundle = bundles[j];
+
+
+                if (curveFit != null) {
+                    switch (curveFit) {
+                        case "spline":
+                            bundle.add(TypedValues.CycleType.TYPE_CURVE_FIT, 0);
+                            break;
+                        case "linear":
+                            bundle.add(TypedValues.CycleType.TYPE_CURVE_FIT, 1);
+                            break;
+                    }
+                }
+                bundle.addIfNotNull(TypedValues.PositionType.TYPE_TRANSITION_EASING,
+                        transitionEasing);
+                if (easing != null) {
+                    bundle.add(TypedValues.CycleType.TYPE_EASING, easing);
+                }
+                if (waveShape != null) {
+                    bundle.add(TypedValues.CycleType.TYPE_WAVE_SHAPE, waveShape);
+                }
+                if (customWave != null) {
+                    bundle.add(TypedValues.CycleType.TYPE_CUSTOM_WAVE_SHAPE, customWave);
+                }
+
+                int frame = frames.getInt(j);
+                bundle.add(TypedValues.TYPE_FRAME_POSITION, frame);
+                transition.addKeyCycle(target, bundle);
+
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/WidgetFrame.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/WidgetFrame.java
@@ -1,0 +1,671 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state;
+
+import androidx.constraintlayout.core.motion.CustomAttribute;
+import androidx.constraintlayout.core.motion.CustomVariable;
+import androidx.constraintlayout.core.motion.utils.TypedBundle;
+import androidx.constraintlayout.core.motion.utils.TypedValues;
+import androidx.constraintlayout.core.parser.CLElement;
+import androidx.constraintlayout.core.parser.CLKey;
+import androidx.constraintlayout.core.parser.CLNumber;
+import androidx.constraintlayout.core.parser.CLObject;
+import androidx.constraintlayout.core.parser.CLParsingException;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * Utility class to encapsulate layout of a widget
+ */
+public class WidgetFrame {
+    public ConstraintWidget widget = null;
+    public int left = 0;
+    public int top = 0;
+    public int right = 0;
+    public int bottom = 0;
+
+    // transforms
+
+    public float pivotX = Float.NaN;
+    public float pivotY = Float.NaN;
+
+    public float rotationX = Float.NaN;
+    public float rotationY = Float.NaN;
+    public float rotationZ = Float.NaN;
+
+    public float translationX = Float.NaN;
+    public float translationY = Float.NaN;
+    public float translationZ = Float.NaN;
+    public static float phone_orientation = Float.NaN;
+
+    public float scaleX = Float.NaN;
+    public float scaleY = Float.NaN;
+
+    public float alpha = Float.NaN;
+    public float interpolatedPos = Float.NaN;
+
+    public int visibility = ConstraintWidget.VISIBLE;
+
+    private final HashMap<String, CustomVariable> mCustom = new HashMap<>();
+
+    public String name = null;
+
+    TypedBundle mMotionProperties;
+
+    // @TODO: add description
+    public int width() {
+        return Math.max(0, right - left);
+    }
+
+    // @TODO: add description
+    public int height() {
+        return Math.max(0, bottom - top);
+    }
+
+    public WidgetFrame() {
+    }
+
+    public WidgetFrame(ConstraintWidget widget) {
+        this.widget = widget;
+    }
+
+    public WidgetFrame(WidgetFrame frame) {
+        widget = frame.widget;
+        left = frame.left;
+        top = frame.top;
+        right = frame.right;
+        bottom = frame.bottom;
+        updateAttributes(frame);
+    }
+
+    // @TODO: add description
+    public void updateAttributes(WidgetFrame frame) {
+        if (frame == null) {
+            return;
+        }
+        pivotX = frame.pivotX;
+        pivotY = frame.pivotY;
+        rotationX = frame.rotationX;
+        rotationY = frame.rotationY;
+        rotationZ = frame.rotationZ;
+        translationX = frame.translationX;
+        translationY = frame.translationY;
+        translationZ = frame.translationZ;
+        scaleX = frame.scaleX;
+        scaleY = frame.scaleY;
+        alpha = frame.alpha;
+        visibility = frame.visibility;
+        setMotionAttributes(frame.mMotionProperties);
+        mCustom.clear();
+        for (CustomVariable c : frame.mCustom.values()) {
+            mCustom.put(c.getName(), c.copy());
+        }
+    }
+
+    public boolean isDefaultTransform() {
+        return Float.isNaN(rotationX)
+                && Float.isNaN(rotationY)
+                && Float.isNaN(rotationZ)
+                && Float.isNaN(translationX)
+                && Float.isNaN(translationY)
+                && Float.isNaN(translationZ)
+                && Float.isNaN(scaleX)
+                && Float.isNaN(scaleY)
+                && Float.isNaN(alpha);
+    }
+
+    // @TODO: add description
+    public static void interpolate(int parentWidth,
+            int parentHeight,
+            WidgetFrame frame,
+            WidgetFrame start,
+            WidgetFrame end,
+            Transition transition,
+            float progress) {
+        int frameNumber = (int) (progress * 100);
+        int startX = start.left;
+        int startY = start.top;
+        int endX = end.left;
+        int endY = end.top;
+        int startWidth = start.right - start.left;
+        int startHeight = start.bottom - start.top;
+        int endWidth = end.right - end.left;
+        int endHeight = end.bottom - end.top;
+
+        float progressPosition = progress;
+
+        float startAlpha = start.alpha;
+        float endAlpha = end.alpha;
+
+        if (start.visibility == ConstraintWidget.GONE) {
+            // On visibility gone, keep the same size to do an alpha to zero
+            startX -= (int) (endWidth / 2f);
+            startY -= (int) (endHeight / 2f);
+            startWidth = endWidth;
+            startHeight = endHeight;
+            if (Float.isNaN(startAlpha)) {
+                // override only if not defined...
+                startAlpha = 0f;
+            }
+        }
+
+        if (end.visibility == ConstraintWidget.GONE) {
+            // On visibility gone, keep the same size to do an alpha to zero
+            endX -= (int) (startWidth / 2f);
+            endY -= (int) (startHeight / 2f);
+            endWidth = startWidth;
+            endHeight = startHeight;
+            if (Float.isNaN(endAlpha)) {
+                // override only if not defined...
+                endAlpha = 0f;
+            }
+        }
+
+        if (Float.isNaN(startAlpha) && !Float.isNaN(endAlpha)) {
+            startAlpha = 1f;
+        }
+        if (!Float.isNaN(startAlpha) && Float.isNaN(endAlpha)) {
+            endAlpha = 1f;
+        }
+
+        if (start.visibility == ConstraintWidget.INVISIBLE) {
+            startAlpha = 0f;
+        }
+
+        if (end.visibility == ConstraintWidget.INVISIBLE) {
+            endAlpha = 0f;
+        }
+
+        if (frame.widget != null && transition.hasPositionKeyframes()) {
+            Transition.KeyPosition firstPosition =
+                    transition.findPreviousPosition(frame.widget.stringId, frameNumber);
+            Transition.KeyPosition lastPosition =
+                    transition.findNextPosition(frame.widget.stringId, frameNumber);
+
+            if (firstPosition == lastPosition) {
+                lastPosition = null;
+            }
+            int interpolateStartFrame = 0;
+            int interpolateEndFrame = 100;
+
+            if (firstPosition != null) {
+                startX = (int) (firstPosition.mX * parentWidth);
+                startY = (int) (firstPosition.mY * parentHeight);
+                interpolateStartFrame = firstPosition.mFrame;
+            }
+            if (lastPosition != null) {
+                endX = (int) (lastPosition.mX * parentWidth);
+                endY = (int) (lastPosition.mY * parentHeight);
+                interpolateEndFrame = lastPosition.mFrame;
+            }
+
+            progressPosition = (progress * 100f - interpolateStartFrame)
+                    / (float) (interpolateEndFrame - interpolateStartFrame);
+        }
+
+        frame.widget = start.widget;
+
+        frame.left = (int) (startX + progressPosition * (endX - startX));
+        frame.top = (int) (startY + progressPosition * (endY - startY));
+        int width = (int) ((1 - progress) * startWidth + (progress * endWidth));
+        int height = (int) ((1 - progress) * startHeight + (progress * endHeight));
+        frame.right = frame.left + width;
+        frame.bottom = frame.top + height;
+
+        frame.pivotX = interpolate(start.pivotX, end.pivotX, 0.5f, progress);
+        frame.pivotY = interpolate(start.pivotY, end.pivotY, 0.5f, progress);
+
+        frame.rotationX = interpolate(start.rotationX, end.rotationX, 0f, progress);
+        frame.rotationY = interpolate(start.rotationY, end.rotationY, 0f, progress);
+        frame.rotationZ = interpolate(start.rotationZ, end.rotationZ, 0f, progress);
+
+        frame.scaleX = interpolate(start.scaleX, end.scaleX, 1f, progress);
+        frame.scaleY = interpolate(start.scaleY, end.scaleY, 1f, progress);
+
+        frame.translationX = interpolate(start.translationX, end.translationX, 0f, progress);
+        frame.translationY = interpolate(start.translationY, end.translationY, 0f, progress);
+        frame.translationZ = interpolate(start.translationZ, end.translationZ, 0f, progress);
+
+        frame.alpha = interpolate(startAlpha, endAlpha, 1f, progress);
+
+        Set<String> keys = end.mCustom.keySet();
+        frame.mCustom.clear();
+        for (String key : keys) {
+            if (start.mCustom.containsKey(key)) {
+                CustomVariable startVariable = start.mCustom.get(key);
+                CustomVariable endVariable = end.mCustom.get(key);
+                CustomVariable interpolated = new CustomVariable(startVariable);
+                frame.mCustom.put(key, interpolated);
+                if (startVariable.numberOfInterpolatedValues() == 1) {
+                    interpolated.setValue(interpolate(startVariable.getValueToInterpolate(),
+                            endVariable.getValueToInterpolate(), 0f, progress));
+                } else {
+                    int n = startVariable.numberOfInterpolatedValues();
+                    float[] startValues = new float[n];
+                    float[] endValues = new float[n];
+                    startVariable.getValuesToInterpolate(startValues);
+                    endVariable.getValuesToInterpolate(endValues);
+                    for (int i = 0; i < n; i++) {
+                        startValues[i] = interpolate(startValues[i], endValues[i], 0f, progress);
+                        interpolated.setValue(startValues);
+                    }
+                }
+            }
+        }
+    }
+
+    private static float interpolate(float start, float end, float defaultValue, float progress) {
+        boolean isStartUnset = Float.isNaN(start);
+        boolean isEndUnset = Float.isNaN(end);
+        if (isStartUnset && isEndUnset) {
+            return Float.NaN;
+        }
+        if (isStartUnset) {
+            start = defaultValue;
+        }
+        if (isEndUnset) {
+            end = defaultValue;
+        }
+        return (start + progress * (end - start));
+    }
+
+    // @TODO: add description
+    public float centerX() {
+        return left + (right - left) / 2f;
+    }
+
+    // @TODO: add description
+    public float centerY() {
+        return top + (bottom - top) / 2f;
+    }
+
+    // @TODO: add description
+    public WidgetFrame update() {
+        if (widget != null) {
+            left = widget.getLeft();
+            top = widget.getTop();
+            right = widget.getRight();
+            bottom = widget.getBottom();
+            WidgetFrame frame = widget.frame;
+            updateAttributes(frame);
+        }
+        return this;
+    }
+
+    // @TODO: add description
+    public WidgetFrame update(ConstraintWidget widget) {
+        if (widget == null) {
+            return this;
+        }
+
+        this.widget = widget;
+        update();
+        return this;
+    }
+
+    /**
+     * Return whether this WidgetFrame contains a custom property of the given name.
+     */
+    public boolean containsCustom(@NonNull String name) {
+        return mCustom.containsKey(name);
+    }
+
+    // @TODO: add description
+    public void addCustomColor(String name, int color) {
+        setCustomAttribute(name, TypedValues.Custom.TYPE_COLOR, color);
+    }
+
+    // @TODO: add description
+    public int getCustomColor(String name) {
+        if (mCustom.containsKey(name)) {
+            return mCustom.get(name).getColorValue();
+        }
+        return 0xFFFFAA88;
+    }
+
+    // @TODO: add description
+    public void addCustomFloat(String name, float value) {
+        setCustomAttribute(name, TypedValues.Custom.TYPE_FLOAT, value);
+    }
+
+    // @TODO: add description
+    public float getCustomFloat(String name) {
+        if (mCustom.containsKey(name)) {
+            return mCustom.get(name).getFloatValue();
+        }
+        return Float.NaN;
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, float value) {
+        if (mCustom.containsKey(name)) {
+            mCustom.get(name).setFloatValue(value);
+        } else {
+            mCustom.put(name, new CustomVariable(name, type, value));
+        }
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, int value) {
+        if (mCustom.containsKey(name)) {
+            mCustom.get(name).setIntValue(value);
+        } else {
+            mCustom.put(name, new CustomVariable(name, type, value));
+        }
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, boolean value) {
+        if (mCustom.containsKey(name)) {
+            mCustom.get(name).setBooleanValue(value);
+        } else {
+            mCustom.put(name, new CustomVariable(name, type, value));
+        }
+    }
+
+    // @TODO: add description
+    public void setCustomAttribute(String name, int type, String value) {
+        if (mCustom.containsKey(name)) {
+            mCustom.get(name).setStringValue(value);
+        } else {
+            mCustom.put(name, new CustomVariable(name, type, value));
+        }
+    }
+
+    /**
+     * Get the custom attribute given Nam
+     * @param name Name of the custom attribut
+     * @return The customAttribute
+     */
+    public CustomVariable getCustomAttribute(String name) {
+        return mCustom.get(name);
+    }
+
+    /**
+     * Get the known custom Attributes names
+     * @return set of custom attribute names
+     */
+    public Set<String> getCustomAttributeNames() {
+        return mCustom.keySet();
+    }
+
+    // @TODO: add description
+    public boolean setValue(String key, CLElement value) throws CLParsingException {
+        switch (key) {
+            case "pivotX":
+                pivotX = value.getFloat();
+                break;
+            case "pivotY":
+                pivotY = value.getFloat();
+                break;
+            case "rotationX":
+                rotationX = value.getFloat();
+                break;
+            case "rotationY":
+                rotationY = value.getFloat();
+                break;
+            case "rotationZ":
+                rotationZ = value.getFloat();
+                break;
+            case "translationX":
+                translationX = value.getFloat();
+                break;
+            case "translationY":
+                translationY = value.getFloat();
+                break;
+            case "translationZ":
+                translationZ = value.getFloat();
+                break;
+            case "scaleX":
+                scaleX = value.getFloat();
+                break;
+            case "scaleY":
+                scaleY = value.getFloat();
+                break;
+            case "alpha":
+                alpha = value.getFloat();
+                break;
+            case "interpolatedPos":
+                interpolatedPos = value.getFloat();
+                break;
+            case "phone_orientation":
+                phone_orientation = value.getFloat();
+                break;
+            case "top":
+                top = value.getInt();
+                break;
+            case "left":
+                left = value.getInt();
+                break;
+            case "right":
+                right = value.getInt();
+                break;
+            case "bottom":
+                bottom = value.getInt();
+                break;
+            case "custom":
+                parseCustom(value);
+                break;
+
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    public String getId() {
+        if (widget == null) {
+            return "unknown";
+        }
+        return widget.stringId;
+    }
+
+    void parseCustom(CLElement custom) throws CLParsingException {
+        CLObject obj = ((CLObject) custom);
+        int n = obj.size();
+        for (int i = 0; i < n; i++) {
+            CLElement tmp = obj.get(i);
+            CLKey k = ((CLKey) tmp);
+            String customName = k.content();
+            CLElement v = k.getValue();
+            String vStr = v.content();
+            // Validate the length of the string to avoid regex or parsing issues
+            if (vStr != null && vStr.length() < 128 && vStr.matches("#[0-9a-fA-F]+")) {
+                int color = Integer.parseInt(vStr.substring(1), 16);
+                // Ensure we use the parsed key as the custom attribute name
+                setCustomAttribute(customName, TypedValues.Custom.TYPE_COLOR, color);
+            } else if (v instanceof CLNumber) {
+                setCustomAttribute(customName, TypedValues.Custom.TYPE_FLOAT, v.getFloat());
+            } else {
+                setCustomAttribute(customName, TypedValues.Custom.TYPE_STRING, vStr);
+            }
+        }
+    }
+
+    // @TODO: add description
+    public StringBuilder serialize(StringBuilder ret) {
+        return serialize(ret, false);
+    }
+
+    /**
+     * If true also send the phone orientation
+     */
+    public StringBuilder serialize(StringBuilder ret, boolean sendPhoneOrientation) {
+        WidgetFrame frame = this;
+        ret.append("{\n");
+        add(ret, "left", frame.left);
+        add(ret, "top", frame.top);
+        add(ret, "right", frame.right);
+        add(ret, "bottom", frame.bottom);
+        add(ret, "pivotX", frame.pivotX);
+        add(ret, "pivotY", frame.pivotY);
+        add(ret, "rotationX", frame.rotationX);
+        add(ret, "rotationY", frame.rotationY);
+        add(ret, "rotationZ", frame.rotationZ);
+        add(ret, "translationX", frame.translationX);
+        add(ret, "translationY", frame.translationY);
+        add(ret, "translationZ", frame.translationZ);
+        add(ret, "scaleX", frame.scaleX);
+        add(ret, "scaleY", frame.scaleY);
+        add(ret, "alpha", frame.alpha);
+        add(ret, "visibility", frame.visibility);
+        add(ret, "interpolatedPos", frame.interpolatedPos);
+        if (widget != null) {
+            for (ConstraintAnchor.Type side : ConstraintAnchor.Type.values()) {
+                serializeAnchor(ret, side);
+            }
+        }
+        if (sendPhoneOrientation) {
+            add(ret, "phone_orientation", phone_orientation);
+        }
+        if (sendPhoneOrientation) {
+            add(ret, "phone_orientation", phone_orientation);
+        }
+
+        if (frame.mCustom.size() != 0) {
+            ret.append("custom : {\n");
+            for (String s : frame.mCustom.keySet()) {
+                CustomVariable value = frame.mCustom.get(s);
+                ret.append(s);
+                ret.append(": ");
+                switch (value.getType()) {
+                    case TypedValues.Custom.TYPE_INT:
+                        ret.append(value.getIntegerValue());
+                        ret.append(",\n");
+                        break;
+                    case TypedValues.Custom.TYPE_FLOAT:
+                    case TypedValues.Custom.TYPE_DIMENSION:
+                        ret.append(value.getFloatValue());
+                        ret.append(",\n");
+                        break;
+                    case TypedValues.Custom.TYPE_COLOR:
+                        ret.append("'");
+                        ret.append(CustomVariable.colorString(value.getIntegerValue()));
+                        ret.append("',\n");
+                        break;
+                    case TypedValues.Custom.TYPE_STRING:
+                        ret.append("'");
+                        ret.append(value.getStringValue());
+                        ret.append("',\n");
+                        break;
+                    case TypedValues.Custom.TYPE_BOOLEAN:
+                        ret.append("'");
+                        ret.append(value.getBooleanValue());
+                        ret.append("',\n");
+                        break;
+                }
+            }
+            ret.append("}\n");
+        }
+
+        ret.append("}\n");
+        return ret;
+    }
+
+    private void serializeAnchor(StringBuilder ret, ConstraintAnchor.Type type) {
+        ConstraintAnchor anchor = widget.getAnchor(type);
+        if (anchor == null || anchor.mTarget == null) {
+            return;
+        }
+        ret.append("Anchor");
+        ret.append(type.name());
+        ret.append(": ['");
+        String str = anchor.mTarget.getOwner().stringId;
+        ret.append(str == null ? "#PARENT" : str);
+        ret.append("', '");
+        ret.append(anchor.mTarget.getType().name());
+        ret.append("', '");
+        ret.append(anchor.mMargin);
+        ret.append("'],\n");
+
+    }
+
+    private static void add(StringBuilder s, String title, int value) {
+        s.append(title);
+        s.append(": ");
+        s.append(value);
+        s.append(",\n");
+    }
+
+    private static void add(StringBuilder s, String title, float value) {
+        if (Float.isNaN(value)) {
+            return;
+        }
+        s.append(title);
+        s.append(": ");
+        s.append(value);
+        s.append(",\n");
+    }
+
+    /**
+     * For debugging only
+     */
+    void printCustomAttributes() {
+        StackTraceElement s = new Throwable().getStackTrace()[1];
+        String ss = ".(" + s.getFileName() + ":" + s.getLineNumber() + ") " + s.getMethodName();
+        ss += " " + (this.hashCode() % 1000);
+        if (widget != null) {
+            ss += "/" + (widget.hashCode() % 1000) + " ";
+        } else {
+            ss += "/NULL ";
+        }
+        if (mCustom != null) {
+            for (String key : mCustom.keySet()) {
+                System.out.println(ss + mCustom.get(key).toString());
+            }
+        }
+    }
+
+    /**
+     * For debugging only
+     */
+    void logv(String str) {
+        StackTraceElement s = new Throwable().getStackTrace()[1];
+        String ss = ".(" + s.getFileName() + ":" + s.getLineNumber() + ") " + s.getMethodName();
+        ss += " " + (this.hashCode() % 1000);
+        if (widget != null) {
+            ss += "/" + (widget.hashCode() % 1000);
+        } else {
+            ss += "/NULL";
+        }
+
+        System.out.println(ss + " " + str);
+    }
+
+    // @TODO: add description
+    public void setCustomValue(CustomAttribute valueAt, float[] mTempValues) {
+    }
+
+    void setMotionAttributes(TypedBundle motionProperties) {
+        mMotionProperties = motionProperties;
+    }
+
+    /**
+     * get the property bundle associated with MotionAttributes
+     *
+     * @return the property bundle associated with MotionAttributes or null
+     */
+    public TypedBundle getMotionProperties() {
+        return mMotionProperties;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/AlignHorizontallyReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/AlignHorizontallyReference.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+
+public class AlignHorizontallyReference extends HelperReference {
+
+    private float mBias = 0.5f;
+
+    public AlignHorizontallyReference(State state) {
+        super(state, State.Helper.ALIGN_VERTICALLY);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+            reference.clearHorizontal();
+            if (mStartToStart != null) {
+                reference.startToStart(mStartToStart);
+            } else if (mStartToEnd != null) {
+                reference.startToEnd(mStartToEnd);
+            } else {
+                reference.startToStart(State.PARENT);
+            }
+            if (mEndToStart != null) {
+                reference.endToStart(mEndToStart);
+            } else if (mEndToEnd != null) {
+                reference.endToEnd(mEndToEnd);
+            } else {
+                reference.endToEnd(State.PARENT);
+            }
+            if (mBias != 0.5f) {
+                reference.horizontalBias(mBias);
+            }
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/AlignVerticallyReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/AlignVerticallyReference.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+
+public class AlignVerticallyReference extends HelperReference {
+
+    private float mBias = 0.5f;
+
+    public AlignVerticallyReference(State state) {
+        super(state, State.Helper.ALIGN_VERTICALLY);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+            reference.clearVertical();
+            if (mTopToTop != null) {
+                reference.topToTop(mTopToTop);
+            } else if (mTopToBottom != null) {
+                reference.topToBottom(mTopToBottom);
+            } else {
+                reference.topToTop(State.PARENT);
+            }
+            if (mBottomToTop != null) {
+                reference.bottomToTop(mBottomToTop);
+            } else if (mBottomToBottom != null) {
+                reference.bottomToBottom(mBottomToBottom);
+            } else {
+                reference.bottomToBottom(State.PARENT);
+            }
+            if (mBias != 0.5f) {
+                reference.verticalBias(mBias);
+            }
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/BarrierReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/BarrierReference.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+public class BarrierReference extends HelperReference {
+
+    private State.Direction mDirection;
+    private int mMargin;
+    private Barrier mBarrierWidget;
+
+    public BarrierReference(State state) {
+        super(state, State.Helper.BARRIER);
+    }
+
+    public void setBarrierDirection(State.Direction barrierDirection) {
+        mDirection = barrierDirection;
+    }
+
+    @Override
+    public ConstraintReference margin(Object marginValue) {
+        margin(mHelperState.convertDimension(marginValue));
+        return this;
+    }
+
+    // @TODO: add description
+    @Override
+    public ConstraintReference margin(int value) {
+        mMargin = value;
+        return this;
+    }
+
+    @Override
+    public HelperWidget getHelperWidget() {
+        if (mBarrierWidget == null) {
+            mBarrierWidget = new Barrier();
+        }
+        return mBarrierWidget;
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        getHelperWidget();
+        int direction = Barrier.LEFT;
+        switch (mDirection) {
+            case LEFT:
+            case START: {
+                // TODO: handle RTL
+            }
+            break;
+            case RIGHT:
+            case END: {
+                // TODO: handle RTL
+                direction = Barrier.RIGHT;
+            }
+            break;
+            case TOP: {
+                direction = Barrier.TOP;
+            }
+            break;
+            case BOTTOM: {
+                direction = Barrier.BOTTOM;
+            }
+        }
+        mBarrierWidget.setBarrierType(direction);
+        mBarrierWidget.setMargin(mMargin);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
+import androidx.annotation.RestrictTo;
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.HashMap;
+
+/**
+ * {@link HelperReference} for Chains.
+ *
+ * Elements should be added with {@link ChainReference#addChainElement}
+ */
+public class ChainReference extends HelperReference {
+
+    protected float mBias = 0.5f;
+
+    /**
+     * @deprecated Unintended visibility, use {@link #getWeight(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapWeights = new HashMap<>();
+
+    /**
+     * @deprecated Unintended visibility, use {@link #getPreMargin(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapPreMargin = new HashMap<>();
+
+    /**
+     * @deprecated Unintended visibility, use {@link #getPostMargin(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapPostMargin = new HashMap<>();
+
+    private HashMap<String, Float> mMapPreGoneMargin;
+    private HashMap<String, Float> mMapPostGoneMargin;
+
+    protected State.@NonNull Chain mStyle = State.Chain.SPREAD;
+
+    public ChainReference(@NonNull State state, State.@NonNull Helper type) {
+        super(state, type);
+    }
+
+    public State.@NonNull Chain getStyle() {
+        return State.Chain.SPREAD;
+    }
+
+    /**
+     * Sets the {@link State.Chain style}.
+     *
+     * @param style Defines the way the chain will lay out its elements
+     * @return This same instance
+     */
+    public @NonNull ChainReference style(State.@NonNull Chain style) {
+        mStyle = style;
+        return this;
+    }
+
+    /**
+     * Adds the element by the given id to the Chain.
+     *
+     * The order in which the elements are added is important. It will represent the element's
+     * position in the Chain.
+     *
+     * @param id         Id of the element to add
+     * @param weight     Weight used to distribute remaining space to each element
+     * @param preMargin  Additional space in pixels between the added element and the previous one
+     *                   (if any)
+     * @param postMargin Additional space in pixels between the added element and the next one (if
+     *                   any)
+     */
+    public void addChainElement(@NonNull String id,
+            float weight,
+            float preMargin,
+            float postMargin) {
+        addChainElement(id, weight, preMargin, postMargin, 0, 0);
+    }
+
+    /**
+     * Adds the element by the given id to the Chain.
+     *
+     * The object's {@link Object#toString()} result will be used to map the given margins and
+     * weight to it, so it must stable and comparable.
+     *
+     * The order in which the elements are added is important. It will represent the element's
+     * position in the Chain.
+     *
+     * @param id             Id of the element to add
+     * @param weight         Weight used to distribute remaining space to each element
+     * @param preMargin      Additional space in pixels between the added element and the
+     *                       previous one
+     *                       (if any)
+     * @param postMargin     Additional space in pixels between the added element and the next
+     *                       one (if
+     *                       any)
+     * @param preGoneMargin  Additional space in pixels between the added element and the previous
+     *                       one (if any) when the previous element has Gone visibility
+     * @param postGoneMargin Additional space in pixels between the added element and the next
+     *                       one (if any) when the next element has Gone visibility
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public void addChainElement(@NonNull Object id,
+            float weight,
+            float preMargin,
+            float postMargin,
+            float preGoneMargin,
+            float postGoneMargin) {
+        super.add(id); // Add element id as is, it's expected to return the same given instance
+        String idString = id.toString();
+        if (!Float.isNaN(weight)) {
+            mMapWeights.put(idString, weight);
+        }
+        if (!Float.isNaN(preMargin)) {
+            mMapPreMargin.put(idString, preMargin);
+        }
+        if (!Float.isNaN(postMargin)) {
+            mMapPostMargin.put(idString, postMargin);
+        }
+        if (!Float.isNaN(preGoneMargin)) {
+            if (mMapPreGoneMargin == null) {
+                mMapPreGoneMargin = new HashMap<>();
+            }
+            mMapPreGoneMargin.put(idString, preGoneMargin);
+        }
+        if (!Float.isNaN(postGoneMargin)) {
+            if (mMapPostGoneMargin == null) {
+                mMapPostGoneMargin = new HashMap<>();
+            }
+            mMapPostGoneMargin.put(idString, postGoneMargin);
+        }
+    }
+
+    protected float getWeight(@NonNull String id) {
+        if (mMapWeights.containsKey(id)) {
+            return mMapWeights.get(id);
+        }
+        return UNKNOWN;
+    }
+
+    protected float getPostMargin(@NonNull String id) {
+        if (mMapPostMargin.containsKey(id)) {
+            return mMapPostMargin.get(id);
+        }
+        return 0;
+    }
+
+    protected float getPreMargin(@NonNull String id) {
+        if (mMapPreMargin.containsKey(id)) {
+            return mMapPreMargin.get(id);
+        }
+        return 0;
+    }
+
+    float getPostGoneMargin(@NonNull String id) {
+        if (mMapPostGoneMargin != null && mMapPostGoneMargin.containsKey(id)) {
+            return mMapPostGoneMargin.get(id);
+        }
+        return 0;
+    }
+
+    float getPreGoneMargin(@NonNull String id) {
+        if (mMapPreGoneMargin != null && mMapPreGoneMargin.containsKey(id)) {
+            return mMapPreGoneMargin.get(id);
+        }
+        return 0;
+    }
+
+    public float getBias() {
+        return mBias;
+    }
+
+    // @TODO: add description
+    @Override
+    public @NonNull ChainReference bias(float bias) {
+        mBias = bias;
+        return this;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/Facade.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/Facade.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+public interface Facade {
+    // @TODO: add description
+    ConstraintWidget getConstraintWidget();
+
+    // @TODO: add description
+    void apply();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+import static androidx.constraintlayout.core.widgets.Flow.HORIZONTAL_ALIGN_CENTER;
+import static androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_CENTER;
+import static androidx.constraintlayout.core.widgets.Flow.WRAP_NONE;
+
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.Flow;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import java.util.HashMap;
+
+/**
+ * The FlowReference class can be used to store the relevant properties of a Flow Helper
+ * when parsing the Flow Helper information in a JSON representation.
+ *
+ */
+public class FlowReference extends HelperReference {
+    protected Flow mFlow;
+
+    protected HashMap<String, Float> mMapWeights;
+    protected HashMap<String, Float> mMapPreMargin;
+    protected HashMap<String, Float> mMapPostMargin;
+
+    protected int mWrapMode = WRAP_NONE;
+
+    protected int mVerticalStyle = UNKNOWN;
+    protected int mFirstVerticalStyle = UNKNOWN;
+    protected int mLastVerticalStyle = UNKNOWN;
+    protected int mHorizontalStyle = UNKNOWN;
+    protected int mFirstHorizontalStyle = UNKNOWN;
+    protected int mLastHorizontalStyle = UNKNOWN;
+
+    protected int mVerticalAlign = HORIZONTAL_ALIGN_CENTER;
+    protected int mHorizontalAlign = VERTICAL_ALIGN_CENTER;
+
+    protected int mVerticalGap = 0;
+    protected int mHorizontalGap = 0;
+
+    protected int mPaddingLeft = 0;
+    protected int mPaddingRight = 0;
+    protected int mPaddingTop = 0;
+    protected int mPaddingBottom = 0;
+
+    protected int mMaxElementsWrap = UNKNOWN;
+
+    protected int mOrientation = HORIZONTAL;
+
+    protected float mFirstVerticalBias = 0.5f;
+    protected float mLastVerticalBias = 0.5f;
+    protected float mFirstHorizontalBias = 0.5f;
+    protected float mLastHorizontalBias = 0.5f;
+
+    public FlowReference(State state, State.Helper type) {
+        super(state, type);
+        if (type == State.Helper.VERTICAL_FLOW) {
+            mOrientation = VERTICAL;
+        }
+    }
+
+    /**
+     * Relate widgets to the FlowReference
+     *
+     * @param id id of a widget
+     * @param weight weight of a widget
+     * @param preMargin preMargin of a widget
+     * @param postMargin postMargin of a widget
+     */
+    public void addFlowElement(String id, float weight, float preMargin, float postMargin) {
+        super.add(id);
+        if (!Float.isNaN(weight)) {
+            if (mMapWeights == null) {
+                mMapWeights = new HashMap<>();
+            }
+            mMapWeights.put(id, weight);
+        }
+        if (!Float.isNaN(preMargin)) {
+            if (mMapPreMargin == null) {
+                mMapPreMargin = new HashMap<>();
+            }
+            mMapPreMargin.put(id, preMargin);
+        }
+        if (!Float.isNaN(postMargin)) {
+            if (mMapPostMargin == null) {
+                mMapPostMargin = new HashMap<>();
+            }
+            mMapPostMargin.put(id, postMargin);
+        }
+    }
+
+    /**
+     * Get the weight of a widget
+     *
+     * @param id id of a widget
+     * @return the weight of a widget
+     */
+    protected float getWeight(String id) {
+        if (mMapWeights == null) {
+            return UNKNOWN;
+        }
+        if (mMapWeights.containsKey(id)) {
+            return mMapWeights.get(id);
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Get the post margin of a widget
+     *
+     * @param id id id of a widget
+     * @return the post margin of a widget
+     */
+    protected float getPostMargin(String id) {
+        if (mMapPreMargin != null  && mMapPreMargin.containsKey(id)) {
+            return mMapPreMargin.get(id);
+        }
+        return 0;
+    }
+
+    /**
+     * Get the pre margin of a widget
+     *
+     * @param id id id of a widget
+     * @return the pre margin of a widget
+     */
+    protected float getPreMargin(String id) {
+        if (mMapPostMargin != null  && mMapPostMargin.containsKey(id)) {
+            return mMapPostMargin.get(id);
+        }
+        return 0;
+    }
+
+    /**
+     * Get wrap mode
+     *
+     * @return wrap mode
+     */
+    public int getWrapMode() {
+        return mWrapMode;
+    }
+
+    /**
+     * Set wrap Mode
+     *
+     * @param wrap wrap Mode
+     */
+    public void setWrapMode(int wrap) {
+        this.mWrapMode = wrap;
+    }
+
+    /**
+     * Get paddingLeft
+     *
+     * @return paddingLeft value
+     */
+    public int getPaddingLeft() {
+        return mPaddingLeft;
+    }
+
+    /**
+     * Set paddingLeft
+     *
+     * @param padding paddingLeft value
+     */
+    public void setPaddingLeft(int padding) {
+        this.mPaddingLeft = padding;
+    }
+
+    /**
+     * Get paddingTop
+     *
+     * @return paddingTop value
+     */
+    public int getPaddingTop() {
+        return mPaddingTop;
+    }
+
+    /**
+     * Set paddingTop
+     *
+     * @param padding paddingTop value
+     */
+    public void setPaddingTop(int padding) {
+        this.mPaddingTop = padding;
+    }
+
+    /**
+     * Get paddingRight
+     *
+     * @return paddingRight value
+     */
+    public int getPaddingRight() {
+        return mPaddingRight;
+    }
+
+    /**
+     * Set paddingRight
+     *
+     * @param padding paddingRight value
+     */
+    public void setPaddingRight(int padding) {
+        this.mPaddingRight = padding;
+    }
+
+    /**
+     * Get paddingBottom
+     *
+     * @return paddingBottom value
+     */
+    public int getPaddingBottom() {
+        return mPaddingBottom;
+    }
+
+    /**
+     * Set padding
+     *
+     * @param padding paddingBottom value
+     */
+    public void setPaddingBottom(int padding) {
+        this.mPaddingBottom = padding;
+    }
+
+    /**
+     * Get vertical style
+     *
+     * @return vertical style
+     */
+    public int getVerticalStyle() {
+        return mVerticalStyle;
+    }
+
+    /**
+     * set vertical style
+     *
+     * @param verticalStyle Flow vertical style
+     */
+    public void setVerticalStyle(int verticalStyle) {
+        this.mVerticalStyle = verticalStyle;
+    }
+
+    /**
+     * Get first vertical style
+     *
+     * @return first vertical style
+     */
+    public int getFirstVerticalStyle() {
+        return mFirstVerticalStyle;
+    }
+
+    /**
+     * Set first vertical style
+     *
+     * @param firstVerticalStyle Flow first vertical style
+     */
+    public void setFirstVerticalStyle(int firstVerticalStyle) {
+        this.mFirstVerticalStyle = firstVerticalStyle;
+    }
+
+    /**
+     * Get last vertical style
+     *
+     * @return last vertical style
+     */
+    public int getLastVerticalStyle() {
+        return mLastVerticalStyle;
+    }
+
+    /**
+     * Set last vertical style
+     *
+     * @param lastVerticalStyle Flow last vertical style
+     */
+    public void setLastVerticalStyle(int lastVerticalStyle) {
+        this.mLastVerticalStyle = lastVerticalStyle;
+    }
+
+    /**
+     * Get horizontal style
+     *
+     * @return horizontal style
+     */
+    public int getHorizontalStyle() {
+        return mHorizontalStyle;
+    }
+
+    /**
+     * Set horizontal style
+     *
+     * @param horizontalStyle Flow horizontal style
+     */
+    public void setHorizontalStyle(int horizontalStyle) {
+        this.mHorizontalStyle = horizontalStyle;
+    }
+
+    /**
+     * Get first horizontal style
+     *
+     * @return first horizontal style
+     */
+    public int getFirstHorizontalStyle() {
+        return mFirstHorizontalStyle;
+    }
+
+    /**
+     * Set first horizontal style
+     *
+     * @param firstHorizontalStyle Flow first horizontal style
+     */
+    public void setFirstHorizontalStyle(int firstHorizontalStyle) {
+        this.mFirstHorizontalStyle = firstHorizontalStyle;
+    }
+
+    /**
+     * Get last horizontal style
+     *
+     * @return last horizontal style
+     */
+    public int getLastHorizontalStyle() {
+        return mLastHorizontalStyle;
+    }
+
+    /**
+     * Set last horizontal style
+     *
+     * @param lastHorizontalStyle Flow last horizontal style
+     */
+    public void setLastHorizontalStyle(int lastHorizontalStyle) {
+        this.mLastHorizontalStyle = lastHorizontalStyle;
+    }
+
+    /**
+     * Get vertical align
+     * @return vertical align value
+     */
+    public int getVerticalAlign() {
+        return mVerticalAlign;
+    }
+
+    /**
+     * Set vertical align
+     *
+     * @param verticalAlign vertical align value
+     */
+    public void setVerticalAlign(int verticalAlign) {
+        this.mVerticalAlign = verticalAlign;
+    }
+
+    /**
+     * Get horizontal align
+     *
+     * @return horizontal align value
+     */
+    public int getHorizontalAlign() {
+        return mHorizontalAlign;
+    }
+
+    /**
+     * Set horizontal align
+     *
+     * @param horizontalAlign horizontal align value
+     */
+    public void setHorizontalAlign(int horizontalAlign) {
+        this.mHorizontalAlign = horizontalAlign;
+    }
+
+    /**
+     * Get vertical gap
+     *
+     * @return vertical gap value
+     */
+    public int getVerticalGap() {
+        return mVerticalGap;
+    }
+
+    /**
+     * Set vertical gap
+     *
+     * @param verticalGap vertical gap value
+     */
+    public void setVerticalGap(int verticalGap) {
+        this.mVerticalGap = verticalGap;
+    }
+
+    /**
+     * Get horizontal gap
+     *
+     * @return horizontal gap value
+     */
+    public int getHorizontalGap() {
+        return mHorizontalGap;
+    }
+
+    /**
+     * Set horizontal gap
+     *
+     * @param horizontalGap horizontal gap value
+     */
+    public void setHorizontalGap(int horizontalGap) {
+        mHorizontalGap = horizontalGap;
+    }
+
+    /**
+     * Get max element wrap
+     *
+     * @return max element wrap value
+     */
+    public int getMaxElementsWrap() {
+        return mMaxElementsWrap;
+    }
+
+    /**
+     * Set max element wrap
+     *
+     * @param maxElementsWrap max element wrap value
+     */
+    public void setMaxElementsWrap(int maxElementsWrap) {
+        this.mMaxElementsWrap = maxElementsWrap;
+    }
+
+    /**
+     * Get the orientation of a Flow
+     *
+     * @return orientation value
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * Set the orientation of a Flow
+     *
+     * @param mOrientation orientation value
+     */
+    public void setOrientation(int mOrientation) {
+        this.mOrientation = mOrientation;
+    }
+
+    /**
+     * Get vertical bias
+     *
+     * @return vertical bias value
+     */
+    public float getVerticalBias() {
+        return mVerticalBias;
+    }
+
+
+    /**
+     * Get first vertical bias
+     *
+     * @return first vertical bias value
+     */
+    public float getFirstVerticalBias() {
+        return mFirstVerticalBias;
+    }
+
+    /**
+     * Set first vertical bias
+     *
+     * @param firstVerticalBias first vertical bias value
+     */
+    public void setFirstVerticalBias(float firstVerticalBias) {
+        this.mFirstVerticalBias = firstVerticalBias;
+    }
+
+    /**
+     * Get last vertical bias
+     *
+     * @return last vertical bias
+     */
+    public float getLastVerticalBias() {
+        return mLastVerticalBias;
+    }
+
+    /**
+     * Set last vertical bias
+     *
+     * @param lastVerticalBias last vertical bias value
+     */
+    public void setLastVerticalBias(float lastVerticalBias) {
+        this.mLastVerticalBias = lastVerticalBias;
+    }
+
+    /**
+     * Get horizontal bias
+     * @return horizontal bias value
+     */
+    public float getHorizontalBias() {
+        return mHorizontalBias;
+    }
+
+    /**
+     * Get first horizontal bias
+     *
+     * @return first horizontal bias
+     */
+    public float getFirstHorizontalBias() {
+        return mFirstHorizontalBias;
+    }
+
+    /**
+     * Set first horizontal bias
+     *
+     * @param firstHorizontalBias first horizontal bias value
+     */
+    public void setFirstHorizontalBias(float firstHorizontalBias) {
+        this.mFirstHorizontalBias = firstHorizontalBias;
+    }
+
+    /**
+     * Get last horizontal bias
+     *
+     * @return last horizontal bias value
+     */
+    public float getLastHorizontalBias() {
+        return mLastHorizontalBias;
+    }
+
+    /**
+     * Set last horizontal bias
+     *
+     * @param lastHorizontalBias last horizontal bias value
+     */
+    public void setLastHorizontalBias(float lastHorizontalBias) {
+        this.mLastHorizontalBias = lastHorizontalBias;
+    }
+
+    @Override
+    public HelperWidget getHelperWidget() {
+        if (mFlow == null) {
+            mFlow = new Flow();
+        }
+        return mFlow;
+    }
+
+    @Override
+    public void setHelperWidget(HelperWidget widget) {
+        if (widget instanceof Flow) {
+            mFlow = (Flow) widget;
+        } else {
+            mFlow = null;
+        }
+    }
+
+    @Override
+    public void apply() {
+        getHelperWidget();
+        this.setConstraintWidget(mFlow);
+        mFlow.setOrientation(mOrientation);
+        mFlow.setWrapMode(mWrapMode);
+
+        if (mMaxElementsWrap != UNKNOWN) {
+            mFlow.setMaxElementsWrap(mMaxElementsWrap);
+        }
+
+        // Padding
+        if (mPaddingLeft != 0) {
+            mFlow.setPaddingLeft(mPaddingLeft);
+        }
+        if (mPaddingTop != 0) {
+            mFlow.setPaddingTop(mPaddingTop);
+        }
+        if (mPaddingRight != 0) {
+            mFlow.setPaddingRight(mPaddingRight);
+        }
+        if (mPaddingBottom != 0) {
+            mFlow.setPaddingBottom(mPaddingBottom);
+        }
+
+        // Gap
+        if (mHorizontalGap != 0) {
+            mFlow.setHorizontalGap(mHorizontalGap);
+        }
+        if (mVerticalGap != 0) {
+            mFlow.setVerticalGap(mVerticalGap);
+        }
+
+        // Bias
+        if (mHorizontalBias != 0.5f) {
+            mFlow.setHorizontalBias(mHorizontalBias);
+        }
+        if (mFirstHorizontalBias != 0.5f) {
+            mFlow.setFirstHorizontalBias(mFirstHorizontalBias);
+        }
+        if (mLastHorizontalBias != 0.5f) {
+            mFlow.setLastHorizontalBias(mLastHorizontalBias);
+        }
+        if (mVerticalBias != 0.5f) {
+            mFlow.setVerticalBias(mVerticalBias);
+        }
+        if (mFirstVerticalBias != 0.5f) {
+            mFlow.setFirstVerticalBias(mFirstVerticalBias);
+        }
+        if (mLastVerticalBias != 0.5f) {
+            mFlow.setLastVerticalBias(mLastVerticalBias);
+        }
+
+        // Align
+        if (mHorizontalAlign != HORIZONTAL_ALIGN_CENTER) {
+            mFlow.setHorizontalAlign(mHorizontalAlign);
+        }
+        if (mVerticalAlign != VERTICAL_ALIGN_CENTER) {
+            mFlow.setVerticalAlign(mVerticalAlign);
+        }
+
+        // Style
+        if (mVerticalStyle != UNKNOWN) {
+            mFlow.setVerticalStyle(mVerticalStyle);
+        }
+        if (mFirstVerticalStyle != UNKNOWN) {
+            mFlow.setFirstVerticalStyle(mFirstVerticalStyle);
+        }
+        if (mLastVerticalStyle != UNKNOWN) {
+            mFlow.setLastVerticalStyle(mLastVerticalStyle);
+        }
+        if (mHorizontalStyle != UNKNOWN) {
+            mFlow.setHorizontalStyle(mHorizontalStyle);
+        }
+        if (mFirstHorizontalStyle != UNKNOWN) {
+            mFlow.setFirstHorizontalStyle(mFirstHorizontalStyle);
+        }
+        if (mLastHorizontalStyle!= UNKNOWN) {
+            mFlow.setLastHorizontalStyle(mLastHorizontalStyle);
+        }
+
+        // General attributes of a widget
+        applyBase();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.utils.GridCore;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A HelperReference of a Grid Helper that helps enable Grid in Compose
+ */
+public class GridReference extends HelperReference {
+
+    private static final String SPANS_RESPECT_WIDGET_ORDER_STRING = "spansrespectwidgetorder";
+    private static final String SUB_GRID_BY_COL_ROW_STRING = "subgridbycolrow";
+
+    public GridReference(@NonNull State state, State.@NonNull Helper type) {
+        super(state, type);
+        if (type == State.Helper.ROW) {
+            this.mRowsSet = 1;
+        } else if (type == State.Helper.COLUMN) {
+            this.mColumnsSet = 1;
+        }
+    }
+
+    /**
+     * The Grid Object
+     */
+    private GridCore mGrid;
+
+    /**
+     * padding start
+     */
+    private int mPaddingStart = 0;
+
+    /**
+     * padding end
+     */
+    private int mPaddingEnd = 0;
+
+    /**
+     * padding top
+     */
+    private int mPaddingTop = 0;
+
+    /**
+     * padding bottom
+     */
+    private int mPaddingBottom = 0;
+
+    /**
+     * The orientation of the widgets arrangement horizontally or vertically
+     */
+    private int mOrientation;
+
+    /**
+     * Number of rows of the Grid
+     */
+    private int mRowsSet;
+
+    /**
+     * Number of columns of the Grid
+     */
+    private int mColumnsSet;
+
+    /**
+     * The horizontal gaps between widgets
+     */
+    private float mHorizontalGaps;
+
+    /**
+     * The vertical gaps between widgets
+     */
+    private float mVerticalGaps;
+
+    /**
+     * The weight of each widget in a row
+     */
+    private String mRowWeights;
+
+    /**
+     * The weight of each widget in a column
+     */
+    private String mColumnWeights;
+
+    /**
+     * Specify the spanned areas of widgets
+     */
+    private String mSpans;
+
+    /**
+     * Specify the positions to be skipped in the Grid
+     */
+    private String mSkips;
+
+    /**
+     * An int value containing flag information.
+     */
+    private int mFlags;
+
+    /**
+     * get padding left
+     * @return padding left
+     */
+    public int getPaddingStart() {
+        return mPaddingStart;
+    }
+
+    /**
+     * set padding left
+     * @param paddingStart padding left to be set
+     */
+    public void setPaddingStart(int paddingStart) {
+        mPaddingStart = paddingStart;
+    }
+
+    /**
+     * get padding right
+     * @return padding right
+     */
+    public int getPaddingEnd() {
+        return mPaddingEnd;
+    }
+
+    /**
+     * set padding right
+     * @param paddingEnd padding right to be set
+     */
+    public void setPaddingEnd(int paddingEnd) {
+        mPaddingEnd = paddingEnd;
+    }
+
+    /**
+     * get padding top
+     * @return padding top
+     */
+    public int getPaddingTop() {
+        return mPaddingTop;
+    }
+
+    /**
+     * set padding top
+     * @param paddingTop padding top to be set
+     */
+    public void setPaddingTop(int paddingTop) {
+        mPaddingTop = paddingTop;
+    }
+
+    /**
+     * get padding bottom
+     * @return padding bottom
+     */
+    public int getPaddingBottom() {
+        return mPaddingBottom;
+    }
+
+    /**
+     * set padding bottom
+     * @param paddingBottom padding bottom to be set
+     */
+    public void setPaddingBottom(int paddingBottom) {
+        mPaddingBottom = paddingBottom;
+    }
+
+    /**
+     * Get all the flags of a Grid
+     * @return an int value containing flag information
+     */
+    public int getFlags() {
+        return mFlags;
+    }
+
+    /**
+     * Set flags of a Grid
+     * @param flags an int value containing flag information
+     */
+    public void setFlags(int flags) {
+        mFlags = flags;
+    }
+
+    /**
+     * Set flags of a Grid
+     * @param flags a String containing all the flags
+     */
+    public void setFlags(@NonNull String flags) {
+        if (flags.isEmpty()) {
+            return;
+        }
+
+        String[] strArr = flags.split("\\|");
+        mFlags = 0;
+        for (String str: strArr) {
+            switch (str.toLowerCase()) {
+                case SUB_GRID_BY_COL_ROW_STRING:
+                    mFlags |= 1;
+                    break;
+                case SPANS_RESPECT_WIDGET_ORDER_STRING:
+                    mFlags |= 2;
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Get the number of rows
+     * @return the number of rows
+     */
+    public int getRowsSet() {
+        return mRowsSet;
+    }
+
+    /**
+     * Set the number of rows
+     * @param rowsSet the number of rows
+     */
+    public void setRowsSet(int rowsSet) {
+        if (super.getType() == State.Helper.COLUMN) {
+            return;
+        }
+        mRowsSet = rowsSet;
+    }
+
+    /**
+     * Get the number of columns
+     * @return the number of columns
+     */
+    public int getColumnsSet() {
+        return mColumnsSet;
+    }
+
+    /**
+     * Set the number of columns
+     * @param columnsSet the number of columns
+     */
+    public void setColumnsSet(int columnsSet) {
+        if (super.getType() == State.Helper.ROW) {
+            return;
+        }
+        mColumnsSet = columnsSet;
+    }
+
+    /**
+     * Get the horizontal gaps
+     * @return the horizontal gaps
+     */
+    public float getHorizontalGaps() {
+        return mHorizontalGaps;
+    }
+
+    /**
+     * Set the horizontal gaps
+     * @param horizontalGaps the horizontal gaps
+     */
+    public void setHorizontalGaps(float horizontalGaps) {
+        mHorizontalGaps = horizontalGaps;
+    }
+
+    /**
+     * Get the vertical gaps
+     * @return the vertical gaps
+     */
+    public float getVerticalGaps() {
+        return mVerticalGaps;
+    }
+
+    /**
+     * Set the vertical gaps
+     * @param verticalGaps  the vertical gaps
+     */
+    public void setVerticalGaps(float verticalGaps) {
+        mVerticalGaps = verticalGaps;
+    }
+
+    /**
+     * Get the row weights
+     * @return the row weights
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getRowWeights() {
+        return mRowWeights;
+    }
+
+    /**
+     * Set the row weights
+     * @param rowWeights the row weights
+     */
+    public void setRowWeights(@NonNull String rowWeights) {
+        mRowWeights = rowWeights;
+    }
+
+    /**
+     * Get the column weights
+     * @return the column weights
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getColumnWeights() {
+        return mColumnWeights;
+    }
+
+    /**
+     * Set the column weights
+     * @param columnWeights the column weights
+     */
+    public void setColumnWeights(@NonNull String columnWeights) {
+        mColumnWeights = columnWeights;
+    }
+
+    /**
+     * Get the spans
+     * @return the spans
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getSpans() {
+        return mSpans;
+    }
+
+    /**
+     * Set the spans
+     * @param spans the spans
+     */
+    public void setSpans(@NonNull String spans) {
+        mSpans = spans;
+    }
+
+    /**
+     * Get the skips
+     * @return the skips
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getSkips() {
+        return mSkips;
+    }
+
+    /**
+     * Set the skips
+     * @param skips the skips
+     */
+    public void setSkips(@NonNull String skips) {
+        mSkips = skips;
+    }
+
+    /**
+     * Get the helper widget (Grid)
+     * @return the helper widget (Grid)
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    @Override
+    public @NonNull HelperWidget getHelperWidget() {
+        if (mGrid == null) {
+            mGrid = new GridCore();
+        }
+        return mGrid;
+    }
+
+    /**
+     * Set the helper widget (Grid)
+     * @param widget the helper widget (Grid)
+     */
+    @Override
+    public void setHelperWidget(@Nullable HelperWidget widget) {
+        if (widget instanceof GridCore) {
+            mGrid = (GridCore) widget;
+        } else {
+            mGrid = null;
+        }
+    }
+
+    /**
+     * Get the Orientation
+     * @return the Orientation
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * Set the Orientation
+     * @param orientation the Orientation
+     */
+    public void setOrientation(int orientation) {
+        mOrientation = orientation;
+
+    }
+
+    /**
+     * Apply all the attributes to the helper widget (Grid)
+     */
+    @Override
+    public void apply() {
+        getHelperWidget();
+
+        mGrid.setOrientation(mOrientation);
+
+        if (mRowsSet != 0) {
+            mGrid.setRows(mRowsSet);
+        }
+
+        if (mColumnsSet != 0) {
+            mGrid.setColumns(mColumnsSet);
+        }
+
+        if (mHorizontalGaps != 0) {
+            mGrid.setHorizontalGaps(mHorizontalGaps);
+        }
+
+        if (mVerticalGaps != 0) {
+            mGrid.setVerticalGaps(mVerticalGaps);
+        }
+
+        if (mRowWeights != null && !mRowWeights.isEmpty()) {
+            mGrid.setRowWeights(mRowWeights);
+        }
+
+        if (mColumnWeights != null && !mColumnWeights.isEmpty()) {
+            mGrid.setColumnWeights(mColumnWeights);
+        }
+
+        if (mSpans != null && !mSpans.isEmpty()) {
+            mGrid.setSpans(mSpans);
+        }
+
+        if (mSkips != null && !mSkips.isEmpty()) {
+            mGrid.setSkips(mSkips);
+        }
+
+        mGrid.setFlags(mFlags);
+
+        mGrid.setPaddingStart(mPaddingStart);
+        mGrid.setPaddingEnd(mPaddingEnd);
+        mGrid.setPaddingTop(mPaddingTop);
+        mGrid.setPaddingBottom(mPaddingBottom);
+
+        // General attributes of a widget
+        applyBase();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/GuidelineReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/GuidelineReference.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.Reference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.Guideline;
+
+public class GuidelineReference implements Facade, Reference {
+
+    final State mState;
+    private int mOrientation;
+    private Guideline mGuidelineWidget;
+    private int mStart = -1;
+    private int mEnd = -1;
+    private float mPercent = 0;
+
+    private Object mKey;
+
+    @Override
+    public void setKey(Object key) {
+        this.mKey = key;
+    }
+
+    @Override
+    public Object getKey() {
+        return mKey;
+    }
+
+    public GuidelineReference(State state) {
+        mState = state;
+    }
+
+    // @TODO: add description
+    public GuidelineReference start(Object margin) {
+        mStart = mState.convertDimension(margin);
+        mEnd = -1;
+        mPercent = 0;
+        return this;
+    }
+
+    // @TODO: add description
+    public GuidelineReference end(Object margin) {
+        mStart = -1;
+        mEnd = mState.convertDimension(margin);
+        mPercent = 0;
+        return this;
+    }
+
+    // @TODO: add description
+    public GuidelineReference percent(float percent) {
+        mStart = -1;
+        mEnd = -1;
+        mPercent = percent;
+        return this;
+    }
+
+    public void setOrientation(int orientation) {
+        mOrientation = orientation;
+    }
+
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        mGuidelineWidget.setOrientation(mOrientation);
+        if (mStart != -1) {
+            mGuidelineWidget.setGuideBegin(mStart);
+        } else if (mEnd != -1) {
+            mGuidelineWidget.setGuideEnd(mEnd);
+        } else {
+            mGuidelineWidget.setGuidePercent(mPercent);
+        }
+    }
+
+    @Override
+    public Facade getFacade() {
+        return null;
+    }
+
+    @Override
+    public ConstraintWidget getConstraintWidget() {
+        if (mGuidelineWidget == null) {
+            mGuidelineWidget = new Guideline();
+        }
+        return mGuidelineWidget;
+    }
+
+    @Override
+    public void setConstraintWidget(ConstraintWidget widget) {
+        if (widget instanceof Guideline) {
+            mGuidelineWidget = (Guideline) widget;
+        } else {
+            mGuidelineWidget = null;
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+public class HorizontalChainReference extends ChainReference {
+
+    public HorizontalChainReference(State state) {
+        super(state, State.Helper.HORIZONTAL_CHAIN);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        ConstraintReference first = null;
+        ConstraintReference previous = null;
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+            reference.clearHorizontal();
+        }
+
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+
+            if (first == null) {
+                first = reference;
+                if (mStartToStart != null) {
+                    first.startToStart(mStartToStart)
+                            .margin(mMarginStart)
+                            .marginGone(mMarginStartGone);
+                } else if (mStartToEnd != null) {
+                    first.startToEnd(mStartToEnd).margin(mMarginStart).marginGone(mMarginStartGone);
+                } else if (mLeftToLeft != null) {
+                    // TODO: Hack until we support RTL properly
+                    first.startToStart(mLeftToLeft).margin(mMarginLeft).marginGone(mMarginLeftGone);
+                } else if (mLeftToRight != null) {
+                    // TODO: Hack until we support RTL properly
+                    first.startToEnd(mLeftToRight).margin(mMarginLeft).marginGone(mMarginLeftGone);
+                } else {
+                    // No constraint declared, default to Parent.
+                    String refKey = reference.getKey().toString();
+                    first.startToStart(State.PARENT).margin(getPreMargin(refKey)).marginGone(
+                            getPreGoneMargin(refKey));
+                }
+            }
+            if (previous != null) {
+                String preKey = previous.getKey().toString();
+                String refKey = reference.getKey().toString();
+                previous.endToStart(reference.getKey()).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+                reference.startToEnd(previous.getKey()).margin(getPreMargin(refKey)).marginGone(
+                        getPreGoneMargin(refKey));
+            }
+            float weight = getWeight(key.toString());
+            if (weight != UNKNOWN) {
+                reference.setHorizontalChainWeight(weight);
+            }
+            previous = reference;
+        }
+
+        if (previous != null) {
+            if (mEndToStart != null) {
+                previous.endToStart(mEndToStart).margin(mMarginEnd).marginGone(mMarginEndGone);
+            } else if (mEndToEnd != null) {
+                previous.endToEnd(mEndToEnd).margin(mMarginEnd).marginGone(mMarginEndGone);
+            } else if (mRightToLeft != null) {
+                // TODO: Hack until we support RTL properly
+                previous.endToStart(mRightToLeft).margin(mMarginRight).marginGone(mMarginRightGone);
+            } else if (mRightToRight != null) {
+                // TODO: Hack until we support RTL properly
+                previous.endToEnd(mRightToRight).margin(mMarginRight).marginGone(mMarginRightGone);
+            } else {
+                // No constraint declared, default to Parent.
+                String preKey = previous.getKey().toString();
+                previous.endToEnd(State.PARENT).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+            }
+        }
+
+        if (first == null) {
+            return;
+        }
+
+        if (mBias != 0.5f) {
+            first.horizontalBias(mBias);
+        }
+
+        switch (mStyle) {
+            case SPREAD: {
+                first.setHorizontalChainStyle(ConstraintWidget.CHAIN_SPREAD);
+            }
+            break;
+            case SPREAD_INSIDE: {
+                first.setHorizontalChainStyle(ConstraintWidget.CHAIN_SPREAD_INSIDE);
+            }
+            break;
+            case PACKED: {
+                first.setHorizontalChainStyle(ConstraintWidget.CHAIN_PACKED);
+            }
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+public class VerticalChainReference extends ChainReference {
+
+    public VerticalChainReference(State state) {
+        super(state, State.Helper.VERTICAL_CHAIN);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        ConstraintReference first = null;
+        ConstraintReference previous = null;
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+            reference.clearVertical();
+        }
+
+        for (Object key : mReferences) {
+            ConstraintReference reference = mHelperState.constraints(key);
+            if (first == null) {
+                first = reference;
+                if (mTopToTop != null) {
+                    first.topToTop(mTopToTop).margin(mMarginTop).marginGone(mMarginTopGone);
+                } else if (mTopToBottom != null) {
+                    first.topToBottom(mTopToBottom).margin(mMarginTop).marginGone(mMarginTopGone);
+                } else {
+                    // No constraint declared, default to Parent.
+                    String refKey = reference.getKey().toString();
+                    first.topToTop(State.PARENT).margin(getPreMargin(refKey)).marginGone(
+                            getPreGoneMargin(refKey));
+                }
+            }
+            if (previous != null) {
+                String preKey = previous.getKey().toString();
+                String refKey = reference.getKey().toString();
+                previous.bottomToTop(reference.getKey()).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+                reference.topToBottom(previous.getKey()).margin(getPreMargin(refKey)).marginGone(
+                        getPreGoneMargin(refKey));
+            }
+            float weight = getWeight(key.toString());
+            if (weight != UNKNOWN) {
+                reference.setVerticalChainWeight(weight);
+            }
+            previous = reference;
+        }
+
+        if (previous != null) {
+            if (mBottomToTop != null) {
+                previous.bottomToTop(mBottomToTop)
+                        .margin(mMarginBottom)
+                        .marginGone(mMarginBottomGone);
+            } else if (mBottomToBottom != null) {
+                previous.bottomToBottom(mBottomToBottom)
+                        .margin(mMarginBottom)
+                        .marginGone(mMarginBottomGone);
+            } else {
+                // No constraint declared, default to Parent.
+                String preKey = previous.getKey().toString();
+                previous.bottomToBottom(State.PARENT).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+            }
+        }
+
+        if (first == null) {
+            return;
+        }
+
+        if (mBias != 0.5f) {
+            first.verticalBias(mBias);
+        }
+
+        switch (mStyle) {
+            case SPREAD: {
+                first.setVerticalChainStyle(ConstraintWidget.CHAIN_SPREAD);
+            }
+            break;
+            case SPREAD_INSIDE: {
+                first.setVerticalChainStyle(ConstraintWidget.CHAIN_SPREAD_INSIDE);
+            }
+            break;
+            case PACKED: {
+                first.setVerticalChainStyle(ConstraintWidget.CHAIN_PACKED);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/utils/GridCore.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/utils/GridCore.java
@@ -1,0 +1,1016 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.utils;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.VirtualLayout;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The Grid Helper in the Core library that helps to enable Grid in Compose
+ */
+public class GridCore extends VirtualLayout {
+    // TODO: Handle padding from VirtualLayout. It should represent the padding applied around the
+    //  Grid itself. Usually decreasing its size.
+
+    public static final int HORIZONTAL = 0;
+    public static final int VERTICAL = 1;
+
+    // Flags using incremental bit positions
+    public static final int SUB_GRID_BY_COL_ROW = 1;
+    public static final int SPANS_RESPECT_WIDGET_ORDER = 2;
+
+    private static final int DEFAULT_SIZE = 3; // default rows and columns.
+    private static final int MAX_ROWS = 50; // maximum number of rows can be specified.
+    private static final int MAX_COLUMNS = 50; // maximum number of columns can be specified.
+
+    /**
+     * Container for all the ConstraintWidgets
+     */
+    ConstraintWidgetContainer mContainer;
+
+    /**
+     * boxWidgets were created as anchor points for arranging the associated widgets
+     */
+    private ConstraintWidget[] mBoxWidgets;
+
+    /**
+     * Check if skips/spans of a Row or a Columns is handled
+     */
+    private boolean mExtraSpaceHandled = false;
+
+    /**
+     * number of rows of the grid
+     */
+    private int mRows;
+
+    /**
+     * number of rows set by the JSON or API
+     */
+    private int mRowsSet;
+
+    /**
+     * number of columns of the grid
+     */
+    private int mColumns;
+
+    /**
+     * number of columns set by the XML or API
+     */
+    private int mColumnsSet;
+
+    /**
+     * Horizontal gaps in Dp
+     */
+    private float mHorizontalGaps;
+
+    /**
+     * Vertical gaps in Dp
+     */
+    private float mVerticalGaps;
+
+    /**
+     * string format of the row weight
+     */
+    private String mRowWeights;
+
+    /**
+     * string format of the column weight
+     */
+    private String mColumnWeights;
+
+    /**
+     * string format of the input Spans
+     */
+    private String mSpans;
+
+    /**
+     * string format of the input Skips
+     */
+    private String mSkips;
+
+    /**
+     * orientation of the widget arrangement - vertical or horizontal
+     */
+    private int mOrientation;
+
+    /**
+     * Indicates what is the next available position to place a widget
+     */
+    private int mNextAvailableIndex = 0;
+
+    /**
+     * A boolean matrix that tracks the positions that are occupied by skips and spans
+     * true: available position
+     * false: non-available position
+     */
+    private boolean[][] mPositionMatrix;
+
+    /**
+     * Store the widget ids of handled spans
+     */
+    Set<String> mSpanIds = new HashSet<>();
+
+    /**
+     * A int matrix that contains the positions where a widget would constraint to at each direction
+     * Each row contains 4 values that indicate the position to constraint of a widget.
+     * Example row: [left, top, right, bottom]
+     */
+    private int[][] mConstraintMatrix;
+
+    /**
+     * An int value containing flag information.
+     */
+    private int mFlags;
+
+    /**
+     * A int matrix to store the span related information
+     */
+    private int[][] mSpanMatrix;
+
+    /**
+     * Index specify the next span to be handled.
+     */
+    private int mSpanIndex = 0;
+
+    public GridCore() {
+        updateActualRowsAndColumns();
+        initMatrices();
+    }
+
+    public GridCore(int rows, int columns) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+        initMatrices();
+    }
+
+    /**
+     * get the parent ConstraintWidgetContainer
+     *
+     * @return the parent ConstraintWidgetContainer
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable ConstraintWidgetContainer getContainer() {
+        return mContainer;
+    }
+
+    /**
+     * Set the parent ConstraintWidgetContainer
+     * @param container the parent ConstraintWidgetContainer
+     */
+    public void setContainer(@NonNull ConstraintWidgetContainer container) {
+        mContainer = container;
+    }
+
+    /**
+     * set new spans value
+     *
+     * @param spans new spans value
+     */
+    public void setSpans(@NonNull CharSequence spans) {
+        if (mSpans != null && mSpans.equals(spans.toString())) {
+            return;
+        }
+        mExtraSpaceHandled = false;
+        mSpans = spans.toString();
+    }
+
+    /**
+     * set new skips value
+     *
+     * @param skips new spans value
+     */
+    public void setSkips(@NonNull String skips) {
+        if (mSkips != null && mSkips.equals(skips)) {
+            return;
+        }
+        mExtraSpaceHandled = false;
+        mSkips = skips;
+
+    }
+
+    /**
+     * get the value of horizontalGaps
+     *
+     * @return the value of horizontalGaps
+     */
+    public float getHorizontalGaps() {
+        return mHorizontalGaps;
+    }
+
+    /**
+     * set new horizontalGaps value and also invoke invalidate
+     *
+     * @param horizontalGaps new horizontalGaps value
+     */
+    public void setHorizontalGaps(float horizontalGaps) {
+        if (horizontalGaps < 0) {
+            return;
+        }
+
+        if (mHorizontalGaps == horizontalGaps) {
+            return;
+        }
+
+        mHorizontalGaps = horizontalGaps;
+    }
+
+    /**
+     * get the value of verticalGaps
+     *
+     * @return the value of verticalGaps
+     */
+    public float getVerticalGaps() {
+        return mVerticalGaps;
+    }
+
+    /**
+     * set new verticalGaps value and also invoke invalidate
+     *
+     * @param verticalGaps new verticalGaps value
+     */
+    public void setVerticalGaps(float verticalGaps) {
+        if (verticalGaps < 0) {
+            return;
+        }
+
+        if (mVerticalGaps == verticalGaps) {
+            return;
+        }
+
+        mVerticalGaps = verticalGaps;
+    }
+
+    /**
+     * get the string value of rowWeights
+     *
+     * @return the string value of rowWeights
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getRowWeights() {
+        return mRowWeights;
+    }
+
+    /**
+     * set new rowWeights value and also invoke invalidate
+     *
+     * @param rowWeights new rowWeights value
+     */
+    public void setRowWeights(@NonNull String rowWeights) {
+        if (mRowWeights != null && mRowWeights.equals(rowWeights)) {
+            return;
+        }
+
+        mRowWeights = rowWeights;
+    }
+
+    /**
+     * get the string value of columnWeights
+     *
+     * @return the string value of columnWeights
+     */
+    @SuppressWarnings("GetterSetterNullability")
+    public @Nullable String getColumnWeights() {
+        return mColumnWeights;
+    }
+
+    /**
+     * set new columnWeights value and also invoke invalidate
+     *
+     * @param columnWeights new columnWeights value
+     */
+    public void setColumnWeights(@NonNull String columnWeights) {
+        if (mColumnWeights != null && mColumnWeights.equals(columnWeights)) {
+            return;
+        }
+
+        mColumnWeights = columnWeights;
+    }
+
+    /**
+     * get the value of orientation
+     *
+     * @return the value of orientation
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * set new orientation value
+     *
+     * @param orientation new orientation value
+     */
+    public void setOrientation(int orientation) {
+        if (!(orientation == HORIZONTAL || orientation == VERTICAL)) {
+            return;
+        }
+
+        if (mOrientation == orientation) {
+            return;
+        }
+
+        mOrientation = orientation;
+    }
+
+    /**
+     * set new rows value
+     *
+     * @param rows new rows value
+     */
+    public void setRows(int rows) {
+        if (rows > MAX_ROWS) {
+            return;
+        }
+
+        if (mRowsSet == rows) {
+            return;
+        }
+
+        mRowsSet = rows;
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    /**
+     * set new columns value
+     *
+     * @param columns new rows value
+     */
+    public void setColumns(int columns) {
+        if (columns > MAX_COLUMNS) {
+            return;
+        }
+
+        if (mColumnsSet == columns) {
+            return;
+        }
+
+        mColumnsSet = columns;
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    /**
+     * Get all the flags of a Grid
+     * @return an int value containing flag information
+     */
+    public int getFlags() {
+        return mFlags;
+    }
+
+    /**
+     * Set flags of a Grid
+     * @param flags an int value containing flag information
+     */
+    public void setFlags(int flags) {
+        mFlags = flags;
+    }
+
+    /**
+     * Handle the span use cases
+     *
+     * @param spansMatrix a int matrix that contains span information
+     */
+    private void handleSpans(int[][] spansMatrix) {
+        if (isSpansRespectWidgetOrder()) {
+            return;
+        }
+
+        for (int i = 0; i < spansMatrix.length; i++) {
+            int row = getRowByIndex(spansMatrix[i][0]);
+            int col = getColByIndex(spansMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    spansMatrix[i][1], spansMatrix[i][2])) {
+                return;
+            }
+            connectWidget(mWidgets[i], row, col,
+                    spansMatrix[i][1], spansMatrix[i][2]);
+            mSpanIds.add(mWidgets[i].stringId);
+        }
+    }
+
+    /**
+     * Arrange the widgets in the constraint_referenced_ids
+     */
+    private void arrangeWidgets() {
+        int position;
+
+        // @TODO handle RTL
+        for (int i = 0; i < mWidgetsCount; i++) {
+            if (mSpanIds.contains(mWidgets[i].stringId)) {
+                // skip the widget Id that's already handled by handleSpans
+                continue;
+            }
+
+            position = getNextPosition();
+            int row = getRowByIndex(position);
+            int col = getColByIndex(position);
+            if (position == -1) {
+                // no more available position.
+                return;
+            }
+
+            if (isSpansRespectWidgetOrder() && mSpanMatrix != null) {
+                if (mSpanIndex < mSpanMatrix.length && mSpanMatrix[mSpanIndex][0] == position) {
+                    // when invoke getNextPosition this position would be set to false
+                    mPositionMatrix[row][col] = true;
+                    // if there is not enough space to constrain the span, don't do it.
+                    if (!invalidatePositions(row, col,
+                            mSpanMatrix[mSpanIndex][1], mSpanMatrix[mSpanIndex][2])) {
+                        continue;
+                    }
+                    connectWidget(mWidgets[i], row, col,
+                            mSpanMatrix[mSpanIndex][1], mSpanMatrix[mSpanIndex][2]);
+                    mSpanIndex++;
+                    continue;
+                }
+            }
+            connectWidget(mWidgets[i], row, col, 1, 1);
+        }
+    }
+
+    /**
+     * generate the Grid form based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    private void setupGrid(boolean isUpdate) {
+        if (mRows < 1 || mColumns < 1) {
+            return;
+        }
+
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+            mSpanIds.clear();
+        }
+
+        mNextAvailableIndex = 0;
+
+        if (mSkips != null && !mSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(this.mSkips, false);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mSpans != null && !mSpans.trim().isEmpty()) {
+            mSpanMatrix = parseSpans(this.mSpans, true);
+        }
+
+        // Need to create boxes before handleSpans since the spanned widgets would be
+        // constrained in this step.
+        createBoxes();
+
+        if (mSpanMatrix != null) {
+            handleSpans(mSpanMatrix);
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row
+     *
+     * @param index index in 1D
+     * @return row as its values.
+     */
+    private int getRowByIndex(int index) {
+        if (mOrientation == 1) {
+            return index % mRows;
+
+        } else {
+            return index / mColumns;
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for column
+     *
+     * @param index index in 1D
+     * @return column as its values.
+     */
+    private int getColByIndex(int index) {
+        if (mOrientation == 1) {
+            return index / mRows;
+        } else {
+            return index % mColumns;
+        }
+    }
+
+    /**
+     * Make positions in the grid unavailable based on the skips attr
+     *
+     * @param skipsMatrix a int matrix that contains skip information
+     */
+    private void handleSkips(int[][] skipsMatrix) {
+        for (int[] matrix : skipsMatrix) {
+            int row = getRowByIndex(matrix[0]);
+            int col = getColByIndex(matrix[0]);
+            if (!invalidatePositions(row, col,
+                    matrix[1], matrix[2])) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Make the specified positions in the grid unavailable.
+     *
+     * @param startRow the row of the staring position
+     * @param startColumn the column of the staring position
+     * @param rowSpan how many rows to span
+     * @param columnSpan how many columns to span
+     * @return true if we could properly invalidate the positions else false
+     */
+    private boolean invalidatePositions(int startRow, int startColumn,
+                                        int rowSpan, int columnSpan) {
+        for (int i = startRow; i < startRow + rowSpan; i++) {
+            for (int j = startColumn; j < startColumn + columnSpan; j++) {
+                if (i >= mPositionMatrix.length || j >= mPositionMatrix[0].length
+                        || !mPositionMatrix[i][j]) {
+                    // the position is already occupied.
+                    return false;
+                }
+                mPositionMatrix[i][j] = false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Parse the weights/pads in the string format into a float array. Note that weight are
+     * normally expected to match the size. But in case they don't, we trim or pad the weight with
+     * trailing 1 to match the expected size.
+     *
+     * @param size size of the return array
+     * @param str  weights/pads in a string format
+     * @return a float array with weights/pads values
+     */
+    private float[] parseWeights(int size, String str) {
+        if (str == null || str.trim().isEmpty()) {
+            return null;
+        }
+
+        String[] values = str.split(",");
+
+        // Return array must be of the expected size, effectively trimming excess weights
+        float[] arr = new float[size];
+        for (int i = 0; i < arr.length; i++) {
+            if (i < values.length) {
+                try {
+                    arr[i] = Float.parseFloat(values[i]);
+                } catch (Exception e) {
+                    System.err.println("Error parsing `" + values[i] + "`: " + e.getMessage());
+                    // Fallback to 1f.
+                    arr[i] = 1f;
+                }
+            } else {
+                // Fill in missing weights with 1f
+                arr[i] = 1f;
+            }
+        }
+        return arr;
+    }
+
+    /**
+     * Get the next available position for widget arrangement.
+     * @return int[] -> [row, column]
+     */
+    private int getNextPosition() {
+        int position = 0;
+        boolean positionFound = false;
+
+        while (!positionFound) {
+            if (mNextAvailableIndex >= mRows * mColumns) {
+                return -1;
+            }
+
+            position = mNextAvailableIndex;
+            int row = getRowByIndex(mNextAvailableIndex);
+            int col = getColByIndex(mNextAvailableIndex);
+            if (mPositionMatrix[row][col]) {
+                mPositionMatrix[row][col] = false;
+                positionFound = true;
+            }
+
+            mNextAvailableIndex++;
+        }
+        return position;
+    }
+
+    /**
+     * Compute the actual rows and columns given what was set
+     * if 0,0 find the most square rows and columns that fits
+     * if 0,n or n,0 scale to fit
+     */
+    private void updateActualRowsAndColumns() {
+        if (mRowsSet == 0 || mColumnsSet == 0) {
+            if (mColumnsSet > 0) {
+                mColumns = mColumnsSet;
+                mRows = (mWidgetsCount + mColumns - 1) / mColumnsSet; // round up
+            } else  if (mRowsSet > 0) {
+                mRows = mRowsSet;
+                mColumns = (mWidgetsCount + mRowsSet - 1) / mRowsSet; // round up
+            } else { // as close to square as possible favoring more rows
+                mRows = (int)  (1.5 + Math.sqrt(mWidgetsCount));
+                mColumns = (mWidgetsCount + mRows - 1) / mRows;
+            }
+        } else {
+            mRows = mRowsSet;
+            mColumns = mColumnsSet;
+        }
+    }
+
+    /**
+     * Create a new boxWidget for constraining widgets
+     * @return the created boxWidget
+     */
+    private ConstraintWidget makeNewWidget() {
+        ConstraintWidget widget = new ConstraintWidget();
+        widget.mListDimensionBehaviors[HORIZONTAL] = MATCH_CONSTRAINT;
+        widget.mListDimensionBehaviors[VERTICAL] = MATCH_CONSTRAINT;
+        widget.stringId = String.valueOf(widget.hashCode());
+        return widget;
+    }
+
+    /**
+     * Connect the widget to the corresponding widgetBoxes based on the input params
+     *
+     * @param widget the widget that we want to add constraints to
+     * @param row    row position to place the widget
+     * @param column column position to place the widget
+     */
+    private void connectWidget(ConstraintWidget widget, int row, int column,
+                               int rowSpan, int columnSpan) {
+        // Connect the 4 sides
+        widget.mLeft.connect(mBoxWidgets[column].mLeft, 0);
+        widget.mTop.connect(mBoxWidgets[row].mTop, 0);
+        widget.mRight.connect(mBoxWidgets[column + columnSpan - 1].mRight, 0);
+        widget.mBottom.connect(mBoxWidgets[row + rowSpan - 1].mBottom, 0);
+    }
+
+    /**
+     * Set chain between boxWidget horizontally
+     */
+    private void setBoxWidgetHorizontalChains() {
+        int maxVal = Math.max(mRows, mColumns);
+
+        ConstraintWidget widget = mBoxWidgets[0];
+        float[] columnWeights = parseWeights(mColumns, mColumnWeights);
+        // chain all the widgets on the longer side (either horizontal or vertical)
+        if (mColumns == 1) {
+            clearHorizontalAttributes(widget);
+            widget.mLeft.connect(mLeft, 0);
+            widget.mRight.connect(mRight, 0);
+            return;
+        }
+
+        //  chains are grid <- box <-> box <-> box -> grid
+        for (int i = 0; i < mColumns; i++) {
+            widget = mBoxWidgets[i];
+            clearHorizontalAttributes(widget);
+            if (columnWeights != null) {
+                widget.setHorizontalWeight(columnWeights[i]);
+            }
+            if (i > 0) {
+                widget.mLeft.connect(mBoxWidgets[i - 1].mRight, 0);
+            } else {
+                widget.mLeft.connect(mLeft, 0);
+            }
+            if (i < mColumns - 1) {
+                widget.mRight.connect(mBoxWidgets[i + 1].mLeft, 0);
+            } else {
+                widget.mRight.connect(mRight, 0);
+            }
+            if (i > 0) {
+                widget.mLeft.mMargin = (int) mHorizontalGaps;
+            }
+        }
+        // excess boxes are connected to grid those sides are not use
+        // for efficiency they should be connected to parent
+        for (int i = mColumns; i < maxVal; i++) {
+            widget = mBoxWidgets[i];
+            clearHorizontalAttributes(widget);
+            widget.mLeft.connect(mLeft, 0);
+            widget.mRight.connect(mRight, 0);
+        }
+    }
+
+    /**
+     * Set chain between boxWidget vertically
+     */
+    private void setBoxWidgetVerticalChains() {
+        int maxVal = Math.max(mRows, mColumns);
+
+        ConstraintWidget widget = mBoxWidgets[0];
+        float[] rowWeights = parseWeights(mRows, mRowWeights);
+        // chain all the widgets on the longer side (either horizontal or vertical)
+        if (mRows == 1) {
+            clearVerticalAttributes(widget);
+            widget.mTop.connect(mTop, 0);
+            widget.mBottom.connect(mBottom, 0);
+            return;
+        }
+
+        // chains are constrained like this: grid <- box <-> box <-> box -> grid
+        for (int i = 0; i < mRows; i++) {
+            widget = mBoxWidgets[i];
+            clearVerticalAttributes(widget);
+            if (rowWeights != null) {
+                widget.setVerticalWeight(rowWeights[i]);
+            }
+            if (i > 0) {
+                widget.mTop.connect(mBoxWidgets[i - 1].mBottom, 0);
+            } else {
+                widget.mTop.connect(mTop, 0);
+            }
+            if (i < mRows - 1) {
+                widget.mBottom.connect(mBoxWidgets[i + 1].mTop, 0);
+            } else {
+                widget.mBottom.connect(mBottom, 0);
+            }
+            if (i > 0) {
+                widget.mTop.mMargin = (int) mVerticalGaps;
+            }
+        }
+
+        // excess boxes are connected to grid those sides are not use
+        // for efficiency they should be connected to parent
+        for (int i = mRows; i < maxVal; i++) {
+            widget = mBoxWidgets[i];
+            clearVerticalAttributes(widget);
+            widget.mTop.connect(mTop, 0);
+            widget.mBottom.connect(mBottom, 0);
+        }
+    }
+
+    /**
+     * Chains the boxWidgets and add constraints to the widgets
+     */
+    private void addConstraints() {
+        setBoxWidgetVerticalChains();
+        setBoxWidgetHorizontalChains();
+        arrangeWidgets();
+    }
+
+    /**
+     * Create all the boxWidgets that will be used to constrain widgets
+     */
+    private void createBoxes() {
+        int boxCount = Math.max(mRows, mColumns);
+        if (mBoxWidgets == null) { // no box widgets build all
+            mBoxWidgets = new ConstraintWidget[boxCount];
+            for (int i = 0; i < mBoxWidgets.length; i++) {
+                mBoxWidgets[i] = makeNewWidget(); // need to remove old Widgets
+            }
+        } else {
+            if (boxCount != mBoxWidgets.length) {
+                ConstraintWidget[] temp = new ConstraintWidget[boxCount];
+                for (int i = 0; i < boxCount; i++) {
+                    if (i < mBoxWidgets.length) { // use old one
+                        temp[i] = mBoxWidgets[i];
+                    } else { // make new one
+                        temp[i] = makeNewWidget();
+                    }
+                }
+                // remove excess
+                for (int j = boxCount; j < mBoxWidgets.length; j++) {
+                    ConstraintWidget widget = mBoxWidgets[j];
+                    mContainer.remove(widget);
+                }
+                mBoxWidgets = temp;
+            }
+        }
+    }
+
+    /**
+     * Clear the vertical related attributes
+     * @param widget widget that has the attributes to be cleared
+     */
+    private void clearVerticalAttributes(ConstraintWidget widget) {
+        widget.setVerticalWeight(UNKNOWN);
+        widget.mTop.reset();
+        widget.mBottom.reset();
+        widget.mBaseline.reset();
+    }
+
+    /**
+     * Clear the horizontal related attributes
+     * @param widget widget that has the attributes to be cleared
+     */
+    private void clearHorizontalAttributes(ConstraintWidget widget) {
+        widget.setHorizontalWeight(UNKNOWN);
+        widget.mLeft.reset();
+        widget.mRight.reset();
+    }
+
+    /**
+     * Initialize the relevant variables
+     */
+    private void initVariables() {
+        mPositionMatrix = new boolean[mRows][mColumns];
+        for (boolean[] row : mPositionMatrix) {
+            Arrays.fill(row, true);
+        }
+
+        if (mWidgetsCount > 0) {
+            mConstraintMatrix = new int[mWidgetsCount][4];
+            for (int[] row : mConstraintMatrix) {
+                Arrays.fill(row, -1);
+            }
+        }
+    }
+
+    /**
+     * parse the skips/spans in the string format into a int matrix
+     * that each row has the information - [index, row_span, col_span]
+     * the format of the input string is index:row_spanxcol_span.
+     * index - the index of the starting position
+     * row_span - the number of rows to span
+     * col_span- the number of columns to span
+     *
+     * @param str string format of skips or spans
+     * @param isSpans whether is spans to be parsed (it is skips if not)
+     * @return a int matrix that contains skip information.
+     */
+    private int[][] parseSpans(String str, boolean isSpans) {
+        try {
+            int extraRows = 0;
+            int extraColumns = 0;
+            String[] spans = str.split(",");
+            // Sort the spans by the position
+            Arrays.sort(spans, (span1, span2) -> Integer.parseInt(span1.split(":")[0])
+                    - Integer.parseInt(span2.split(":")[0]));
+            int[][] spanMatrix = new int[spans.length][3];
+            String[] indexAndSpan;
+            if (mRows == 1 || mColumns == 1) {
+                for (int i = 0; i < spans.length; i++) {
+                    indexAndSpan = spans[i].trim().split(":");
+                    spanMatrix[i][0] = Integer.parseInt(indexAndSpan[0]);
+                    spanMatrix[i][1] = 1;
+                    spanMatrix[i][2] = 1;
+
+                    if (mColumns == 1) {
+                        spanMatrix[i][1] = Integer.parseInt(indexAndSpan[1]);
+                        extraRows += spanMatrix[i][1];
+                        if (isSpans) {
+                            extraRows--;
+                        }
+                    }
+                    if (mRows == 1) {
+                        spanMatrix[i][2] = Integer.parseInt(indexAndSpan[1]);
+                        extraColumns += spanMatrix[i][2];
+                        if (isSpans) {
+                            extraColumns--;
+                        }
+                    }
+                }
+
+                if (extraRows != 0 && !mExtraSpaceHandled) {
+                    this.setRows(mRows + extraRows);
+                }
+                if (extraColumns != 0 && !mExtraSpaceHandled) {
+                    this.setColumns(mColumns + extraColumns);
+                }
+                mExtraSpaceHandled = true;
+            } else {
+                String[] rowAndCol;
+                for (int i = 0; i < spans.length; i++) {
+                    indexAndSpan = spans[i].trim().split(":");
+                    rowAndCol = indexAndSpan[1].split("x");
+                    spanMatrix[i][0] = Integer.parseInt(indexAndSpan[0]);
+                    if (isSubGridByColRow()) {
+                        spanMatrix[i][1] = Integer.parseInt(rowAndCol[1]);
+                        spanMatrix[i][2] = Integer.parseInt(rowAndCol[0]);
+                    } else {
+                        spanMatrix[i][1] = Integer.parseInt(rowAndCol[0]);
+                        spanMatrix[i][2] = Integer.parseInt(rowAndCol[1]);
+                    }
+
+                }
+            }
+            return spanMatrix;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * fill the constraintMatrix based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    private void fillConstraintMatrix(boolean isUpdate) {
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+
+            for (int i = 0; i < mConstraintMatrix.length; i++) {
+                for (int j = 0; j < mConstraintMatrix[0].length; j++) {
+                    mConstraintMatrix[i][j] = -1;
+                }
+            }
+        }
+
+        mNextAvailableIndex = 0;
+
+        if (mSkips != null && !mSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(this.mSkips, false);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mSpans != null && !mSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(this.mSpans, true);
+            if (mSpans != null) {
+                handleSpans(mSpans);
+            }
+        }
+    }
+
+    /**
+     * Set up the Grid engine.
+     */
+    private void initMatrices() {
+        boolean isUpdate = mConstraintMatrix != null
+                && mConstraintMatrix.length == mWidgetsCount
+                && mPositionMatrix != null
+                && mPositionMatrix.length == mRows
+                && mPositionMatrix[0].length == mColumns;
+
+        if (!isUpdate) {
+            initVariables();
+        }
+
+        fillConstraintMatrix(isUpdate);
+    }
+
+    /**
+     * Flag to implicitly reverse the order of width/height specified in spans & skips.
+     * E.g.: 1:3x2 is read as 1:2x3
+     */
+    private boolean isSubGridByColRow() {
+        return (mFlags & SUB_GRID_BY_COL_ROW) > 0;
+    }
+
+    /**
+     * Flag to respect the order of the Widgets when arranging for spans.
+     */
+    private boolean isSpansRespectWidgetOrder() {
+        return (mFlags & SPANS_RESPECT_WIDGET_ORDER) > 0;
+    }
+
+    @Override
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        super.measure(widthMode, widthSize, heightMode, heightSize);
+        mContainer = (ConstraintWidgetContainer) getParent();
+        setupGrid(false);
+        mContainer.add(mBoxWidgets);
+    }
+
+    @Override
+    public void addToSolver(@Nullable LinearSystem system, boolean optimize) {
+        super.addToSolver(system, optimize);
+        addConstraints();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/utils/GridEngine.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/utils/GridEngine.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.utils;
+
+import java.util.Arrays;
+
+/**
+ * GridEngine class contains the main logic of the Grid Helper
+ */
+public class GridEngine {
+
+    public static final int VERTICAL = 1;
+    public static final int HORIZONTAL = 0;
+    private static final int MAX_ROWS = 50; // maximum number of rows can be specified.
+    private static final int MAX_COLUMNS = 50; // maximum number of columns can be specified.
+    private static final int DEFAULT_SIZE = 3; // default rows and columns.
+
+    /**
+     * number of rows of the grid
+     */
+    private int mRows;
+
+    /**
+     * number of rows set by the XML or API
+     */
+    private int mRowsSet;
+
+    /**
+     * How many widgets need to be placed in the Grid
+     */
+    private int mNumWidgets;
+
+    /**
+     * number of columns of the grid
+     */
+    private int mColumns;
+
+    /**
+     * number of columns set by the XML or API
+     */
+    private int mColumnsSet;
+
+    /**
+     * string format of the input Spans
+     */
+    private String mStrSpans;
+
+    /**
+     * string format of the input Skips
+     */
+    private String mStrSkips;
+
+    /**
+     * orientation of the view arrangement - vertical or horizontal
+     */
+    private int mOrientation;
+
+    /**
+     * Indicates what is the next available position to place an widget
+     */
+    private int mNextAvailableIndex = 0;
+
+    /**
+     * A boolean matrix that tracks the positions that are occupied by skips and spans
+     * true: available position
+     * false: non-available position
+     */
+    private boolean[][] mPositionMatrix;
+
+    /**
+     * A int matrix that contains the positions where a widget would constraint to at each direction
+     * Each row contains 4 values that indicate the position to constraint of a widget.
+     * Example row: [left, top, right, bottom]
+     */
+    private int[][] mConstraintMatrix;
+
+    public GridEngine() {}
+
+    public GridEngine(int rows, int columns) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    public GridEngine(int rows, int columns, int numWidgets) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        mNumWidgets = numWidgets;
+
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+
+        if (numWidgets > mRows * mColumns || numWidgets < 1) {
+            mNumWidgets = mRows * mColumns;
+        }
+
+        initVariables();
+        fillConstraintMatrix(false);
+    }
+
+    /**
+     * Initialize the relevant variables
+     */
+    private void initVariables() {
+        mPositionMatrix = new boolean[mRows][mColumns];
+        for (boolean[] row : mPositionMatrix) {
+            Arrays.fill(row, true);
+        }
+
+        if (mNumWidgets > 0) {
+            mConstraintMatrix = new int[mNumWidgets][4];
+            for (int[] row : mConstraintMatrix) {
+                Arrays.fill(row, -1);
+            }
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return row as its values.
+     */
+    private int getRowByIndex(int index) {
+        if (mOrientation == 1) {
+            return index % mRows;
+
+        } else {
+            return index / mColumns;
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return column as its values.
+     */
+    private int getColByIndex(int index) {
+        if (mOrientation == 1) {
+            return index / mRows;
+        } else {
+            return index % mColumns;
+        }
+    }
+
+    /**
+     * Check if the value of the spans/skips is valid
+     *
+     * @param str spans/skips in string format
+     * @return true if it is valid else false
+     */
+    private boolean isSpansValid(CharSequence str) {
+        if (str == null) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * parse the skips/spans in the string format into a int matrix
+     * that each row has the information - [index, row_span, col_span]
+     * the format of the input string is index:row_spanxcol_span.
+     * index - the index of the starting position
+     * row_span - the number of rows to span
+     * col_span- the number of columns to span
+     *
+     * @param str string format of skips or spans
+     * @return a int matrix that contains skip information.
+     */
+    private int[][] parseSpans(String str) {
+        if (!isSpansValid(str)) {
+            return null;
+        }
+
+        String[] spans = str.split(",");
+        int[][] spanMatrix = new int[spans.length][3];
+
+        String[] indexAndSpan;
+        String[] rowAndCol;
+        for (int i = 0; i < spans.length; i++) {
+            indexAndSpan = spans[i].trim().split(":");
+            rowAndCol = indexAndSpan[1].split("x");
+            spanMatrix[i][0] = Integer.parseInt(indexAndSpan[0]);
+            spanMatrix[i][1] = Integer.parseInt(rowAndCol[0]);
+            spanMatrix[i][2] = Integer.parseInt(rowAndCol[1]);
+        }
+        return spanMatrix;
+    }
+
+    /**
+     * fill the constraintMatrix based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    private void fillConstraintMatrix(boolean isUpdate) {
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+
+            for (int i = 0; i < mConstraintMatrix.length; i++) {
+                for (int j = 0; j < mConstraintMatrix[0].length; j++) {
+                    mConstraintMatrix[i][j] = -1;
+                }
+            }
+        }
+
+        mNextAvailableIndex = 0;
+
+        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(mStrSkips);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(mStrSpans);
+            if (mSpans != null) {
+                handleSpans(mSpans);
+            }
+        }
+
+        addAllConstraintPositions();
+    }
+
+    /**
+     * Get the next available position for widget arrangement.
+     * @return int[] -> [row, column]
+     */
+    private int getNextPosition() {
+        int position = 0;
+        boolean positionFound = false;
+
+        while (!positionFound) {
+            if (mNextAvailableIndex >= mRows * mColumns) {
+                return -1;
+            }
+
+            position = mNextAvailableIndex;
+            int row = getRowByIndex(mNextAvailableIndex);
+            int col = getColByIndex(mNextAvailableIndex);
+            if (mPositionMatrix[row][col]) {
+                mPositionMatrix[row][col] = false;
+                positionFound = true;
+            }
+
+            mNextAvailableIndex++;
+        }
+        return position;
+    }
+
+    /**
+     * add the constraint position info of a widget based on the input params
+     *
+     * @param widgetId the Id of the widget
+     * @param row row position to place the view
+     * @param column column position to place the view
+     */
+    private void addConstraintPosition(int widgetId, int row, int column,
+                                       int rowSpan, int columnSpan) {
+
+        mConstraintMatrix[widgetId][0] = column;
+        mConstraintMatrix[widgetId][1] = row;
+        mConstraintMatrix[widgetId][2] = column + columnSpan - 1;
+        mConstraintMatrix[widgetId][3] = row + rowSpan - 1;
+    }
+
+    /**
+     * Handle the span use cases
+     *
+     * @param spansMatrix a int matrix that contains span information
+     */
+    private void handleSpans(int[][] spansMatrix) {
+        for (int i = 0; i < spansMatrix.length; i++) {
+            int row = getRowByIndex(spansMatrix[i][0]);
+            int col = getColByIndex(spansMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    spansMatrix[i][1], spansMatrix[i][2])) {
+                return;
+            }
+            addConstraintPosition(i, row, col,
+                    spansMatrix[i][1], spansMatrix[i][2]);
+        }
+    }
+
+    /**
+     * Make positions in the grid unavailable based on the skips attr
+     *
+     * @param skipsMatrix a int matrix that contains skip information
+     */
+    private void handleSkips(int[][] skipsMatrix) {
+        for (int i = 0; i < skipsMatrix.length; i++) {
+            int row = getRowByIndex(skipsMatrix[i][0]);
+            int col = getColByIndex(skipsMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    skipsMatrix[i][1], skipsMatrix[i][2])) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Make the specified positions in the grid unavailable.
+     *
+     * @param startRow the row of the staring position
+     * @param startColumn the column of the staring position
+     * @param rowSpan how many rows to span
+     * @param columnSpan how many columns to span
+     * @return true if we could properly invalidate the positions else false
+     */
+    private boolean invalidatePositions(int startRow, int startColumn,
+                                        int rowSpan, int columnSpan) {
+        for (int i = startRow; i < startRow + rowSpan; i++) {
+            for (int j = startColumn; j < startColumn + columnSpan; j++) {
+                if (i >= mPositionMatrix.length || j >= mPositionMatrix[0].length
+                        || !mPositionMatrix[i][j]) {
+                    // the position is already occupied.
+                    return false;
+                }
+                mPositionMatrix[i][j] = false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Arrange the views in the constraint_referenced_ids
+     */
+    private void addAllConstraintPositions() {
+        int position;
+
+        for (int i = 0; i < mNumWidgets; i++) {
+
+            // Already added ConstraintPosition
+            if (leftOfWidget(i) != -1) {
+                continue;
+            }
+
+            position = getNextPosition();
+            int row = getRowByIndex(position);
+            int col = getColByIndex(position);
+            if (position == -1) {
+                // no more available position.
+                return;
+            }
+            addConstraintPosition(i, row, col, 1, 1);
+        }
+    }
+
+    /**
+     * Compute the actual rows and columns given what was set
+     * if 0,0 find the most square rows and columns that fits
+     * if 0,n or n,0 scale to fit
+     */
+    private void updateActualRowsAndColumns() {
+        if (mRowsSet == 0 || mColumnsSet == 0) {
+            if (mColumnsSet > 0) {
+                mColumns = mColumnsSet;
+                mRows = (mNumWidgets + mColumns - 1) / mColumnsSet; // round up
+            } else  if (mRowsSet > 0) {
+                mRows = mRowsSet;
+                mColumns = (mNumWidgets + mRowsSet - 1) / mRowsSet; // round up
+            } else { // as close to square as possible favoring more rows
+                mRows = (int)  (1.5 + Math.sqrt(mNumWidgets));
+                mColumns = (mNumWidgets + mRows - 1) / mRows;
+            }
+        } else {
+            mRows = mRowsSet;
+            mColumns = mColumnsSet;
+        }
+    }
+
+    /**
+     * Set up the Grid engine.
+     */
+    public void setup() {
+        boolean isUpdate = true;
+
+        if (mConstraintMatrix == null
+                || mConstraintMatrix.length != mNumWidgets
+                || mPositionMatrix == null
+                || mPositionMatrix.length != mRows
+                || mPositionMatrix[0].length != mColumns) {
+            isUpdate = false;
+        }
+
+        if (!isUpdate) {
+            initVariables();
+        }
+
+        fillConstraintMatrix(isUpdate);
+    }
+
+    /**
+     * set new spans value
+     *
+     * @param spans new spans value
+     */
+    public void setSpans(CharSequence spans) {
+        if (mStrSpans != null && mStrSpans.equals(spans.toString())) {
+            return;
+        }
+
+        mStrSpans = spans.toString();
+    }
+
+    /**
+     * set new skips value
+     *
+     * @param skips new spans value
+     */
+    public void setSkips(String skips) {
+        if (mStrSkips != null && mStrSkips.equals(skips)) {
+            return;
+        }
+
+        mStrSkips = skips;
+
+    }
+
+    /**
+     * set new orientation value
+     *
+     * @param orientation new orientation value
+     */
+    public void setOrientation(int orientation) {
+        if (!(orientation == HORIZONTAL || orientation == VERTICAL)) {
+            return;
+        }
+
+        if (mOrientation == orientation) {
+            return;
+        }
+
+        mOrientation = orientation;
+    }
+
+    /**
+     * Set new NumWidgets value
+     * @param num how many widgets to be arranged in Grid
+     */
+    public void setNumWidgets(int num) {
+        if (num > mRows * mColumns) {
+            return;
+        }
+
+        mNumWidgets = num;
+    }
+
+    /**
+     * set new rows value
+     *
+     * @param rows new rows value
+     */
+    public void setRows(int rows) {
+        if (rows > MAX_ROWS) {
+            return;
+        }
+
+        if (mRowsSet == rows) {
+            return;
+        }
+
+        mRowsSet = rows;
+        updateActualRowsAndColumns();
+
+    }
+
+    /**
+     * set new columns value
+     *
+     * @param columns new rows value
+     */
+    public void setColumns(int columns) {
+        if (columns > MAX_COLUMNS) {
+            return;
+        }
+
+        if (mColumnsSet == columns) {
+            return;
+        }
+
+        mColumnsSet = columns;
+        updateActualRowsAndColumns();
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the left
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the left
+     */
+    public int leftOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][0];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the top
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the top
+     */
+    public int topOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][1];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the right
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the right
+     */
+    public int rightOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][2];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the bottom
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the bottom
+     */
+    public int bottomOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][3];
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Barrier.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Barrier.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.SolverVariable;
+
+import java.util.HashMap;
+
+/**
+ * A Barrier takes multiple widgets
+ */
+public class Barrier extends HelperWidget {
+
+    public static final int LEFT = 0;
+    public static final int RIGHT = 1;
+    public static final int TOP = 2;
+    public static final int BOTTOM = 3;
+    private static final boolean USE_RESOLUTION = true;
+    private static final boolean USE_RELAX_GONE = false;
+
+    private int mBarrierType = LEFT;
+
+    private boolean mAllowsGoneWidget = true;
+    private int mMargin = 0;
+    boolean mResolved = false;
+
+    public Barrier() {
+    }
+
+    public Barrier(String debugName) {
+        setDebugName(debugName);
+    }
+
+    @Override
+    public boolean allowedInBarrier() {
+        return true;
+    }
+
+    public int getBarrierType() {
+        return mBarrierType;
+    }
+
+    public void setBarrierType(int barrierType) {
+        mBarrierType = barrierType;
+    }
+
+    public void setAllowsGoneWidget(boolean allowsGoneWidget) {
+        mAllowsGoneWidget = allowsGoneWidget;
+    }
+
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     * @deprecated This method should be called {@code getAllowsGoneWidget}
+     * such that {@code allowsGoneWidget}
+     * can be accessed as a property from Kotlin; {@see https://android.github
+     * .io/kotlin-guides/interop.html#property-prefixes}.
+     * Use {@link #getAllowsGoneWidget()} instead.
+     */
+    @Deprecated
+    public boolean allowsGoneWidget() {
+        return mAllowsGoneWidget;
+    }
+
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     */
+    public boolean getAllowsGoneWidget() {
+        return mAllowsGoneWidget;
+    }
+
+    @Override
+    public boolean isResolvedHorizontally() {
+        return mResolved;
+    }
+
+    @Override
+    public boolean isResolvedVertically() {
+        return mResolved;
+    }
+
+    @Override
+    public void copy(ConstraintWidget src, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        super.copy(src, map);
+        Barrier srcBarrier = (Barrier) src;
+        mBarrierType = srcBarrier.mBarrierType;
+        mAllowsGoneWidget = srcBarrier.mAllowsGoneWidget;
+        mMargin = srcBarrier.mMargin;
+    }
+
+    @Override
+    public String toString() {
+        String debug = "[Barrier] " + getDebugName() + " {";
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (i > 0) {
+                debug += ", ";
+            }
+            debug += widget.getDebugName();
+        }
+        debug += "}";
+        return debug;
+    }
+
+    protected void markWidgets() {
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (!mAllowsGoneWidget && !widget.allowedInBarrier()) {
+                continue;
+            }
+            if (mBarrierType == LEFT || mBarrierType == RIGHT) {
+                widget.setInBarrier(HORIZONTAL, true);
+            } else if (mBarrierType == TOP || mBarrierType == BOTTOM) {
+                widget.setInBarrier(VERTICAL, true);
+            }
+        }
+    }
+
+    /**
+     * Add this widget to the solver
+     *
+     * @param system   the solver we want to add the widget to
+     * @param optimize true if {@link Optimizer#OPTIMIZATION_GRAPH} is on
+     */
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("\n----------------------------------------------");
+            System.out.println("-- adding " + getDebugName() + " to the solver");
+            System.out.println("----------------------------------------------\n");
+        }
+
+        ConstraintAnchor position;
+        mListAnchors[LEFT] = mLeft;
+        mListAnchors[TOP] = mTop;
+        mListAnchors[RIGHT] = mRight;
+        mListAnchors[BOTTOM] = mBottom;
+        for (int i = 0; i < mListAnchors.length; i++) {
+            mListAnchors[i].mSolverVariable = system.createObjectVariable(mListAnchors[i]);
+        }
+        if (mBarrierType >= 0 && mBarrierType < 4) {
+            position = mListAnchors[mBarrierType];
+        } else {
+            return;
+        }
+
+        if (USE_RESOLUTION) {
+            if (!mResolved) {
+                allSolved();
+            }
+            if (mResolved) {
+                mResolved = false;
+                if (mBarrierType == LEFT || mBarrierType == RIGHT) {
+                    system.addEquality(mLeft.mSolverVariable, mX);
+                    system.addEquality(mRight.mSolverVariable, mX);
+                } else if (mBarrierType == TOP || mBarrierType == BOTTOM) {
+                    system.addEquality(mTop.mSolverVariable, mY);
+                    system.addEquality(mBottom.mSolverVariable, mY);
+                }
+                return;
+            }
+        }
+
+        // We have to handle the case where some of the elements
+        //  referenced in the barrier are set as
+        // match_constraint; we have to take it in account to set the strength of the barrier.
+        boolean hasMatchConstraintWidgets = false;
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (!mAllowsGoneWidget && !widget.allowedInBarrier()) {
+                continue;
+            }
+            if ((mBarrierType == LEFT || mBarrierType == RIGHT)
+                    && (widget.getHorizontalDimensionBehaviour()
+                    == DimensionBehaviour.MATCH_CONSTRAINT)
+                    && widget.mLeft.mTarget != null && widget.mRight.mTarget != null) {
+                hasMatchConstraintWidgets = true;
+                break;
+            } else if ((mBarrierType == TOP || mBarrierType == BOTTOM)
+                    && (widget.getVerticalDimensionBehaviour()
+                    == DimensionBehaviour.MATCH_CONSTRAINT)
+                    && widget.mTop.mTarget != null && widget.mBottom.mTarget != null) {
+                hasMatchConstraintWidgets = true;
+                break;
+            }
+        }
+
+        boolean mHasHorizontalCenteredDependents =
+                mLeft.hasCenteredDependents() || mRight.hasCenteredDependents();
+        boolean mHasVerticalCenteredDependents =
+                mTop.hasCenteredDependents() || mBottom.hasCenteredDependents();
+        boolean applyEqualityOnReferences = !hasMatchConstraintWidgets
+                && ((mBarrierType == LEFT && mHasHorizontalCenteredDependents)
+                || (mBarrierType == TOP && mHasVerticalCenteredDependents)
+                || (mBarrierType == RIGHT && mHasHorizontalCenteredDependents)
+                || (mBarrierType == BOTTOM && mHasVerticalCenteredDependents));
+
+        int equalityOnReferencesStrength = SolverVariable.STRENGTH_EQUALITY;
+        if (!applyEqualityOnReferences) {
+            equalityOnReferencesStrength = SolverVariable.STRENGTH_HIGHEST;
+        }
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (!mAllowsGoneWidget && !widget.allowedInBarrier()) {
+                continue;
+            }
+            SolverVariable target = system.createObjectVariable(widget.mListAnchors[mBarrierType]);
+            widget.mListAnchors[mBarrierType].mSolverVariable = target;
+            int margin = 0;
+            if (widget.mListAnchors[mBarrierType].mTarget != null
+                    && widget.mListAnchors[mBarrierType].mTarget.mOwner == this) {
+                margin += widget.mListAnchors[mBarrierType].mMargin;
+            }
+            if (mBarrierType == LEFT || mBarrierType == TOP) {
+                system.addLowerBarrier(position.mSolverVariable, target,
+                        mMargin - margin, hasMatchConstraintWidgets);
+            } else {
+                system.addGreaterBarrier(position.mSolverVariable, target,
+                        mMargin + margin, hasMatchConstraintWidgets);
+            }
+            if (USE_RELAX_GONE) {
+                if (widget.getVisibility() != GONE
+                        || widget instanceof Guideline || widget instanceof Barrier) {
+                    system.addEquality(position.mSolverVariable, target,
+                            mMargin + margin, equalityOnReferencesStrength);
+                }
+            } else {
+                system.addEquality(position.mSolverVariable, target,
+                        mMargin + margin, equalityOnReferencesStrength);
+            }
+        }
+
+        int barrierParentStrength = SolverVariable.STRENGTH_HIGHEST;
+        int barrierParentStrengthOpposite = SolverVariable.STRENGTH_NONE;
+
+        if (mBarrierType == LEFT) {
+            system.addEquality(mRight.mSolverVariable,
+                    mLeft.mSolverVariable, 0, SolverVariable.STRENGTH_FIXED);
+            system.addEquality(mLeft.mSolverVariable,
+                    mParent.mRight.mSolverVariable, 0, barrierParentStrength);
+            system.addEquality(mLeft.mSolverVariable,
+                    mParent.mLeft.mSolverVariable, 0, barrierParentStrengthOpposite);
+        } else if (mBarrierType == RIGHT) {
+            system.addEquality(mLeft.mSolverVariable,
+                    mRight.mSolverVariable, 0, SolverVariable.STRENGTH_FIXED);
+            system.addEquality(mLeft.mSolverVariable,
+                    mParent.mLeft.mSolverVariable, 0, barrierParentStrength);
+            system.addEquality(mLeft.mSolverVariable,
+                    mParent.mRight.mSolverVariable, 0, barrierParentStrengthOpposite);
+        } else if (mBarrierType == TOP) {
+            system.addEquality(mBottom.mSolverVariable,
+                    mTop.mSolverVariable, 0, SolverVariable.STRENGTH_FIXED);
+            system.addEquality(mTop.mSolverVariable,
+                    mParent.mBottom.mSolverVariable, 0, barrierParentStrength);
+            system.addEquality(mTop.mSolverVariable,
+                    mParent.mTop.mSolverVariable, 0, barrierParentStrengthOpposite);
+        } else if (mBarrierType == BOTTOM) {
+            system.addEquality(mTop.mSolverVariable,
+                    mBottom.mSolverVariable, 0, SolverVariable.STRENGTH_FIXED);
+            system.addEquality(mTop.mSolverVariable,
+                    mParent.mTop.mSolverVariable, 0, barrierParentStrength);
+            system.addEquality(mTop.mSolverVariable,
+                    mParent.mBottom.mSolverVariable, 0, barrierParentStrengthOpposite);
+        }
+    }
+
+    public void setMargin(int margin) {
+        mMargin = margin;
+    }
+
+    public int getMargin() {
+        return mMargin;
+    }
+
+    // @TODO: add description
+    public int getOrientation() {
+        switch (mBarrierType) {
+            case LEFT:
+            case RIGHT:
+                return HORIZONTAL;
+            case TOP:
+            case BOTTOM:
+                return VERTICAL;
+        }
+        return UNKNOWN;
+    }
+
+    // @TODO: add description
+    public boolean allSolved() {
+        if (!USE_RESOLUTION) {
+            return false;
+        }
+        boolean hasAllWidgetsResolved = true;
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (!mAllowsGoneWidget && !widget.allowedInBarrier()) {
+                continue;
+            }
+            if ((mBarrierType == LEFT || mBarrierType == RIGHT)
+                    && !widget.isResolvedHorizontally()) {
+                hasAllWidgetsResolved = false;
+            } else if ((mBarrierType == TOP || mBarrierType == BOTTOM)
+                    && !widget.isResolvedVertically()) {
+                hasAllWidgetsResolved = false;
+            }
+        }
+
+        if (hasAllWidgetsResolved && mWidgetsCount > 0) {
+            // we're done!
+            int barrierPosition = 0;
+            boolean initialized = false;
+            for (int i = 0; i < mWidgetsCount; i++) {
+                ConstraintWidget widget = mWidgets[i];
+                if (!mAllowsGoneWidget && !widget.allowedInBarrier()) {
+                    continue;
+                }
+                if (!initialized) {
+                    if (mBarrierType == LEFT) {
+                        barrierPosition =
+                                widget.getAnchor(ConstraintAnchor.Type.LEFT).getFinalValue();
+                    } else if (mBarrierType == RIGHT) {
+                        barrierPosition =
+                                widget.getAnchor(ConstraintAnchor.Type.RIGHT).getFinalValue();
+                    } else if (mBarrierType == TOP) {
+                        barrierPosition =
+                                widget.getAnchor(ConstraintAnchor.Type.TOP).getFinalValue();
+                    } else if (mBarrierType == BOTTOM) {
+                        barrierPosition =
+                                widget.getAnchor(ConstraintAnchor.Type.BOTTOM).getFinalValue();
+                    }
+                    initialized = true;
+                }
+                if (mBarrierType == LEFT) {
+                    barrierPosition = Math.min(barrierPosition,
+                            widget.getAnchor(ConstraintAnchor.Type.LEFT).getFinalValue());
+                } else if (mBarrierType == RIGHT) {
+                    barrierPosition = Math.max(barrierPosition,
+                            widget.getAnchor(ConstraintAnchor.Type.RIGHT).getFinalValue());
+                } else if (mBarrierType == TOP) {
+                    barrierPosition = Math.min(barrierPosition,
+                            widget.getAnchor(ConstraintAnchor.Type.TOP).getFinalValue());
+                } else if (mBarrierType == BOTTOM) {
+                    barrierPosition = Math.max(barrierPosition,
+                            widget.getAnchor(ConstraintAnchor.Type.BOTTOM).getFinalValue());
+                }
+            }
+            barrierPosition += mMargin;
+            if (mBarrierType == LEFT || mBarrierType == RIGHT) {
+                setFinalHorizontal(barrierPosition, barrierPosition);
+            } else {
+                setFinalVertical(barrierPosition, barrierPosition);
+            }
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("*** BARRIER " + getDebugName()
+                        + " SOLVED TO " + barrierPosition + " ***");
+            }
+            mResolved = true;
+            return true;
+        }
+        return false;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Chain.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Chain.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.GONE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+
+import androidx.constraintlayout.core.ArrayRow;
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.SolverVariable;
+import androidx.constraintlayout.core.widgets.analyzer.Direct;
+
+import java.util.ArrayList;
+
+/**
+ * Chain management and constraints creation
+ */
+public class Chain {
+
+    private static final boolean DEBUG = false;
+    public static final boolean USE_CHAIN_OPTIMIZATION = false;
+
+    /**
+     * Apply specific rules for dealing with chains of widgets.
+     * Chains are defined as a list of widget linked together with bi-directional connections
+     *
+     * @param constraintWidgetContainer root container
+     * @param system                    the linear system we add the equations to
+     * @param widgets                   if this is null or contains any chainheads' widgets,
+     *                                  constrain all chains / the corresponding chains
+     * @param orientation               HORIZONTAL or VERTICAL
+     */
+    public static void applyChainConstraints(
+            ConstraintWidgetContainer constraintWidgetContainer,
+            LinearSystem system,
+            ArrayList<ConstraintWidget> widgets,
+            int orientation) {
+        // what to do:
+        // Don't skip things. Either the element is GONE or not.
+        int offset = 0;
+        int chainsSize = 0;
+        ChainHead[] chainsArray = null;
+        if (orientation == ConstraintWidget.HORIZONTAL) {
+            offset = 0;
+            chainsSize = constraintWidgetContainer.mHorizontalChainsSize;
+            chainsArray = constraintWidgetContainer.mHorizontalChainsArray;
+        } else {
+            offset = 2;
+            chainsSize = constraintWidgetContainer.mVerticalChainsSize;
+            chainsArray = constraintWidgetContainer.mVerticalChainsArray;
+        }
+
+        for (int i = 0; i < chainsSize; i++) {
+            ChainHead first = chainsArray[i];
+            // we have to make sure we define the ChainHead here,
+            // otherwise the values we use may not be correctly initialized
+            // (as we initialize them in the ConstraintWidget.addToSolver())
+            first.define();
+            if (widgets == null || widgets.contains(first.mFirst)) {
+                applyChainConstraints(constraintWidgetContainer,
+                        system, orientation, offset, first);
+            }
+        }
+    }
+
+    /**
+     * Apply specific rules for dealing with chains of widgets.
+     * Chains are defined as a list of widget linked together with bi-directional connections
+     *
+     * @param container   the root container
+     * @param system      the linear system we add the equations to
+     * @param orientation HORIZONTAL or VERTICAL
+     * @param offset      0 or 2 to accommodate for HORIZONTAL / VERTICAL
+     * @param chainHead   a chain represented by its main elements
+     */
+    static void applyChainConstraints(ConstraintWidgetContainer container, LinearSystem system,
+            int orientation, int offset, ChainHead chainHead) {
+        ConstraintWidget first = chainHead.mFirst;
+        ConstraintWidget last = chainHead.mLast;
+        ConstraintWidget firstVisibleWidget = chainHead.mFirstVisibleWidget;
+        ConstraintWidget lastVisibleWidget = chainHead.mLastVisibleWidget;
+        ConstraintWidget head = chainHead.mHead;
+
+        ConstraintWidget widget = first;
+        ConstraintWidget next = null;
+        boolean done = false;
+
+        float totalWeights = chainHead.mTotalWeight;
+        @SuppressWarnings("unused") ConstraintWidget firstMatchConstraintsWidget =
+                chainHead.mFirstMatchConstraintWidget;
+        @SuppressWarnings("unused") ConstraintWidget previousMatchConstraintsWidget =
+                chainHead.mLastMatchConstraintWidget;
+
+        boolean isWrapContent = container.mListDimensionBehaviors[orientation]
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+        boolean isChainSpread = false;
+        boolean isChainSpreadInside = false;
+        boolean isChainPacked = false;
+
+        if (orientation == ConstraintWidget.HORIZONTAL) {
+            isChainSpread = head.mHorizontalChainStyle == ConstraintWidget.CHAIN_SPREAD;
+            isChainSpreadInside =
+                    head.mHorizontalChainStyle == ConstraintWidget.CHAIN_SPREAD_INSIDE;
+            isChainPacked = head.mHorizontalChainStyle == ConstraintWidget.CHAIN_PACKED;
+        } else {
+            isChainSpread = head.mVerticalChainStyle == ConstraintWidget.CHAIN_SPREAD;
+            isChainSpreadInside = head.mVerticalChainStyle == ConstraintWidget.CHAIN_SPREAD_INSIDE;
+            isChainPacked = head.mVerticalChainStyle == ConstraintWidget.CHAIN_PACKED;
+        }
+
+        if (USE_CHAIN_OPTIMIZATION && !isWrapContent
+                && Direct.solveChain(container, system, orientation, offset, chainHead,
+                isChainSpread, isChainSpreadInside, isChainPacked)) {
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("### CHAIN FULLY SOLVED! ###");
+            }
+            return; // done with the chain!
+        } else if (LinearSystem.FULL_DEBUG) {
+            System.out.println("### CHAIN WASN'T SOLVED DIRECTLY... ###");
+        }
+
+        // This traversal will:
+        // - set up some basic ordering constraints
+        // - build a linked list of matched constraints widgets
+        while (!done) {
+            ConstraintAnchor begin = widget.mListAnchors[offset];
+
+            int strength = SolverVariable.STRENGTH_HIGHEST;
+            if (isChainPacked) {
+                strength = SolverVariable.STRENGTH_LOW;
+            }
+            int margin = begin.getMargin();
+            boolean isSpreadOnly = widget.mListDimensionBehaviors[orientation]
+                    == DimensionBehaviour.MATCH_CONSTRAINT
+                    && widget.mResolvedMatchConstraintDefault[orientation]
+                    == MATCH_CONSTRAINT_SPREAD;
+
+            if (begin.mTarget != null && widget != first) {
+                margin += begin.mTarget.getMargin();
+            }
+
+            if (isChainPacked && widget != first && widget != firstVisibleWidget) {
+                strength = SolverVariable.STRENGTH_FIXED;
+            }
+
+            if (begin.mTarget != null) {
+                if (widget == firstVisibleWidget) {
+                    system.addGreaterThan(begin.mSolverVariable, begin.mTarget.mSolverVariable,
+                            margin, SolverVariable.STRENGTH_BARRIER);
+                } else {
+                    system.addGreaterThan(begin.mSolverVariable, begin.mTarget.mSolverVariable,
+                            margin, SolverVariable.STRENGTH_FIXED);
+                }
+                if (isSpreadOnly && !isChainPacked) {
+                    strength = SolverVariable.STRENGTH_EQUALITY;
+                }
+                if (widget == firstVisibleWidget && isChainPacked
+                        && widget.isInBarrier(orientation)) {
+                    strength = SolverVariable.STRENGTH_EQUALITY;
+                }
+                system.addEquality(begin.mSolverVariable, begin.mTarget.mSolverVariable, margin,
+                        strength);
+            }
+
+            if (isWrapContent) {
+                if (widget.getVisibility() != ConstraintWidget.GONE
+                        && widget.mListDimensionBehaviors[orientation]
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+                    system.addGreaterThan(widget.mListAnchors[offset + 1].mSolverVariable,
+                            widget.mListAnchors[offset].mSolverVariable, 0,
+                            SolverVariable.STRENGTH_EQUALITY);
+                }
+                system.addGreaterThan(widget.mListAnchors[offset].mSolverVariable,
+                        container.mListAnchors[offset].mSolverVariable,
+                        0, SolverVariable.STRENGTH_FIXED);
+            }
+
+            // go to the next widget
+            ConstraintAnchor nextAnchor = widget.mListAnchors[offset + 1].mTarget;
+            if (nextAnchor != null) {
+                next = nextAnchor.mOwner;
+                if (next.mListAnchors[offset].mTarget == null
+                        || next.mListAnchors[offset].mTarget.mOwner != widget) {
+                    next = null;
+                }
+            } else {
+                next = null;
+            }
+            if (next != null) {
+                widget = next;
+            } else {
+                done = true;
+            }
+        }
+
+        // Make sure we have constraints for the last anchors / targets
+        if (lastVisibleWidget != null && last.mListAnchors[offset + 1].mTarget != null) {
+            ConstraintAnchor end = lastVisibleWidget.mListAnchors[offset + 1];
+            boolean isSpreadOnly = lastVisibleWidget.mListDimensionBehaviors[orientation]
+                    == DimensionBehaviour.MATCH_CONSTRAINT
+                    && lastVisibleWidget.mResolvedMatchConstraintDefault[orientation]
+                    == MATCH_CONSTRAINT_SPREAD;
+            if (isSpreadOnly && !isChainPacked && end.mTarget.mOwner == container) {
+                system.addEquality(end.mSolverVariable, end.mTarget.mSolverVariable,
+                        -end.getMargin(), SolverVariable.STRENGTH_EQUALITY);
+            } else if (isChainPacked && end.mTarget.mOwner == container) {
+                system.addEquality(end.mSolverVariable, end.mTarget.mSolverVariable,
+                        -end.getMargin(), SolverVariable.STRENGTH_HIGHEST);
+            }
+            system.addLowerThan(end.mSolverVariable,
+                    last.mListAnchors[offset + 1].mTarget.mSolverVariable, -end.getMargin(),
+                    SolverVariable.STRENGTH_BARRIER);
+        }
+
+        // ... and make sure the root end is constrained in wrap content.
+        if (isWrapContent) {
+            system.addGreaterThan(container.mListAnchors[offset + 1].mSolverVariable,
+                    last.mListAnchors[offset + 1].mSolverVariable,
+                    last.mListAnchors[offset + 1].getMargin(), SolverVariable.STRENGTH_FIXED);
+        }
+
+        // Now, let's apply the centering / spreading for matched constraints widgets
+        ArrayList<ConstraintWidget> listMatchConstraints =
+                chainHead.mWeightedMatchConstraintsWidgets;
+        if (listMatchConstraints != null) {
+            final int count = listMatchConstraints.size();
+            if (count > 1) {
+                ConstraintWidget lastMatch = null;
+                float lastWeight = 0;
+
+                if (chainHead.mHasUndefinedWeights && !chainHead.mHasComplexMatchWeights) {
+                    totalWeights = chainHead.mWidgetsMatchCount;
+                }
+
+                for (int i = 0; i < count; i++) {
+                    ConstraintWidget match = listMatchConstraints.get(i);
+                    float currentWeight = match.mWeight[orientation];
+
+                    if (currentWeight < 0) {
+                        if (chainHead.mHasComplexMatchWeights) {
+                            system.addEquality(match.mListAnchors[offset + 1].mSolverVariable,
+                                    match.mListAnchors[offset].mSolverVariable,
+                                    0, SolverVariable.STRENGTH_HIGHEST);
+                            continue;
+                        }
+                        currentWeight = 1;
+                    }
+                    if (currentWeight == 0) {
+                        system.addEquality(match.mListAnchors[offset + 1].mSolverVariable,
+                                match.mListAnchors[offset].mSolverVariable,
+                                0, SolverVariable.STRENGTH_FIXED);
+                        continue;
+                    }
+
+                    if (lastMatch != null) {
+                        SolverVariable begin = lastMatch.mListAnchors[offset].mSolverVariable;
+                        SolverVariable end = lastMatch.mListAnchors[offset + 1].mSolverVariable;
+                        SolverVariable nextBegin = match.mListAnchors[offset].mSolverVariable;
+                        SolverVariable nextEnd = match.mListAnchors[offset + 1].mSolverVariable;
+                        ArrayRow row = system.createRow();
+                        row.createRowEqualMatchDimensions(lastWeight, totalWeights, currentWeight,
+                                begin, end, nextBegin, nextEnd);
+                        system.addConstraint(row);
+                    }
+
+                    lastMatch = match;
+                    lastWeight = currentWeight;
+                }
+            }
+        }
+
+        if (DEBUG) {
+            widget = firstVisibleWidget;
+            while (widget != null) {
+                next = widget.mNextChainWidget[orientation];
+                widget.mListAnchors[offset].mSolverVariable
+                        .setName("" + widget.getDebugName() + ".left");
+                widget.mListAnchors[offset + 1].mSolverVariable
+                        .setName("" + widget.getDebugName() + ".right");
+                widget = next;
+            }
+        }
+
+        // Finally, let's apply the specific rules dealing with the different chain types
+
+        if (firstVisibleWidget != null
+                && (firstVisibleWidget == lastVisibleWidget || isChainPacked)) {
+            ConstraintAnchor begin = first.mListAnchors[offset];
+            ConstraintAnchor end = last.mListAnchors[offset + 1];
+            SolverVariable beginTarget = begin.mTarget != null
+                    ? begin.mTarget.mSolverVariable : null;
+            SolverVariable endTarget = end.mTarget != null ? end.mTarget.mSolverVariable : null;
+            begin = firstVisibleWidget.mListAnchors[offset];
+            if (lastVisibleWidget != null) {
+                end = lastVisibleWidget.mListAnchors[offset + 1];
+            }
+            if (beginTarget != null && endTarget != null) {
+                float bias = 0.5f;
+                if (orientation == ConstraintWidget.HORIZONTAL) {
+                    bias = head.mHorizontalBiasPercent;
+                } else {
+                    bias = head.mVerticalBiasPercent;
+                }
+                int beginMargin = begin.getMargin();
+                int endMargin = end.getMargin();
+                system.addCentering(begin.mSolverVariable, beginTarget,
+                        beginMargin, bias, endTarget, end.mSolverVariable,
+                        endMargin, SolverVariable.STRENGTH_CENTERING);
+            }
+        } else if (isChainSpread && firstVisibleWidget != null) {
+            // for chain spread, we need to add equal dimensions in between *visible* widgets
+            widget = firstVisibleWidget;
+            ConstraintWidget previousVisibleWidget = firstVisibleWidget;
+            boolean applyFixedEquality = chainHead.mWidgetsMatchCount > 0
+                    && (chainHead.mWidgetsCount == chainHead.mWidgetsMatchCount);
+            while (widget != null) {
+                next = widget.mNextChainWidget[orientation];
+                while (next != null && next.getVisibility() == GONE) {
+                    next = next.mNextChainWidget[orientation];
+                }
+                if (next != null || widget == lastVisibleWidget) {
+                    ConstraintAnchor beginAnchor = widget.mListAnchors[offset];
+                    SolverVariable begin = beginAnchor.mSolverVariable;
+                    SolverVariable beginTarget = beginAnchor.mTarget != null
+                            ? beginAnchor.mTarget.mSolverVariable : null;
+                    if (previousVisibleWidget != widget) {
+                        beginTarget =
+                                previousVisibleWidget.mListAnchors[offset + 1].mSolverVariable;
+                    } else if (widget == firstVisibleWidget) {
+                        beginTarget = first.mListAnchors[offset].mTarget != null
+                                ? first.mListAnchors[offset].mTarget.mSolverVariable : null;
+                    }
+
+                    ConstraintAnchor beginNextAnchor = null;
+                    SolverVariable beginNext = null;
+                    @SuppressWarnings("unused") SolverVariable beginNextTarget = null;
+                    int beginMargin = beginAnchor.getMargin();
+                    int nextMargin = widget.mListAnchors[offset + 1].getMargin();
+
+                    if (next != null) {
+                        beginNextAnchor = next.mListAnchors[offset];
+                        beginNext = beginNextAnchor.mSolverVariable;
+                    } else {
+                        beginNextAnchor = last.mListAnchors[offset + 1].mTarget;
+                        if (beginNextAnchor != null) {
+                            beginNext = beginNextAnchor.mSolverVariable;
+                        }
+                    }
+                    beginNextTarget = widget.mListAnchors[offset + 1].mSolverVariable;
+
+                    if (beginNextAnchor != null) {
+                        nextMargin += beginNextAnchor.getMargin();
+                    }
+                    beginMargin += previousVisibleWidget.mListAnchors[offset + 1].getMargin();
+                    if (begin != null && beginTarget != null
+                            && beginNext != null && beginNextTarget != null) {
+                        int margin1 = beginMargin;
+                        if (widget == firstVisibleWidget) {
+                            margin1 = firstVisibleWidget.mListAnchors[offset].getMargin();
+                        }
+                        int margin2 = nextMargin;
+                        if (widget == lastVisibleWidget) {
+                            margin2 = lastVisibleWidget.mListAnchors[offset + 1].getMargin();
+                        }
+                        int strength = SolverVariable.STRENGTH_EQUALITY;
+                        if (applyFixedEquality) {
+                            strength = SolverVariable.STRENGTH_FIXED;
+                        }
+                        system.addCentering(begin, beginTarget, margin1, 0.5f,
+                                beginNext, beginNextTarget, margin2,
+                                strength);
+                    }
+                }
+                if (widget.getVisibility() != GONE) {
+                    previousVisibleWidget = widget;
+                }
+                widget = next;
+            }
+        } else if (isChainSpreadInside && firstVisibleWidget != null) {
+            // for chain spread inside, we need to add equal dimensions in between *visible* widgets
+            widget = firstVisibleWidget;
+            ConstraintWidget previousVisibleWidget = firstVisibleWidget;
+            boolean applyFixedEquality = chainHead.mWidgetsMatchCount > 0
+                    && (chainHead.mWidgetsCount == chainHead.mWidgetsMatchCount);
+            while (widget != null) {
+                next = widget.mNextChainWidget[orientation];
+                while (next != null && next.getVisibility() == GONE) {
+                    next = next.mNextChainWidget[orientation];
+                }
+                if (widget != firstVisibleWidget && widget != lastVisibleWidget && next != null) {
+                    if (next == lastVisibleWidget) {
+                        next = null;
+                    }
+                    ConstraintAnchor beginAnchor = widget.mListAnchors[offset];
+                    SolverVariable begin = beginAnchor.mSolverVariable;
+                    @SuppressWarnings("unused") SolverVariable beginTarget =
+                            beginAnchor.mTarget != null
+                            ? beginAnchor.mTarget.mSolverVariable : null;
+                    beginTarget = previousVisibleWidget.mListAnchors[offset + 1].mSolverVariable;
+                    ConstraintAnchor beginNextAnchor = null;
+                    SolverVariable beginNext = null;
+                    SolverVariable beginNextTarget = null;
+                    int beginMargin = beginAnchor.getMargin();
+                    int nextMargin = widget.mListAnchors[offset + 1].getMargin();
+
+                    if (next != null) {
+                        beginNextAnchor = next.mListAnchors[offset];
+                        beginNext = beginNextAnchor.mSolverVariable;
+                        beginNextTarget = beginNextAnchor.mTarget != null
+                                ? beginNextAnchor.mTarget.mSolverVariable : null;
+                    } else {
+                        beginNextAnchor = lastVisibleWidget.mListAnchors[offset];
+                        if (beginNextAnchor != null) {
+                            beginNext = beginNextAnchor.mSolverVariable;
+                        }
+                        beginNextTarget = widget.mListAnchors[offset + 1].mSolverVariable;
+                    }
+
+                    if (beginNextAnchor != null) {
+                        nextMargin += beginNextAnchor.getMargin();
+                    }
+                    beginMargin += previousVisibleWidget.mListAnchors[offset + 1].getMargin();
+                    int strength = SolverVariable.STRENGTH_HIGHEST;
+                    if (applyFixedEquality) {
+                        strength = SolverVariable.STRENGTH_FIXED;
+                    }
+                    if (begin != null && beginTarget != null
+                            && beginNext != null && beginNextTarget != null) {
+                        system.addCentering(begin, beginTarget, beginMargin, 0.5f,
+                                beginNext, beginNextTarget, nextMargin,
+                                strength);
+                    }
+                }
+                if (widget.getVisibility() != GONE) {
+                    previousVisibleWidget = widget;
+                }
+                widget = next;
+            }
+            ConstraintAnchor begin = firstVisibleWidget.mListAnchors[offset];
+            ConstraintAnchor beginTarget = first.mListAnchors[offset].mTarget;
+            ConstraintAnchor end = lastVisibleWidget.mListAnchors[offset + 1];
+            ConstraintAnchor endTarget = last.mListAnchors[offset + 1].mTarget;
+            int endPointsStrength = SolverVariable.STRENGTH_EQUALITY;
+            if (beginTarget != null) {
+                if (firstVisibleWidget != lastVisibleWidget) {
+                    system.addEquality(begin.mSolverVariable, beginTarget.mSolverVariable,
+                            begin.getMargin(), endPointsStrength);
+                } else if (endTarget != null) {
+                    system.addCentering(begin.mSolverVariable, beginTarget.mSolverVariable,
+                            begin.getMargin(), 0.5f, end.mSolverVariable, endTarget.mSolverVariable,
+                            end.getMargin(), endPointsStrength);
+                }
+            }
+            if (endTarget != null && (firstVisibleWidget != lastVisibleWidget)) {
+                system.addEquality(end.mSolverVariable,
+                        endTarget.mSolverVariable, -end.getMargin(), endPointsStrength);
+            }
+
+        }
+
+        // final centering, necessary if the chain is larger than the available space...
+        if ((isChainSpread || isChainSpreadInside) && firstVisibleWidget
+                != null && firstVisibleWidget != lastVisibleWidget) {
+            ConstraintAnchor begin = firstVisibleWidget.mListAnchors[offset];
+            if (lastVisibleWidget == null) {
+                lastVisibleWidget = firstVisibleWidget;
+            }
+            ConstraintAnchor end = lastVisibleWidget.mListAnchors[offset + 1];
+            SolverVariable beginTarget =
+                    begin.mTarget != null ? begin.mTarget.mSolverVariable : null;
+            SolverVariable endTarget = end.mTarget != null ? end.mTarget.mSolverVariable : null;
+            if (last != lastVisibleWidget) {
+                ConstraintAnchor realEnd = last.mListAnchors[offset + 1];
+                endTarget = realEnd.mTarget != null ? realEnd.mTarget.mSolverVariable : null;
+            }
+            if (firstVisibleWidget == lastVisibleWidget) {
+                begin = firstVisibleWidget.mListAnchors[offset];
+                end = firstVisibleWidget.mListAnchors[offset + 1];
+            }
+            if (beginTarget != null && endTarget != null) {
+                float bias = 0.5f;
+                int beginMargin = begin.getMargin();
+                int endMargin = lastVisibleWidget.mListAnchors[offset + 1].getMargin();
+                system.addCentering(begin.mSolverVariable, beginTarget, beginMargin,
+                        bias, endTarget, end.mSolverVariable, endMargin,
+                        SolverVariable.STRENGTH_EQUALITY);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ChainHead.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ChainHead.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_RATIO;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour;
+
+import java.util.ArrayList;
+
+/**
+ * Class to represent a chain by its main elements.
+ */
+public class ChainHead {
+
+    protected ConstraintWidget mFirst;
+    protected ConstraintWidget mFirstVisibleWidget;
+    protected ConstraintWidget mLast;
+    protected ConstraintWidget mLastVisibleWidget;
+    protected ConstraintWidget mHead;
+    protected ConstraintWidget mFirstMatchConstraintWidget;
+    protected ConstraintWidget mLastMatchConstraintWidget;
+    protected ArrayList<ConstraintWidget> mWeightedMatchConstraintsWidgets;
+    protected int mWidgetsCount;
+    protected int mWidgetsMatchCount;
+    protected float mTotalWeight = 0f;
+    int mVisibleWidgets;
+    int mTotalSize;
+    int mTotalMargins;
+    boolean mOptimizable;
+    private int mOrientation;
+    private boolean mIsRtl = false;
+    protected boolean mHasUndefinedWeights;
+    protected boolean mHasDefinedWeights;
+    protected boolean mHasComplexMatchWeights;
+    protected boolean mHasRatio;
+    private boolean mDefined;
+
+    /**
+     * Initialize variables, then determine visible widgets, the head of chain and
+     * matched constraint widgets.
+     *
+     * @param first       first widget in a chain
+     * @param orientation orientation of the chain (either Horizontal or Vertical)
+     * @param isRtl       Right-to-left layout flag to determine the actual head of the chain
+     */
+    public ChainHead(ConstraintWidget first, int orientation, boolean isRtl) {
+        mFirst = first;
+        mOrientation = orientation;
+        mIsRtl = isRtl;
+    }
+
+    /**
+     * Returns true if the widget should be part of the match equality rules in the chain
+     *
+     * @param widget      the widget to test
+     * @param orientation current orientation, HORIZONTAL or VERTICAL
+     */
+    private static boolean isMatchConstraintEqualityCandidate(ConstraintWidget widget,
+            int orientation) {
+        return widget.getVisibility() != ConstraintWidget.GONE
+                && widget.mListDimensionBehaviors[orientation]
+                == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && (widget.mResolvedMatchConstraintDefault[orientation] == MATCH_CONSTRAINT_SPREAD
+                || widget.mResolvedMatchConstraintDefault[orientation] == MATCH_CONSTRAINT_RATIO);
+    }
+
+    private void defineChainProperties() {
+        int offset = mOrientation * 2;
+        ConstraintWidget lastVisited = mFirst;
+        mOptimizable = true;
+
+        // TraverseChain
+        ConstraintWidget widget = mFirst;
+        ConstraintWidget next = mFirst;
+        boolean done = false;
+        while (!done) {
+            mWidgetsCount++;
+            widget.mNextChainWidget[mOrientation] = null;
+            widget.mListNextMatchConstraintsWidget[mOrientation] = null;
+            if (widget.getVisibility() != ConstraintWidget.GONE) {
+                mVisibleWidgets++;
+                if (widget.getDimensionBehaviour(mOrientation)
+                        != DimensionBehaviour.MATCH_CONSTRAINT) {
+                    mTotalSize += widget.getLength(mOrientation);
+                }
+                mTotalSize += widget.mListAnchors[offset].getMargin();
+                mTotalSize += widget.mListAnchors[offset + 1].getMargin();
+                mTotalMargins += widget.mListAnchors[offset].getMargin();
+                mTotalMargins += widget.mListAnchors[offset + 1].getMargin();
+                // Visible widgets linked list.
+                if (mFirstVisibleWidget == null) {
+                    mFirstVisibleWidget = widget;
+                }
+                mLastVisibleWidget = widget;
+
+                // Match constraint linked list.
+                if (widget.mListDimensionBehaviors[mOrientation]
+                        == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    if (widget.mResolvedMatchConstraintDefault[mOrientation]
+                            == MATCH_CONSTRAINT_SPREAD
+                            || widget.mResolvedMatchConstraintDefault[mOrientation]
+                            == MATCH_CONSTRAINT_RATIO
+                            || widget.mResolvedMatchConstraintDefault[mOrientation]
+                            == MATCH_CONSTRAINT_PERCENT) {
+                        mWidgetsMatchCount++;
+                        // Note: Might cause an issue if we support MATCH_CONSTRAINT_RATIO_RESOLVED
+                        // in chain optimization. (we currently don't)
+                        float weight = widget.mWeight[mOrientation];
+                        if (weight > 0) {
+                            mTotalWeight += widget.mWeight[mOrientation];
+                        }
+
+                        if (isMatchConstraintEqualityCandidate(widget, mOrientation)) {
+                            if (weight < 0) {
+                                mHasUndefinedWeights = true;
+                            } else {
+                                mHasDefinedWeights = true;
+                            }
+                            if (mWeightedMatchConstraintsWidgets == null) {
+                                mWeightedMatchConstraintsWidgets = new ArrayList<>();
+                            }
+                            mWeightedMatchConstraintsWidgets.add(widget);
+                        }
+
+                        if (mFirstMatchConstraintWidget == null) {
+                            mFirstMatchConstraintWidget = widget;
+                        }
+                        if (mLastMatchConstraintWidget != null) {
+                            mLastMatchConstraintWidget
+                                    .mListNextMatchConstraintsWidget[mOrientation] = widget;
+                        }
+                        mLastMatchConstraintWidget = widget;
+                    }
+                    if (mOrientation == ConstraintWidget.HORIZONTAL) {
+                        if (widget.mMatchConstraintDefaultWidth
+                                != ConstraintWidget.MATCH_CONSTRAINT_SPREAD) {
+                            mOptimizable = false;
+                        } else if (widget.mMatchConstraintMinWidth != 0
+                                || widget.mMatchConstraintMaxWidth != 0) {
+                            mOptimizable = false;
+                        }
+                    } else {
+                        if (widget.mMatchConstraintDefaultHeight
+                                != ConstraintWidget.MATCH_CONSTRAINT_SPREAD) {
+                            mOptimizable = false;
+                        } else if (widget.mMatchConstraintMinHeight != 0
+                                || widget.mMatchConstraintMaxHeight != 0) {
+                            mOptimizable = false;
+                        }
+                    }
+                    if (widget.mDimensionRatio != 0.0f) {
+                        //TODO: Improve (Could use ratio optimization).
+                        mOptimizable = false;
+                        mHasRatio = true;
+                    }
+                }
+            }
+            if (lastVisited != widget) {
+                lastVisited.mNextChainWidget[mOrientation] = widget;
+            }
+            lastVisited = widget;
+
+            // go to the next widget
+            ConstraintAnchor nextAnchor = widget.mListAnchors[offset + 1].mTarget;
+            if (nextAnchor != null) {
+                next = nextAnchor.mOwner;
+                if (next.mListAnchors[offset].mTarget == null
+                        || next.mListAnchors[offset].mTarget.mOwner != widget) {
+                    next = null;
+                }
+            } else {
+                next = null;
+            }
+            if (next != null) {
+                widget = next;
+            } else {
+                done = true;
+            }
+        }
+        if (mFirstVisibleWidget != null) {
+            mTotalSize -= mFirstVisibleWidget.mListAnchors[offset].getMargin();
+        }
+        if (mLastVisibleWidget != null) {
+            mTotalSize -= mLastVisibleWidget.mListAnchors[offset + 1].getMargin();
+        }
+        mLast = widget;
+
+        if (mOrientation == ConstraintWidget.HORIZONTAL && mIsRtl) {
+            mHead = mLast;
+        } else {
+            mHead = mFirst;
+        }
+
+        mHasComplexMatchWeights = mHasDefinedWeights && mHasUndefinedWeights;
+    }
+
+    public ConstraintWidget getFirst() {
+        return mFirst;
+    }
+
+    public ConstraintWidget getFirstVisibleWidget() {
+        return mFirstVisibleWidget;
+    }
+
+    public ConstraintWidget getLast() {
+        return mLast;
+    }
+
+    public ConstraintWidget getLastVisibleWidget() {
+        return mLastVisibleWidget;
+    }
+
+    public ConstraintWidget getHead() {
+        return mHead;
+    }
+
+    public ConstraintWidget getFirstMatchConstraintWidget() {
+        return mFirstMatchConstraintWidget;
+    }
+
+    public ConstraintWidget getLastMatchConstraintWidget() {
+        return mLastMatchConstraintWidget;
+    }
+
+    public float getTotalWeight() {
+        return mTotalWeight;
+    }
+
+    // @TODO: add description
+    public void define() {
+        if (!mDefined) {
+            defineChainProperties();
+        }
+        mDefined = true;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintAnchor.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintAnchor.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+import androidx.constraintlayout.core.Cache;
+import androidx.constraintlayout.core.SolverVariable;
+import androidx.constraintlayout.core.widgets.analyzer.Grouping;
+import androidx.constraintlayout.core.widgets.analyzer.WidgetGroup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Model a constraint relation. Widgets contains anchors, and a constraint relation between
+ * two widgets is made by connecting one anchor to another. The anchor will contains a pointer
+ * to the target anchor if it is connected.
+ */
+public class ConstraintAnchor {
+
+    private static final boolean ALLOW_BINARY = false;
+
+    private HashSet<ConstraintAnchor> mDependents = null;
+    private int mFinalValue;
+    private boolean mHasFinalValue;
+
+    // @TODO: add description
+    public void findDependents(int orientation, ArrayList<WidgetGroup> list, WidgetGroup group) {
+        if (mDependents != null) {
+            for (ConstraintAnchor anchor : mDependents) {
+                Grouping.findDependents(anchor.mOwner, orientation, list, group);
+            }
+        }
+    }
+
+    public HashSet<ConstraintAnchor> getDependents() {
+        return mDependents;
+    }
+
+    // @TODO: add description
+    public boolean hasDependents() {
+        if (mDependents == null) {
+            return false;
+        }
+        return mDependents.size() > 0;
+    }
+
+    // @TODO: add description
+    public boolean hasCenteredDependents() {
+        if (mDependents == null) {
+            return false;
+        }
+        for (ConstraintAnchor anchor : mDependents) {
+            ConstraintAnchor opposite = anchor.getOpposite();
+            if (opposite.isConnected()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    public void setFinalValue(int finalValue) {
+        this.mFinalValue = finalValue;
+        this.mHasFinalValue = true;
+    }
+
+    // @TODO: add description
+    public int getFinalValue() {
+        if (!mHasFinalValue) {
+            return 0;
+        }
+        return mFinalValue;
+    }
+
+    // @TODO: add description
+    public void resetFinalResolution() {
+        mHasFinalValue = false;
+        mFinalValue = 0;
+    }
+
+    // @TODO: add description
+    public boolean hasFinalValue() {
+        return mHasFinalValue;
+    }
+
+    /**
+     * Define the type of anchor
+     */
+    public enum Type {NONE, LEFT, TOP, RIGHT, BOTTOM, BASELINE, CENTER, CENTER_X, CENTER_Y}
+
+    private static final int UNSET_GONE_MARGIN = Integer.MIN_VALUE;
+
+    public final ConstraintWidget mOwner;
+    public final Type mType;
+    public ConstraintAnchor mTarget;
+    public int mMargin = 0;
+    int mGoneMargin = UNSET_GONE_MARGIN;
+
+    SolverVariable mSolverVariable;
+
+    // @TODO: add description
+    public void copyFrom(ConstraintAnchor source, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        if (mTarget != null) {
+            if (mTarget.mDependents != null) {
+                mTarget.mDependents.remove(this);
+            }
+        }
+        if (source.mTarget != null) {
+            Type type = source.mTarget.getType();
+            ConstraintWidget owner = map.get(source.mTarget.mOwner);
+            mTarget = owner.getAnchor(type);
+        } else {
+            mTarget = null;
+        }
+        if (mTarget != null) {
+            if (mTarget.mDependents == null) {
+                mTarget.mDependents = new HashSet<>();
+            }
+            mTarget.mDependents.add(this);
+        }
+        mMargin = source.mMargin;
+        mGoneMargin = source.mGoneMargin;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param owner the widget owner of this anchor.
+     * @param type  the anchor type.
+     */
+    public ConstraintAnchor(ConstraintWidget owner, Type type) {
+        mOwner = owner;
+        mType = type;
+    }
+
+    /**
+     * Return the solver variable for this anchor
+     */
+    public SolverVariable getSolverVariable() {
+        return mSolverVariable;
+    }
+
+    /**
+     * Reset the solver variable
+     */
+    public void resetSolverVariable(Cache cache) {
+        if (mSolverVariable == null) {
+            mSolverVariable = new SolverVariable(SolverVariable.Type.UNRESTRICTED, null);
+        } else {
+            mSolverVariable.reset();
+        }
+    }
+
+    /**
+     * Return the anchor's owner
+     *
+     * @return the Widget owning the anchor
+     */
+    public ConstraintWidget getOwner() {
+        return mOwner;
+    }
+
+    /**
+     * Return the type of the anchor
+     *
+     * @return type of the anchor.
+     */
+    public Type getType() {
+        return mType;
+    }
+
+    /**
+     * Return the connection's margin from this anchor to its target.
+     *
+     * @return the margin value. 0 if not connected.
+     */
+    public int getMargin() {
+        if (mOwner.getVisibility() == ConstraintWidget.GONE) {
+            return 0;
+        }
+        if (mGoneMargin != UNSET_GONE_MARGIN && mTarget != null
+                && mTarget.mOwner.getVisibility() == ConstraintWidget.GONE) {
+            return mGoneMargin;
+        }
+        return mMargin;
+    }
+
+    /**
+     * Return the connection's target (null if not connected)
+     *
+     * @return the ConstraintAnchor target
+     */
+    public ConstraintAnchor getTarget() {
+        return mTarget;
+    }
+
+    /**
+     * Resets the anchor's connection.
+     */
+    public void reset() {
+        if (mTarget != null && mTarget.mDependents != null) {
+            mTarget.mDependents.remove(this);
+            if (mTarget.mDependents.size() == 0) {
+                mTarget.mDependents = null;
+            }
+        }
+        mDependents = null;
+        mTarget = null;
+        mMargin = 0;
+        mGoneMargin = UNSET_GONE_MARGIN;
+        mHasFinalValue = false;
+        mFinalValue = 0;
+    }
+
+    /**
+     * Connects this anchor to another one.
+     *
+     * @return true if the connection succeeds.
+     */
+    public boolean connect(ConstraintAnchor toAnchor, int margin, int goneMargin,
+            boolean forceConnection) {
+        if (toAnchor == null) {
+            reset();
+            return true;
+        }
+        if (!forceConnection && !isValidConnection(toAnchor)) {
+            return false;
+        }
+        mTarget = toAnchor;
+        if (mTarget.mDependents == null) {
+            mTarget.mDependents = new HashSet<>();
+        }
+        if (mTarget.mDependents != null) {
+            mTarget.mDependents.add(this);
+        }
+        mMargin = margin;
+        mGoneMargin = goneMargin;
+        return true;
+    }
+
+
+    /**
+     * Connects this anchor to another one.
+     *
+     * @return true if the connection succeeds.
+     */
+    public boolean connect(ConstraintAnchor toAnchor, int margin) {
+        return connect(toAnchor, margin, UNSET_GONE_MARGIN, false);
+    }
+
+    /**
+     * Returns the connection status of this anchor
+     *
+     * @return true if the anchor is connected to another one.
+     */
+    public boolean isConnected() {
+        return mTarget != null;
+    }
+
+    /**
+     * Checks if the connection to a given anchor is valid.
+     *
+     * @param anchor the anchor we want to connect to
+     * @return true if it's a compatible anchor
+     */
+    public boolean isValidConnection(ConstraintAnchor anchor) {
+        if (anchor == null) {
+            return false;
+        }
+        Type target = anchor.getType();
+        if (target == mType) {
+            if (mType == Type.BASELINE
+                    && (!anchor.getOwner().hasBaseline() || !getOwner().hasBaseline())) {
+                return false;
+            }
+            return true;
+        }
+        switch (mType) {
+            case CENTER: {
+                // allow everything but baseline and center_x/center_y
+                return target != Type.BASELINE && target != Type.CENTER_X
+                        && target != Type.CENTER_Y;
+            }
+            case LEFT:
+            case RIGHT: {
+                boolean isCompatible = target == Type.LEFT || target == Type.RIGHT;
+                if (anchor.getOwner() instanceof Guideline) {
+                    isCompatible = isCompatible || target == Type.CENTER_X;
+                }
+                return isCompatible;
+            }
+            case TOP:
+            case BOTTOM: {
+                boolean isCompatible = target == Type.TOP || target == Type.BOTTOM;
+                if (anchor.getOwner() instanceof Guideline) {
+                    isCompatible = isCompatible || target == Type.CENTER_Y;
+                }
+                return isCompatible;
+            }
+            case BASELINE: {
+                if (target == Type.LEFT || target == Type.RIGHT) {
+                    return false;
+                }
+                return true;
+            }
+            case CENTER_X:
+            case CENTER_Y:
+            case NONE:
+                return false;
+        }
+        throw new AssertionError(mType.name());
+    }
+
+    /**
+     * Return true if this anchor is a side anchor
+     *
+     * @return true if side anchor
+     */
+    public boolean isSideAnchor() {
+        switch (mType) {
+            case LEFT:
+            case RIGHT:
+            case TOP:
+            case BOTTOM:
+                return true;
+            case BASELINE:
+            case CENTER:
+            case CENTER_X:
+            case CENTER_Y:
+            case NONE:
+                return false;
+        }
+        throw new AssertionError(mType.name());
+    }
+
+    /**
+     * Return true if the connection to the given anchor is in the
+     * same dimension (horizontal or vertical)
+     *
+     * @param anchor the anchor we want to connect to
+     * @return true if it's an anchor on the same dimension
+     */
+    public boolean isSimilarDimensionConnection(ConstraintAnchor anchor) {
+        Type target = anchor.getType();
+        if (target == mType) {
+            return true;
+        }
+        switch (mType) {
+            case CENTER: {
+                return target != Type.BASELINE;
+            }
+            case LEFT:
+            case RIGHT:
+            case CENTER_X: {
+                return target == Type.LEFT || target == Type.RIGHT || target == Type.CENTER_X;
+            }
+            case TOP:
+            case BOTTOM:
+            case CENTER_Y:
+            case BASELINE: {
+                return target == Type.TOP || target == Type.BOTTOM
+                        || target == Type.CENTER_Y || target == Type.BASELINE;
+            }
+            case NONE:
+                return false;
+        }
+        throw new AssertionError(mType.name());
+    }
+
+    /**
+     * Set the margin of the connection (if there's one)
+     *
+     * @param margin the new margin of the connection
+     */
+    public void setMargin(int margin) {
+        if (isConnected()) {
+            mMargin = margin;
+        }
+    }
+
+    /**
+     * Set the gone margin of the connection (if there's one)
+     *
+     * @param margin the new margin of the connection
+     */
+    public void setGoneMargin(int margin) {
+        if (isConnected()) {
+            mGoneMargin = margin;
+        }
+    }
+
+    /**
+     * Utility function returning true if this anchor is a vertical one.
+     *
+     * @return true if vertical anchor, false otherwise
+     */
+    public boolean isVerticalAnchor() {
+        switch (mType) {
+            case LEFT:
+            case RIGHT:
+            case CENTER:
+            case CENTER_X:
+                return false;
+            case CENTER_Y:
+            case TOP:
+            case BOTTOM:
+            case BASELINE:
+            case NONE:
+                return true;
+        }
+        throw new AssertionError(mType.name());
+    }
+
+    /**
+     * Return a string representation of this anchor
+     *
+     * @return string representation of the anchor
+     */
+    @Override
+    public String toString() {
+        return mOwner.getDebugName() + ":" + mType.toString();
+    }
+
+    /**
+     * Return true if we can connect this anchor to this target.
+     * We recursively follow connections in order to detect eventual cycles; if we
+     * do we disallow the connection.
+     * We also only allow connections to direct parent, siblings, and descendants.
+     *
+     * @param target the ConstraintWidget we are trying to connect to
+     * @param anchor Allow anchor if it loops back to me directly
+     * @return if the connection is allowed, false otherwise
+     */
+    public boolean isConnectionAllowed(ConstraintWidget target, ConstraintAnchor anchor) {
+        if (ALLOW_BINARY) {
+            if (anchor != null && anchor.getTarget() == this) {
+                return true;
+            }
+        }
+        return isConnectionAllowed(target);
+    }
+
+    /**
+     * Return true if we can connect this anchor to this target.
+     * We recursively follow connections in order to detect eventual cycles; if we
+     * do we disallow the connection.
+     * We also only allow connections to direct parent, siblings, and descendants.
+     *
+     * @param target the ConstraintWidget we are trying to connect to
+     * @return true if the connection is allowed, false otherwise
+     */
+    public boolean isConnectionAllowed(ConstraintWidget target) {
+        HashSet<ConstraintWidget> checked = new HashSet<>();
+        if (isConnectionToMe(target, checked)) {
+            return false;
+        }
+        ConstraintWidget parent = getOwner().getParent();
+        if (parent == target) { // allow connections to parent
+            return true;
+        }
+        if (target.getParent() == parent) { // allow if we share the same parent
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Recursive with check for loop
+     *
+     * @param checked set of things already checked
+     * @return true if it is connected to me
+     */
+    private boolean isConnectionToMe(ConstraintWidget target, HashSet<ConstraintWidget> checked) {
+        if (checked.contains(target)) {
+            return false;
+        }
+        checked.add(target);
+
+        if (target == getOwner()) {
+            return true;
+        }
+        ArrayList<ConstraintAnchor> targetAnchors = target.getAnchors();
+        for (int i = 0, targetAnchorsSize = targetAnchors.size(); i < targetAnchorsSize; i++) {
+            ConstraintAnchor anchor = targetAnchors.get(i);
+            if (anchor.isSimilarDimensionConnection(this) && anchor.isConnected()) {
+                if (isConnectionToMe(anchor.getTarget().getOwner(), checked)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the opposite anchor to this one
+     *
+     * @return opposite anchor
+     */
+    public final ConstraintAnchor getOpposite() {
+        switch (mType) {
+            case LEFT: {
+                return mOwner.mRight;
+            }
+            case RIGHT: {
+                return mOwner.mLeft;
+            }
+            case TOP: {
+                return mOwner.mBottom;
+            }
+            case BOTTOM: {
+                return mOwner.mTop;
+            }
+            case BASELINE:
+            case CENTER:
+            case CENTER_X:
+            case CENTER_Y:
+            case NONE:
+                return null;
+        }
+        throw new AssertionError(mType.name());
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
@@ -1,0 +1,3840 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.LinearSystem.DEBUG;
+import static androidx.constraintlayout.core.LinearSystem.FULL_DEBUG;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+
+import androidx.constraintlayout.core.Cache;
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.SolverVariable;
+import androidx.constraintlayout.core.state.WidgetFrame;
+import androidx.constraintlayout.core.widgets.analyzer.ChainRun;
+import androidx.constraintlayout.core.widgets.analyzer.HorizontalWidgetRun;
+import androidx.constraintlayout.core.widgets.analyzer.VerticalWidgetRun;
+import androidx.constraintlayout.core.widgets.analyzer.WidgetRun;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Implements a constraint Widget model supporting constraints relations between other widgets.
+ * <p>
+ * The widget has various anchors (i.e. Left, Top, Right, Bottom, representing their respective
+ * sides, as well as Baseline, Center_X and Center_Y). Connecting anchors from one widget to another
+ * represents a constraint relation between the two anchors; the {@link LinearSystem} will then
+ * be able to use this model to try to minimize the distances between connected anchors.
+ * </p>
+ * <p>
+ * If opposite anchors are connected (e.g. Left and Right anchors), if they have the same strength,
+ * the widget will be equally pulled toward their respective target anchor positions; if the widget
+ * has a fixed size, this means that the widget will be centered between the two target anchors. If
+ * the widget's size is allowed to adjust, the size of the widget will change to be as large as
+ * necessary so that the widget's anchors and the target anchors' distances are zero.
+ * </p>
+ * Constraints are set by connecting a widget's anchor to another via the
+ * {@link #connect} function.
+ */
+public class ConstraintWidget {
+    private static final boolean AUTOTAG_CENTER = false;
+    private static final boolean DO_NOT_USE = false;
+    protected static final int SOLVER = 1;
+    protected static final int DIRECT = 2;
+
+    // apply an intrinsic size when wrap content for spread dimensions
+    private static final boolean USE_WRAP_DIMENSION_FOR_SPREAD = false;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Graph measurements
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public boolean measured = false;
+    public WidgetRun[] run = new WidgetRun[2];
+    public ChainRun horizontalChainRun;
+    public ChainRun verticalChainRun;
+
+    public HorizontalWidgetRun mHorizontalRun = null;
+    public VerticalWidgetRun mVerticalRun = null;
+
+    public boolean[] isTerminalWidget = {true, true};
+    boolean mResolvedHasRatio = false;
+    private boolean mMeasureRequested = true;
+    private boolean mOptimizeWrapO = false;
+    private boolean mOptimizeWrapOnResolved = true;
+
+    private int mWidthOverride = -1;
+    private int mHeightOverride = -1;
+
+    public WidgetFrame frame = new WidgetFrame(this);
+
+    public String stringId;
+
+    // @TODO: add description
+    public WidgetRun getRun(int orientation) {
+        if (orientation == HORIZONTAL) {
+            return mHorizontalRun;
+        } else if (orientation == VERTICAL) {
+            return mVerticalRun;
+        }
+        return null;
+    }
+
+    private boolean mResolvedHorizontal = false;
+    private boolean mResolvedVertical = false;
+
+    private boolean mHorizontalSolvingPass = false;
+    private boolean mVerticalSolvingPass = false;
+
+    // @TODO: add description
+    public void setFinalFrame(int left,
+            int top,
+            int right,
+            int bottom,
+            int baseline,
+            int orientation) {
+        setFrame(left, top, right, bottom);
+        setBaselineDistance(baseline);
+        if (orientation == HORIZONTAL) {
+            mResolvedHorizontal = true;
+            mResolvedVertical = false;
+        } else if (orientation == VERTICAL) {
+            mResolvedHorizontal = false;
+            mResolvedVertical = true;
+        } else if (orientation == BOTH) {
+            mResolvedHorizontal = true;
+            mResolvedVertical = true;
+        } else {
+            mResolvedHorizontal = false;
+            mResolvedVertical = false;
+        }
+    }
+
+    // @TODO: add description
+    public void setFinalLeft(int x1) {
+        mLeft.setFinalValue(x1);
+        mX = x1;
+    }
+
+    // @TODO: add description
+    public void setFinalTop(int y1) {
+        mTop.setFinalValue(y1);
+        mY = y1;
+    }
+
+    // @TODO: add description
+    public void resetSolvingPassFlag() {
+        mHorizontalSolvingPass = false;
+        mVerticalSolvingPass = false;
+    }
+
+    public boolean isHorizontalSolvingPassDone() {
+        return mHorizontalSolvingPass;
+    }
+
+    public boolean isVerticalSolvingPassDone() {
+        return mVerticalSolvingPass;
+    }
+
+    // @TODO: add description
+    public void markHorizontalSolvingPassDone() {
+        mHorizontalSolvingPass = true;
+    }
+
+    // @TODO: add description
+    public void markVerticalSolvingPassDone() {
+        mVerticalSolvingPass = true;
+    }
+
+    // @TODO: add description
+    public void setFinalHorizontal(int x1, int x2) {
+        if (mResolvedHorizontal) {
+            return;
+        }
+        mLeft.setFinalValue(x1);
+        mRight.setFinalValue(x2);
+        mX = x1;
+        mWidth = x2 - x1;
+        mResolvedHorizontal = true;
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("*** SET FINAL HORIZONTAL FOR " + getDebugName()
+                    + " : " + x1 + " -> " + x2 + " (width: " + mWidth + ")");
+        }
+    }
+
+    // @TODO: add description
+    public void setFinalVertical(int y1, int y2) {
+        if (mResolvedVertical) {
+            return;
+        }
+        mTop.setFinalValue(y1);
+        mBottom.setFinalValue(y2);
+        mY = y1;
+        mHeight = y2 - y1;
+        if (mHasBaseline) {
+            mBaseline.setFinalValue(y1 + mBaselineDistance);
+        }
+        mResolvedVertical = true;
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("*** SET FINAL VERTICAL FOR " + getDebugName()
+                    + " : " + y1 + " -> " + y2 + " (height: " + mHeight + ")");
+        }
+    }
+
+    // @TODO: add description
+    public void setFinalBaseline(int baselineValue) {
+        if (!mHasBaseline) {
+            return;
+        }
+        int y1 = baselineValue - mBaselineDistance;
+        int y2 = y1 + mHeight;
+        mY = y1;
+        mTop.setFinalValue(y1);
+        mBottom.setFinalValue(y2);
+        mBaseline.setFinalValue(baselineValue);
+        mResolvedVertical = true;
+    }
+
+    public boolean isResolvedHorizontally() {
+        return mResolvedHorizontal || (mLeft.hasFinalValue() && mRight.hasFinalValue());
+    }
+
+    public boolean isResolvedVertically() {
+        return mResolvedVertical || (mTop.hasFinalValue() && mBottom.hasFinalValue());
+    }
+
+    // @TODO: add description
+    public void resetFinalResolution() {
+        mResolvedHorizontal = false;
+        mResolvedVertical = false;
+        mHorizontalSolvingPass = false;
+        mVerticalSolvingPass = false;
+        for (int i = 0, mAnchorsSize = mAnchors.size(); i < mAnchorsSize; i++) {
+            final ConstraintAnchor anchor = mAnchors.get(i);
+            anchor.resetFinalResolution();
+        }
+    }
+
+    // @TODO: add description
+    public void ensureMeasureRequested() {
+        mMeasureRequested = true;
+    }
+
+    // @TODO: add description
+    public boolean hasDependencies() {
+        for (int i = 0, mAnchorsSize = mAnchors.size(); i < mAnchorsSize; i++) {
+            final ConstraintAnchor anchor = mAnchors.get(i);
+            if (anchor.hasDependents()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    public boolean hasDanglingDimension(int orientation) {
+        if (orientation == HORIZONTAL) {
+            int horizontalTargets =
+                    (mLeft.mTarget != null ? 1 : 0) + (mRight.mTarget != null ? 1 : 0);
+            return horizontalTargets < 2;
+        } else {
+            int verticalTargets = (mTop.mTarget != null ? 1 : 0)
+                    + (mBottom.mTarget != null ? 1 : 0) + (mBaseline.mTarget != null ? 1 : 0);
+            return verticalTargets < 2;
+        }
+    }
+
+    // @TODO: add description
+    public boolean hasResolvedTargets(int orientation, int size) {
+        if (orientation == HORIZONTAL) {
+            if (mLeft.mTarget != null && mLeft.mTarget.hasFinalValue()
+                    && mRight.mTarget != null && mRight.mTarget.hasFinalValue()) {
+                return ((mRight.mTarget.getFinalValue() - mRight.getMargin())
+                        - (mLeft.mTarget.getFinalValue() + mLeft.getMargin())) >= size;
+            }
+        } else {
+            if (mTop.mTarget != null && mTop.mTarget.hasFinalValue()
+                    && mBottom.mTarget != null && mBottom.mTarget.hasFinalValue()) {
+                return ((mBottom.mTarget.getFinalValue() - mBottom.getMargin())
+                        - (mTop.mTarget.getFinalValue() + mTop.getMargin())) >= size;
+            }
+        }
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public static final int MATCH_CONSTRAINT_SPREAD = 0;
+    public static final int MATCH_CONSTRAINT_WRAP = 1;
+    public static final int MATCH_CONSTRAINT_PERCENT = 2;
+    public static final int MATCH_CONSTRAINT_RATIO = 3;
+    public static final int MATCH_CONSTRAINT_RATIO_RESOLVED = 4;
+
+    public static final int UNKNOWN = -1;
+    public static final int HORIZONTAL = 0;
+    public static final int VERTICAL = 1;
+    public static final int BOTH = 2;
+
+    public static final int VISIBLE = 0;
+    public static final int INVISIBLE = 4;
+    public static final int GONE = 8;
+
+    // Values of the chain styles
+    public static final int CHAIN_SPREAD = 0;
+    public static final int CHAIN_SPREAD_INSIDE = 1;
+    public static final int CHAIN_PACKED = 2;
+
+    // Values of the wrap behavior in parent
+    public static final int WRAP_BEHAVIOR_INCLUDED = 0; // default
+    public static final int WRAP_BEHAVIOR_HORIZONTAL_ONLY = 1;
+    public static final int WRAP_BEHAVIOR_VERTICAL_ONLY = 2;
+    public static final int WRAP_BEHAVIOR_SKIPPED = 3;
+
+    // Support for direct resolution
+    public int mHorizontalResolution = UNKNOWN;
+    public int mVerticalResolution = UNKNOWN;
+
+    private static final int WRAP = -2;
+
+    private int mWrapBehaviorInParent = WRAP_BEHAVIOR_INCLUDED;
+
+    public int mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_SPREAD;
+    public int mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_SPREAD;
+    public int[] mResolvedMatchConstraintDefault = new int[2];
+
+    public int mMatchConstraintMinWidth = 0;
+    public int mMatchConstraintMaxWidth = 0;
+    public float mMatchConstraintPercentWidth = 1;
+    public int mMatchConstraintMinHeight = 0;
+    public int mMatchConstraintMaxHeight = 0;
+    public float mMatchConstraintPercentHeight = 1;
+    public boolean mIsWidthWrapContent;
+    public boolean mIsHeightWrapContent;
+
+    int mResolvedDimensionRatioSide = UNKNOWN;
+    float mResolvedDimensionRatio = 1.0f;
+
+    private int[] mMaxDimension = {Integer.MAX_VALUE, Integer.MAX_VALUE};
+    public float mCircleConstraintAngle = Float.NaN;
+    private boolean mHasBaseline = false;
+    private boolean mInPlaceholder;
+
+    private boolean mInVirtualLayout = false;
+
+    public boolean isInVirtualLayout() {
+        return mInVirtualLayout;
+    }
+
+    public void setInVirtualLayout(boolean inVirtualLayout) {
+        mInVirtualLayout = inVirtualLayout;
+    }
+
+    public int getMaxHeight() {
+        return mMaxDimension[VERTICAL];
+    }
+
+    public int getMaxWidth() {
+        return mMaxDimension[HORIZONTAL];
+    }
+
+    public void setMaxWidth(int maxWidth) {
+        mMaxDimension[HORIZONTAL] = maxWidth;
+    }
+
+    public void setMaxHeight(int maxHeight) {
+        mMaxDimension[VERTICAL] = maxHeight;
+    }
+
+    public boolean isSpreadWidth() {
+        return mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD
+                && mDimensionRatio == 0
+                && mMatchConstraintMinWidth == 0
+                && mMatchConstraintMaxWidth == 0
+                && mListDimensionBehaviors[HORIZONTAL] == MATCH_CONSTRAINT;
+    }
+
+    public boolean isSpreadHeight() {
+        return mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD
+                && mDimensionRatio == 0
+                && mMatchConstraintMinHeight == 0
+                && mMatchConstraintMaxHeight == 0
+                && mListDimensionBehaviors[VERTICAL] == MATCH_CONSTRAINT;
+    }
+
+    public void setHasBaseline(boolean hasBaseline) {
+        this.mHasBaseline = hasBaseline;
+    }
+
+    public boolean getHasBaseline() {
+        return mHasBaseline;
+    }
+
+    public boolean isInPlaceholder() {
+        return mInPlaceholder;
+    }
+
+    public void setInPlaceholder(boolean inPlaceholder) {
+        this.mInPlaceholder = inPlaceholder;
+    }
+
+    protected void setInBarrier(int orientation, boolean value) {
+        mIsInBarrier[orientation] = value;
+    }
+
+    // @TODO: add description
+    public boolean isInBarrier(int orientation) {
+        return mIsInBarrier[orientation];
+    }
+
+    public void setMeasureRequested(boolean measureRequested) {
+        mMeasureRequested = measureRequested;
+    }
+
+    public boolean isMeasureRequested() {
+        return mMeasureRequested && mVisibility != GONE;
+    }
+
+    // @TODO: add description
+    public void setWrapBehaviorInParent(int behavior) {
+        if (behavior >= 0 && behavior <= WRAP_BEHAVIOR_SKIPPED) {
+            mWrapBehaviorInParent = behavior;
+        }
+    }
+
+    public int getWrapBehaviorInParent() {
+        return mWrapBehaviorInParent;
+    }
+
+    /**
+     * Keep a cache of the last measure cache as we can bypass remeasures during the onMeasure...
+     * the View's measure cache will only be reset in onLayout, so too late for us.
+     */
+    private int mLastHorizontalMeasureSpec = 0;
+    private int mLastVerticalMeasureSpec = 0;
+
+    public int getLastHorizontalMeasureSpec() {
+        return mLastHorizontalMeasureSpec;
+    }
+
+    public int getLastVerticalMeasureSpec() {
+        return mLastVerticalMeasureSpec;
+    }
+
+    // @TODO: add description
+    public void setLastMeasureSpec(int horizontal, int vertical) {
+        mLastHorizontalMeasureSpec = horizontal;
+        mLastVerticalMeasureSpec = vertical;
+        setMeasureRequested(false);
+    }
+
+    /**
+     * Define how the widget will resize
+     */
+    public enum DimensionBehaviour {
+        FIXED, WRAP_CONTENT, MATCH_CONSTRAINT, MATCH_PARENT
+    }
+
+    // The anchors available on the widget
+    // note: all anchors should be added to the mAnchors array (see addAnchors())
+    public ConstraintAnchor mLeft = new ConstraintAnchor(this, ConstraintAnchor.Type.LEFT);
+    public ConstraintAnchor mTop = new ConstraintAnchor(this, ConstraintAnchor.Type.TOP);
+    public ConstraintAnchor mRight = new ConstraintAnchor(this, ConstraintAnchor.Type.RIGHT);
+    public ConstraintAnchor mBottom = new ConstraintAnchor(this, ConstraintAnchor.Type.BOTTOM);
+    public ConstraintAnchor mBaseline = new ConstraintAnchor(this, ConstraintAnchor.Type.BASELINE);
+    ConstraintAnchor mCenterX = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER_X);
+    ConstraintAnchor mCenterY = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER_Y);
+    public ConstraintAnchor mCenter = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER);
+
+    public static final int ANCHOR_LEFT = 0;
+    public static final int ANCHOR_RIGHT = 1;
+    public static final int ANCHOR_TOP = 2;
+    public static final int ANCHOR_BOTTOM = 3;
+    public static final int ANCHOR_BASELINE = 4;
+
+    public ConstraintAnchor[] mListAnchors = {mLeft, mRight, mTop, mBottom, mBaseline, mCenter};
+    protected ArrayList<ConstraintAnchor> mAnchors = new ArrayList<>();
+
+    private boolean[] mIsInBarrier = new boolean[2];
+
+    // The horizontal and vertical behaviour for the widgets' dimensions
+    static final int DIMENSION_HORIZONTAL = 0;
+    static final int DIMENSION_VERTICAL = 1;
+    public DimensionBehaviour[] mListDimensionBehaviors =
+            {DimensionBehaviour.FIXED, DimensionBehaviour.FIXED};
+
+    // Parent of this widget
+    public ConstraintWidget mParent = null;
+
+    // Dimensions of the widget
+    int mWidth = 0;
+    int mHeight = 0;
+    public float mDimensionRatio = 0;
+    protected int mDimensionRatioSide = UNKNOWN;
+
+    // Origin of the widget
+    protected int mX = 0;
+    protected int mY = 0;
+    int mRelX = 0;
+    int mRelY = 0;
+
+    // Root offset
+    protected int mOffsetX = 0;
+    protected int mOffsetY = 0;
+
+    // Baseline distance relative to the top of the widget
+    int mBaselineDistance = 0;
+
+    // Minimum sizes for the widget
+    protected int mMinWidth;
+    protected int mMinHeight;
+
+    // Percentages used for biasing one connection over another when dual connections
+    // of the same strength exist
+    public static float DEFAULT_BIAS = 0.5f;
+    float mHorizontalBiasPercent = DEFAULT_BIAS;
+    float mVerticalBiasPercent = DEFAULT_BIAS;
+
+    // The companion widget (typically, the real widget we represent)
+    private Object mCompanionWidget;
+
+    // This is used to possibly "skip" a position while inside a container. For example,
+    // a container like Table can use this to implement empty cells
+    // (the item positioned after the empty cell will have a skip value of 1)
+    private int mContainerItemSkip = 0;
+
+    // Contains the visibility status of the widget (VISIBLE, INVISIBLE, or GONE)
+    private int mVisibility = VISIBLE;
+    // Contains if this widget is animated. Currently only affects gone behaviour
+    private boolean mAnimated = false;
+    private String mDebugName = null;
+    private String mType = null;
+
+    int mDistToTop;
+    int mDistToLeft;
+    int mDistToRight;
+    int mDistToBottom;
+    boolean mLeftHasCentered;
+    boolean mRightHasCentered;
+    boolean mTopHasCentered;
+    boolean mBottomHasCentered;
+    boolean mHorizontalWrapVisited;
+    boolean mVerticalWrapVisited;
+    boolean mGroupsToSolver = false;
+
+    // Chain support
+    int mHorizontalChainStyle = CHAIN_SPREAD;
+    int mVerticalChainStyle = CHAIN_SPREAD;
+    boolean mHorizontalChainFixedPosition;
+    boolean mVerticalChainFixedPosition;
+
+    public float[] mWeight = {UNKNOWN, UNKNOWN};
+
+    protected ConstraintWidget[] mListNextMatchConstraintsWidget = {null, null};
+    protected ConstraintWidget[] mNextChainWidget = {null, null};
+
+    ConstraintWidget mHorizontalNextWidget = null;
+    ConstraintWidget mVerticalNextWidget = null;
+
+    // TODO: see if we can make this simpler
+
+    // @TODO: add description
+    public void reset() {
+        mLeft.reset();
+        mTop.reset();
+        mRight.reset();
+        mBottom.reset();
+        mBaseline.reset();
+        mCenterX.reset();
+        mCenterY.reset();
+        mCenter.reset();
+        mParent = null;
+        mCircleConstraintAngle = Float.NaN;
+        mWidth = 0;
+        mHeight = 0;
+        mDimensionRatio = 0;
+        mDimensionRatioSide = UNKNOWN;
+        mX = 0;
+        mY = 0;
+        mOffsetX = 0;
+        mOffsetY = 0;
+        mBaselineDistance = 0;
+        mMinWidth = 0;
+        mMinHeight = 0;
+        mHorizontalBiasPercent = DEFAULT_BIAS;
+        mVerticalBiasPercent = DEFAULT_BIAS;
+        mListDimensionBehaviors[DIMENSION_HORIZONTAL] = DimensionBehaviour.FIXED;
+        mListDimensionBehaviors[DIMENSION_VERTICAL] = DimensionBehaviour.FIXED;
+        mCompanionWidget = null;
+        mContainerItemSkip = 0;
+        mVisibility = VISIBLE;
+        mType = null;
+        mHorizontalWrapVisited = false;
+        mVerticalWrapVisited = false;
+        mHorizontalChainStyle = CHAIN_SPREAD;
+        mVerticalChainStyle = CHAIN_SPREAD;
+        mHorizontalChainFixedPosition = false;
+        mVerticalChainFixedPosition = false;
+        mWeight[DIMENSION_HORIZONTAL] = UNKNOWN;
+        mWeight[DIMENSION_VERTICAL] = UNKNOWN;
+        mHorizontalResolution = UNKNOWN;
+        mVerticalResolution = UNKNOWN;
+        mMaxDimension[HORIZONTAL] = Integer.MAX_VALUE;
+        mMaxDimension[VERTICAL] = Integer.MAX_VALUE;
+        mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_SPREAD;
+        mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_SPREAD;
+        mMatchConstraintPercentWidth = 1;
+        mMatchConstraintPercentHeight = 1;
+        mMatchConstraintMaxWidth = Integer.MAX_VALUE;
+        mMatchConstraintMaxHeight = Integer.MAX_VALUE;
+        mMatchConstraintMinWidth = 0;
+        mMatchConstraintMinHeight = 0;
+        mResolvedHasRatio = false;
+        mResolvedDimensionRatioSide = UNKNOWN;
+        mResolvedDimensionRatio = 1f;
+        mGroupsToSolver = false;
+        isTerminalWidget[HORIZONTAL] = true;
+        isTerminalWidget[VERTICAL] = true;
+        mInVirtualLayout = false;
+        mIsInBarrier[HORIZONTAL] = false;
+        mIsInBarrier[VERTICAL] = false;
+        mMeasureRequested = true;
+        mResolvedMatchConstraintDefault[HORIZONTAL] = 0;
+        mResolvedMatchConstraintDefault[VERTICAL] = 0;
+        mWidthOverride = -1;
+        mHeightOverride = -1;
+    }
+
+    ///////////////////////////////////SERIALIZE///////////////////////////////////////////////
+
+    private void serializeAnchor(StringBuilder ret, String side, ConstraintAnchor a) {
+        if (a.mTarget == null) {
+            return;
+        }
+        ret.append(side);
+        ret.append(" : [ '");
+        ret.append(a.mTarget);
+        ret.append("',");
+        ret.append(a.mMargin);
+        ret.append(",");
+        ret.append(a.mGoneMargin);
+        ret.append(",");
+        ret.append(" ] ,\n");
+    }
+
+    private void serializeCircle(StringBuilder ret, ConstraintAnchor a, float angle) {
+        if (a.mTarget == null || Float.isNaN(angle)) {
+            return;
+        }
+
+        ret.append("circle : [ '");
+        ret.append(a.mTarget);
+        ret.append("',");
+        ret.append(a.mMargin);
+        ret.append(",");
+        ret.append(angle);
+        ret.append(",");
+        ret.append(" ] ,\n");
+    }
+
+    private void serializeAttribute(StringBuilder ret, String type, float value, float def) {
+        if (value == def) {
+            return;
+        }
+        ret.append(type);
+        ret.append(" :   ");
+        ret.append(value);
+        ret.append(",\n");
+    }
+
+    private void serializeAttribute(StringBuilder ret, String type, int value, int def) {
+        if (value == def) {
+            return;
+        }
+        ret.append(type);
+        ret.append(" :   ");
+        ret.append(value);
+        ret.append(",\n");
+    }
+
+    private void serializeAttribute(StringBuilder ret, String type, String value, String def) {
+        if (def.equals(value)) {
+            return;
+        }
+        ret.append(type);
+        ret.append(" :   ");
+        ret.append(value);
+        ret.append(",\n");
+    }
+
+    private void serializeDimensionRatio(StringBuilder ret,
+            String type,
+            float value,
+            int whichSide) {
+        if (value == 0) {
+            return;
+        }
+        ret.append(type);
+        ret.append(" :  [");
+        ret.append(value);
+        ret.append(",");
+        ret.append(whichSide);
+        ret.append("");
+        ret.append("],\n");
+    }
+
+    private void serializeSize(StringBuilder ret, String type, int size,
+            int min, int max, int override,
+            int matchConstraintMin, int matchConstraintDefault,
+            float matchConstraintPercent,
+            float weight) {
+        ret.append(type);
+        ret.append(" :  {\n");
+        serializeAttribute(ret, "size", size, Integer.MIN_VALUE);
+        serializeAttribute(ret, "min", min, 0);
+        serializeAttribute(ret, "max", max, Integer.MAX_VALUE);
+        serializeAttribute(ret, "matchMin", matchConstraintMin, 0);
+        serializeAttribute(ret, "matchDef", matchConstraintDefault, MATCH_CONSTRAINT_SPREAD);
+        serializeAttribute(ret, "matchPercent", matchConstraintDefault, 1);
+        serializeAttribute(ret, "matchConstraintPercent", matchConstraintPercent, 1);
+        serializeAttribute(ret, "weight", weight, 1);
+        serializeAttribute(ret, "override", override, 1);
+
+        ret.append("},\n");
+    }
+
+    /**
+     * Serialize the anchors for JSON5 output
+     * @param ret StringBuilder to be populated
+     * @return the same string builder to alow chaining
+     */
+    public StringBuilder serialize(StringBuilder ret) {
+        ret.append("{\n");
+        serializeAnchor(ret, "left", mLeft);
+        serializeAnchor(ret, "top", mTop);
+        serializeAnchor(ret, "right", mRight);
+        serializeAnchor(ret, "bottom", mBottom);
+        serializeAnchor(ret, "baseline", mBaseline);
+        serializeAnchor(ret, "centerX", mCenterX);
+        serializeAnchor(ret, "centerY", mCenterY);
+        serializeCircle(ret, mCenter, mCircleConstraintAngle);
+
+        serializeSize(ret, "width",
+                mWidth,
+                mMinWidth,
+                mMaxDimension[HORIZONTAL],
+                mWidthOverride,
+                mMatchConstraintMinWidth,
+                mMatchConstraintDefaultWidth,
+                mMatchConstraintPercentWidth,
+                mWeight[DIMENSION_HORIZONTAL]
+        );
+
+        serializeSize(ret, "height",
+                mHeight,
+                mMinHeight,
+                mMaxDimension[VERTICAL],
+                mHeightOverride,
+                mMatchConstraintMinHeight,
+                mMatchConstraintDefaultHeight,
+                mMatchConstraintPercentHeight,
+                mWeight[DIMENSION_VERTICAL]);
+
+        serializeDimensionRatio(ret, "dimensionRatio", mDimensionRatio, mDimensionRatioSide);
+        serializeAttribute(ret, "horizontalBias", mHorizontalBiasPercent, DEFAULT_BIAS);
+        serializeAttribute(ret, "verticalBias", mVerticalBiasPercent, DEFAULT_BIAS);
+        ret.append("}\n");
+
+        return ret;
+    }
+    ///////////////////////////////////END SERIALIZE///////////////////////////////////////////
+
+    public int horizontalGroup = -1;
+    public int verticalGroup = -1;
+
+    // @TODO: add description
+    public boolean oppositeDimensionDependsOn(int orientation) {
+        int oppositeOrientation = (orientation == HORIZONTAL) ? VERTICAL : HORIZONTAL;
+        DimensionBehaviour dimensionBehaviour = mListDimensionBehaviors[orientation];
+        DimensionBehaviour oppositeDimensionBehaviour =
+                mListDimensionBehaviors[oppositeOrientation];
+        return dimensionBehaviour == MATCH_CONSTRAINT
+                && oppositeDimensionBehaviour == MATCH_CONSTRAINT;
+        //&& mDimensionRatio != 0;
+    }
+
+    // @TODO: add description
+    public boolean oppositeDimensionsTied() {
+        return /* isInHorizontalChain() || isInVerticalChain() || */
+                (mListDimensionBehaviors[HORIZONTAL] == MATCH_CONSTRAINT
+                        && mListDimensionBehaviors[VERTICAL] == MATCH_CONSTRAINT);
+    }
+
+    // @TODO: add description
+    public boolean hasDimensionOverride() {
+        return mWidthOverride != -1 || mHeightOverride != -1;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Creation
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Default constructor
+     */
+    public ConstraintWidget() {
+        addAnchors();
+    }
+
+    public ConstraintWidget(String debugName) {
+        addAnchors();
+        setDebugName(debugName);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param x      x position
+     * @param y      y position
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public ConstraintWidget(int x, int y, int width, int height) {
+        mX = x;
+        mY = y;
+        mWidth = width;
+        mHeight = height;
+        addAnchors();
+    }
+
+    public ConstraintWidget(String debugName, int x, int y, int width, int height) {
+        this(x, y, width, height);
+        setDebugName(debugName);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public ConstraintWidget(int width, int height) {
+        this(0, 0, width, height);
+    }
+
+    // @TODO: add description
+    public void ensureWidgetRuns() {
+        if (mHorizontalRun == null) {
+            mHorizontalRun = new HorizontalWidgetRun(this);
+        }
+        if (mVerticalRun == null) {
+            mVerticalRun = new VerticalWidgetRun(this);
+        }
+    }
+
+    public ConstraintWidget(String debugName, int width, int height) {
+        this(width, height);
+        setDebugName(debugName);
+    }
+
+    /**
+     * Reset the solver variables of the anchors
+     */
+    public void resetSolverVariables(Cache cache) {
+        mLeft.resetSolverVariable(cache);
+        mTop.resetSolverVariable(cache);
+        mRight.resetSolverVariable(cache);
+        mBottom.resetSolverVariable(cache);
+        mBaseline.resetSolverVariable(cache);
+        mCenter.resetSolverVariable(cache);
+        mCenterX.resetSolverVariable(cache);
+        mCenterY.resetSolverVariable(cache);
+    }
+
+    /**
+     * Add all the anchors to the mAnchors array
+     */
+    private void addAnchors() {
+        mAnchors.add(mLeft);
+        mAnchors.add(mTop);
+        mAnchors.add(mRight);
+        mAnchors.add(mBottom);
+        mAnchors.add(mCenterX);
+        mAnchors.add(mCenterY);
+        mAnchors.add(mCenter);
+        mAnchors.add(mBaseline);
+    }
+
+    /**
+     * Returns true if the widget is the root widget
+     *
+     * @return true if root widget, false otherwise
+     */
+    public boolean isRoot() {
+        return mParent == null;
+    }
+
+    /**
+     * Returns the parent of this widget if there is one
+     *
+     * @return parent
+     */
+    public ConstraintWidget getParent() {
+        return mParent;
+    }
+
+    /**
+     * Set the parent of this widget
+     *
+     * @param widget parent
+     */
+    public void setParent(ConstraintWidget widget) {
+        mParent = widget;
+    }
+
+    /**
+     * Keep track of wrap_content for width
+     */
+    public void setWidthWrapContent(boolean widthWrapContent) {
+        this.mIsWidthWrapContent = widthWrapContent;
+    }
+
+    /**
+     * Returns true if width is set to wrap_content
+     */
+    public boolean isWidthWrapContent() {
+        return mIsWidthWrapContent;
+    }
+
+    /**
+     * Keep track of wrap_content for height
+     */
+    public void setHeightWrapContent(boolean heightWrapContent) {
+        this.mIsHeightWrapContent = heightWrapContent;
+    }
+
+    /**
+     * Returns true if height is set to wrap_content
+     */
+    public boolean isHeightWrapContent() {
+        return mIsHeightWrapContent;
+    }
+
+    /**
+     * Set a circular constraint
+     *
+     * @param target the target widget we will use as the center of the circle
+     * @param angle  the angle (from 0 to 360)
+     * @param radius the radius used
+     */
+    public void connectCircularConstraint(ConstraintWidget target, float angle, int radius) {
+        immediateConnect(ConstraintAnchor.Type.CENTER, target, ConstraintAnchor.Type.CENTER,
+                radius, 0);
+        mCircleConstraintAngle = angle;
+    }
+
+    /**
+     * Returns the type string if set
+     *
+     * @return type (null if not set)
+     */
+    public String getType() {
+        return mType;
+    }
+
+    /**
+     * Set the type of the widget (as a String)
+     *
+     * @param type type of the widget
+     */
+    public void setType(String type) {
+        mType = type;
+    }
+
+    /**
+     * Set the visibility for this widget
+     *
+     * @param visibility either VISIBLE, INVISIBLE, or GONE
+     */
+    public void setVisibility(int visibility) {
+        mVisibility = visibility;
+    }
+
+    /**
+     * Returns the current visibility value for this widget
+     *
+     * @return the visibility (VISIBLE, INVISIBLE, or GONE)
+     */
+    public int getVisibility() {
+        return mVisibility;
+    }
+
+    /**
+     * Set if this widget is animated. Currently only affects gone behaviour
+     *
+     * @param animated if true the widget must be positioned correctly when not visible
+     */
+    public void setAnimated(boolean animated) {
+        mAnimated = animated;
+    }
+
+    /**
+     * Returns if this widget is animated. Currently only affects gone behaviour
+     *
+     * @return true if ConstraintWidget is used in Animation
+     */
+    public boolean isAnimated() {
+        return mAnimated;
+    }
+
+    /**
+     * Returns the name of this widget (used for debug purposes)
+     *
+     * @return the debug name
+     */
+    public String getDebugName() {
+        return mDebugName;
+    }
+
+    /**
+     * Set the debug name of this widget
+     */
+    public void setDebugName(String name) {
+        mDebugName = name;
+    }
+
+    /**
+     * Utility debug function. Sets the names of the anchors in the solver given
+     * a widget's name. The given name is used as a prefix, resulting in anchors' names
+     * of the form:
+     * <p/>
+     * <ul>
+     * <li>{name}.left</li>
+     * <li>{name}.top</li>
+     * <li>{name}.right</li>
+     * <li>{name}.bottom</li>
+     * <li>{name}.baseline</li>
+     * </ul>
+     *
+     * @param system solver used
+     * @param name   name of the widget
+     */
+    public void setDebugSolverName(LinearSystem system, String name) {
+        mDebugName = name;
+        SolverVariable left = system.createObjectVariable(mLeft);
+        SolverVariable top = system.createObjectVariable(mTop);
+        SolverVariable right = system.createObjectVariable(mRight);
+        SolverVariable bottom = system.createObjectVariable(mBottom);
+        left.setName(name + ".left");
+        top.setName(name + ".top");
+        right.setName(name + ".right");
+        bottom.setName(name + ".bottom");
+        SolverVariable baseline = system.createObjectVariable(mBaseline);
+        baseline.setName(name + ".baseline");
+    }
+
+    /**
+     * Create all the system variables for this widget
+     *
+     *
+     */
+    public void createObjectVariables(LinearSystem system) {
+        system.createObjectVariable(mLeft);
+        system.createObjectVariable(mTop);
+        system.createObjectVariable(mRight);
+        system.createObjectVariable(mBottom);
+        if (mBaselineDistance > 0) {
+            system.createObjectVariable(mBaseline);
+        }
+    }
+
+    /**
+     * Returns a string representation of the ConstraintWidget
+     *
+     * @return string representation of the widget
+     */
+    @Override
+    public String toString() {
+        return (mType != null ? "type: " + mType + " " : "")
+                + (mDebugName != null ? "id: " + mDebugName + " " : "")
+                + "(" + mX + ", " + mY + ") - (" + mWidth + " x " + mHeight + ")";
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Position
+    /*-----------------------------------------------------------------------*/
+    // The widget position is expressed in two ways:
+    // - relative to its direct parent container (getX(), getY())
+    // - relative to the root container (getDrawX(), getDrawY())
+    // Additionally, getDrawX()/getDrawY() are used when animating the
+    // widget position on screen
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Return the x position of the widget, relative to its container
+     *
+     * @return x position
+     */
+    public int getX() {
+        if (mParent != null && mParent instanceof ConstraintWidgetContainer) {
+            return ((ConstraintWidgetContainer) mParent).mPaddingLeft + mX;
+        }
+        return mX;
+    }
+
+    /**
+     * Return the y position of the widget, relative to its container
+     *
+     * @return y position
+     */
+    public int getY() {
+        if (mParent != null && mParent instanceof ConstraintWidgetContainer) {
+            return ((ConstraintWidgetContainer) mParent).mPaddingTop + mY;
+        }
+        return mY;
+    }
+
+    /**
+     * Return the width of the widget
+     *
+     * @return width width
+     */
+    public int getWidth() {
+        if (mVisibility == ConstraintWidget.GONE) {
+            return 0;
+        }
+        return mWidth;
+    }
+
+    // @TODO: add description
+    public int getOptimizerWrapWidth() {
+        int w = mWidth;
+        if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == MATCH_CONSTRAINT) {
+            if (mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP) {
+                w = Math.max(mMatchConstraintMinWidth, w);
+            } else if (mMatchConstraintMinWidth > 0) {
+                w = mMatchConstraintMinWidth;
+                mWidth = w;
+            } else {
+                w = 0;
+            }
+            if (mMatchConstraintMaxWidth > 0 && mMatchConstraintMaxWidth < w) {
+                w = mMatchConstraintMaxWidth;
+            }
+        }
+        return w;
+    }
+
+    // @TODO: add description
+    public int getOptimizerWrapHeight() {
+        int h = mHeight;
+        if (mListDimensionBehaviors[DIMENSION_VERTICAL] == MATCH_CONSTRAINT) {
+            if (mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP) {
+                h = Math.max(mMatchConstraintMinHeight, h);
+            } else if (mMatchConstraintMinHeight > 0) {
+                h = mMatchConstraintMinHeight;
+                mHeight = h;
+            } else {
+                h = 0;
+            }
+            if (mMatchConstraintMaxHeight > 0 && mMatchConstraintMaxHeight < h) {
+                h = mMatchConstraintMaxHeight;
+            }
+        }
+        return h;
+    }
+
+    /**
+     * Return the height of the widget
+     *
+     * @return height height
+     */
+    public int getHeight() {
+        if (mVisibility == ConstraintWidget.GONE) {
+            return 0;
+        }
+        return mHeight;
+    }
+
+    /**
+     * Get a dimension of the widget in a particular orientation.
+     *
+     * @return The dimension of the specified orientation.
+     */
+    public int getLength(int orientation) {
+        if (orientation == HORIZONTAL) {
+            return getWidth();
+        } else if (orientation == VERTICAL) {
+            return getHeight();
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Return the x position of the widget, relative to the root
+     * (without animation)
+     *
+     * @return x position
+     */
+    protected int getRootX() {
+        return mX + mOffsetX;
+    }
+
+    /**
+     * Return the y position of the widget, relative to the root
+     * (without animation)
+     */
+    protected int getRootY() {
+        return mY + mOffsetY;
+    }
+
+    /**
+     * Return the minimum width of the widget
+     *
+     * @return minimum width
+     */
+    public int getMinWidth() {
+        return mMinWidth;
+    }
+
+    /**
+     * Return the minimum height of the widget
+     *
+     * @return minimum height
+     */
+    public int getMinHeight() {
+        return mMinHeight;
+    }
+
+    /**
+     * Return the left position of the widget (similar to {@link #getX()})
+     *
+     * @return left position of the widget
+     */
+    public int getLeft() {
+        return getX();
+    }
+
+    /**
+     * Return the top position of the widget (similar to {@link #getY()})
+     *
+     * @return top position of the widget
+     */
+    public int getTop() {
+        return getY();
+    }
+
+    /**
+     * Return the right position of the widget
+     *
+     * @return right position of the widget
+     */
+    public int getRight() {
+        return getX() + mWidth;
+    }
+
+    /**
+     * Return the bottom position of the widget
+     *
+     * @return bottom position of the widget
+     */
+    public int getBottom() {
+        return getY() + mHeight;
+    }
+
+    /**
+     * Returns all the horizontal margin of the widget.
+     */
+    public int getHorizontalMargin() {
+        int margin = 0;
+        if (mLeft != null) {
+            margin += mLeft.mMargin;
+        }
+        if (mRight != null) {
+            margin += mRight.mMargin;
+        }
+        return margin;
+    }
+
+    /**
+     * Returns all the vertical margin of the widget
+     */
+    public int getVerticalMargin() {
+        int margin = 0;
+        if (mLeft != null) {
+            margin += mTop.mMargin;
+        }
+        if (mRight != null) {
+            margin += mBottom.mMargin;
+        }
+        return margin;
+    }
+
+    /**
+     * Return the horizontal percentage bias that is used when two opposite connections
+     * exist of the same strength.
+     *
+     * @return horizontal percentage bias
+     */
+    public float getHorizontalBiasPercent() {
+        return mHorizontalBiasPercent;
+    }
+
+    /**
+     * Return the vertical percentage bias that is used when two opposite connections
+     * exist of the same strength.
+     *
+     * @return vertical percentage bias
+     */
+    public float getVerticalBiasPercent() {
+        return mVerticalBiasPercent;
+    }
+
+    /**
+     * Return the percentage bias that is used when two opposite connections exist of the same
+     * strength in a particular orientation.
+     *
+     * @param orientation Orientation {@link #HORIZONTAL}/{@link #VERTICAL}.
+     * @return Respective percentage bias.
+     */
+    public float getBiasPercent(int orientation) {
+        if (orientation == HORIZONTAL) {
+            return mHorizontalBiasPercent;
+        } else if (orientation == VERTICAL) {
+            return mVerticalBiasPercent;
+        } else {
+            return UNKNOWN;
+        }
+    }
+
+    /**
+     * Return true if this widget has a baseline
+     *
+     * @return true if the widget has a baseline, false otherwise
+     */
+    public boolean hasBaseline() {
+        return mHasBaseline;
+    }
+
+    /**
+     * Return the baseline distance relative to the top of the widget
+     *
+     * @return baseline
+     */
+    public int getBaselineDistance() {
+        return mBaselineDistance;
+    }
+
+    /**
+     * Return the companion widget. Typically, this would be the real
+     * widget we represent with this instance of ConstraintWidget.
+     *
+     * @return the companion widget, if set.
+     */
+    public Object getCompanionWidget() {
+        return mCompanionWidget;
+    }
+
+    /**
+     * Return the array of anchors of this widget
+     *
+     * @return array of anchors
+     */
+    public ArrayList<ConstraintAnchor> getAnchors() {
+        return mAnchors;
+    }
+
+    /**
+     * Set the x position of the widget, relative to its container
+     *
+     * @param x x position
+     */
+    public void setX(int x) {
+        mX = x;
+    }
+
+    /**
+     * Set the y position of the widget, relative to its container
+     *
+     * @param y y position
+     */
+    public void setY(int y) {
+        mY = y;
+    }
+
+    /**
+     * Set both the origin in (x, y) of the widget, relative to its container
+     *
+     * @param x x position
+     * @param y y position
+     */
+    public void setOrigin(int x, int y) {
+        mX = x;
+        mY = y;
+    }
+
+    /**
+     * Set the offset of this widget relative to the root widget
+     *
+     * @param x horizontal offset
+     * @param y vertical offset
+     */
+    public void setOffset(int x, int y) {
+        mOffsetX = x;
+        mOffsetY = y;
+    }
+
+    /**
+     * Set the margin to be used when connected to a widget with a visibility of GONE
+     *
+     * @param type       the anchor to set the margin on
+     * @param goneMargin the margin value to use
+     */
+    public void setGoneMargin(ConstraintAnchor.Type type, int goneMargin) {
+        switch (type) {
+            case LEFT: {
+                mLeft.mGoneMargin = goneMargin;
+            }
+            break;
+            case TOP: {
+                mTop.mGoneMargin = goneMargin;
+            }
+            break;
+            case RIGHT: {
+                mRight.mGoneMargin = goneMargin;
+            }
+            break;
+            case BOTTOM: {
+                mBottom.mGoneMargin = goneMargin;
+            }
+            break;
+            case BASELINE: {
+                mBaseline.mGoneMargin = goneMargin;
+            }
+            break;
+            case CENTER:
+            case CENTER_X:
+            case CENTER_Y:
+            case NONE:
+                break;
+        }
+    }
+
+    /**
+     * Set the width of the widget
+     *
+     * @param w width
+     */
+    public void setWidth(int w) {
+        mWidth = w;
+        if (mWidth < mMinWidth) {
+            mWidth = mMinWidth;
+        }
+    }
+
+    /**
+     * Set the height of the widget
+     *
+     * @param h height
+     */
+    public void setHeight(int h) {
+        mHeight = h;
+        if (mHeight < mMinHeight) {
+            mHeight = mMinHeight;
+        }
+    }
+
+    /**
+     * Set the dimension of a widget in a particular orientation.
+     *
+     * @param length      Size of the dimension.
+     * @param orientation HORIZONTAL or VERTICAL
+     */
+    public void setLength(int length, int orientation) {
+        if (orientation == HORIZONTAL) {
+            setWidth(length);
+        } else if (orientation == VERTICAL) {
+            setHeight(length);
+        }
+    }
+
+    /**
+     * Set the horizontal style when MATCH_CONSTRAINT is set
+     *
+     * @param horizontalMatchStyle MATCH_CONSTRAINT_SPREAD or MATCH_CONSTRAINT_WRAP
+     * @param min                  minimum value
+     * @param max                  maximum value
+     * @param percent              Percent width
+     */
+    public void setHorizontalMatchStyle(int horizontalMatchStyle, int min, int max, float percent) {
+        mMatchConstraintDefaultWidth = horizontalMatchStyle;
+        mMatchConstraintMinWidth = min;
+        mMatchConstraintMaxWidth = (max == Integer.MAX_VALUE) ? 0 : max;
+        mMatchConstraintPercentWidth = percent;
+        if (percent > 0 && percent < 1 && mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+            mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_PERCENT;
+        }
+    }
+
+    /**
+     * Set the vertical style when MATCH_CONSTRAINT is set
+     *
+     * @param verticalMatchStyle MATCH_CONSTRAINT_SPREAD or MATCH_CONSTRAINT_WRAP
+     * @param min                minimum value
+     * @param max                maximum value
+     * @param percent            Percent height
+     */
+    public void setVerticalMatchStyle(int verticalMatchStyle, int min, int max, float percent) {
+        mMatchConstraintDefaultHeight = verticalMatchStyle;
+        mMatchConstraintMinHeight = min;
+        mMatchConstraintMaxHeight = (max == Integer.MAX_VALUE) ? 0 : max;
+        mMatchConstraintPercentHeight = percent;
+        if (percent > 0 && percent < 1
+                && mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+            mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_PERCENT;
+        }
+    }
+
+    /**
+     * Set the ratio of the widget
+     *
+     * @param ratio given string of format [H|V],[float|x:y] or [float|x:y]
+     */
+    public void setDimensionRatio(String ratio) {
+        if (ratio == null || ratio.length() == 0) {
+            mDimensionRatio = 0;
+            return;
+        }
+        int dimensionRatioSide = UNKNOWN;
+        float dimensionRatio = 0;
+        int len = ratio.length();
+        int commaIndex = ratio.indexOf(',');
+        if (commaIndex > 0 && commaIndex < len - 1) {
+            String dimension = ratio.substring(0, commaIndex);
+            if (dimension.equalsIgnoreCase("W")) {
+                dimensionRatioSide = HORIZONTAL;
+            } else if (dimension.equalsIgnoreCase("H")) {
+                dimensionRatioSide = VERTICAL;
+            }
+            commaIndex++;
+        } else {
+            commaIndex = 0;
+        }
+        int colonIndex = ratio.indexOf(':');
+
+        if (colonIndex >= 0 && colonIndex < len - 1) {
+            String nominator = ratio.substring(commaIndex, colonIndex);
+            String denominator = ratio.substring(colonIndex + 1);
+            if (nominator.length() > 0 && denominator.length() > 0) {
+                try {
+                    float nominatorValue = Float.parseFloat(nominator);
+                    float denominatorValue = Float.parseFloat(denominator);
+                    if (nominatorValue > 0 && denominatorValue > 0) {
+                        if (dimensionRatioSide == VERTICAL) {
+                            dimensionRatio = Math.abs(denominatorValue / nominatorValue);
+                        } else {
+                            dimensionRatio = Math.abs(nominatorValue / denominatorValue);
+                        }
+                    }
+                } catch (NumberFormatException e) {
+                    // Ignore
+                }
+            }
+        } else {
+            String r = ratio.substring(commaIndex);
+            if (r.length() > 0) {
+                try {
+                    dimensionRatio = Float.parseFloat(r);
+                } catch (NumberFormatException e) {
+                    // Ignore
+                }
+            }
+        }
+
+        if (dimensionRatio > 0) {
+            mDimensionRatio = dimensionRatio;
+            mDimensionRatioSide = dimensionRatioSide;
+        }
+    }
+
+    /**
+     * Set the ratio of the widget
+     * The ratio will be applied if at least one of the dimension
+     * (width or height) is set to a behaviour
+     * of DimensionBehaviour.MATCH_CONSTRAINT
+     * -- the dimension's value will be set to the other dimension * ratio.
+     *
+     * @param ratio              A float value that describes W/H or H/W depending
+     *                           on the provided dimensionRatioSide
+     * @param dimensionRatioSide The side the ratio should be calculated on,
+     *                           HORIZONTAL, VERTICAL, or UNKNOWN
+     */
+    public void setDimensionRatio(float ratio, int dimensionRatioSide) {
+        mDimensionRatio = ratio;
+        mDimensionRatioSide = dimensionRatioSide;
+    }
+
+    /**
+     * Return the current ratio of this widget
+     *
+     * @return the dimension ratio (HORIZONTAL, VERTICAL, or UNKNOWN)
+     */
+    public float getDimensionRatio() {
+        return mDimensionRatio;
+    }
+
+    /**
+     * Return the current side on which ratio will be applied
+     *
+     * @return HORIZONTAL, VERTICAL, or UNKNOWN
+     */
+    public int getDimensionRatioSide() {
+        return mDimensionRatioSide;
+    }
+
+    /**
+     * Set the horizontal bias percent to apply when we have two opposite constraints of
+     * equal strength
+     *
+     * @param horizontalBiasPercent the percentage used
+     */
+    public void setHorizontalBiasPercent(float horizontalBiasPercent) {
+        mHorizontalBiasPercent = horizontalBiasPercent;
+    }
+
+    /**
+     * Set the vertical bias percent to apply when we have two opposite constraints of
+     * equal strength
+     *
+     * @param verticalBiasPercent the percentage used
+     */
+    public void setVerticalBiasPercent(float verticalBiasPercent) {
+        mVerticalBiasPercent = verticalBiasPercent;
+    }
+
+    /**
+     * Set the minimum width of the widget
+     *
+     * @param w minimum width
+     */
+    public void setMinWidth(int w) {
+        if (w < 0) {
+            mMinWidth = 0;
+        } else {
+            mMinWidth = w;
+        }
+    }
+
+    /**
+     * Set the minimum height of the widget
+     *
+     * @param h minimum height
+     */
+    public void setMinHeight(int h) {
+        if (h < 0) {
+            mMinHeight = 0;
+        } else {
+            mMinHeight = h;
+        }
+    }
+
+    /**
+     * Set both width and height of the widget
+     *
+     * @param w width
+     * @param h height
+     */
+    public void setDimension(int w, int h) {
+        mWidth = w;
+        if (mWidth < mMinWidth) {
+            mWidth = mMinWidth;
+        }
+        mHeight = h;
+        if (mHeight < mMinHeight) {
+            mHeight = mMinHeight;
+        }
+    }
+
+    /**
+     * Set the position+dimension of the widget given left/top/right/bottom
+     *
+     * @param left   left side position of the widget
+     * @param top    top side position of the widget
+     * @param right  right side position of the widget
+     * @param bottom bottom side position of the widget
+     */
+    public void setFrame(int left, int top, int right, int bottom) {
+        int w = right - left;
+        int h = bottom - top;
+
+        mX = left;
+        mY = top;
+
+        if (mVisibility == ConstraintWidget.GONE) {
+            mWidth = 0;
+            mHeight = 0;
+            return;
+        }
+
+        // correct dimensional instability caused by rounding errors
+        if (mListDimensionBehaviors[DIMENSION_HORIZONTAL]
+                == DimensionBehaviour.FIXED && w < mWidth) {
+            w = mWidth;
+        }
+        if (mListDimensionBehaviors[DIMENSION_VERTICAL]
+                == DimensionBehaviour.FIXED && h < mHeight) {
+            h = mHeight;
+        }
+
+        mWidth = w;
+        mHeight = h;
+
+        if (mHeight < mMinHeight) {
+            mHeight = mMinHeight;
+        }
+        if (mWidth < mMinWidth) {
+            mWidth = mMinWidth;
+        }
+        if (mMatchConstraintMaxWidth > 0
+                && mListDimensionBehaviors[HORIZONTAL] == MATCH_CONSTRAINT) {
+            mWidth = Math.min(mWidth, mMatchConstraintMaxWidth);
+        }
+        if (mMatchConstraintMaxHeight > 0
+                && mListDimensionBehaviors[VERTICAL] == MATCH_CONSTRAINT) {
+            mHeight = Math.min(mHeight, mMatchConstraintMaxHeight);
+        }
+        if (w != mWidth) {
+            mWidthOverride = mWidth;
+        }
+        if (h != mHeight) {
+            mHeightOverride = mHeight;
+        }
+
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("update from solver " + mDebugName
+                    + " " + mX + ":" + mY + " - " + mWidth + " x " + mHeight);
+        }
+    }
+
+    /**
+     * Set the position+dimension of the widget based on starting/ending positions on one dimension.
+     *
+     * @param start       Left/Top side position of the widget.
+     * @param end         Right/Bottom side position of the widget.
+     * @param orientation Orientation being set (HORIZONTAL/VERTICAL).
+     */
+    public void setFrame(int start, int end, int orientation) {
+        if (orientation == HORIZONTAL) {
+            setHorizontalDimension(start, end);
+        } else if (orientation == VERTICAL) {
+            setVerticalDimension(start, end);
+        }
+    }
+
+    /**
+     * Set the positions for the horizontal dimension only
+     *
+     * @param left  left side position of the widget
+     * @param right right side position of the widget
+     */
+    public void setHorizontalDimension(int left, int right) {
+        mX = left;
+        mWidth = right - left;
+        if (mWidth < mMinWidth) {
+            mWidth = mMinWidth;
+        }
+    }
+
+    /**
+     * Set the positions for the vertical dimension only
+     *
+     * @param top    top side position of the widget
+     * @param bottom bottom side position of the widget
+     */
+    public void setVerticalDimension(int top, int bottom) {
+        mY = top;
+        mHeight = bottom - top;
+        if (mHeight < mMinHeight) {
+            mHeight = mMinHeight;
+        }
+    }
+
+    /**
+     * Get the left/top position of the widget relative to
+     * the outer side of the container (right/bottom).
+     *
+     * @param orientation Orientation by which to find the relative positioning of the widget.
+     * @return The relative position of the widget.
+     */
+    int getRelativePositioning(int orientation) {
+        if (orientation == HORIZONTAL) {
+            return mRelX;
+        } else if (orientation == VERTICAL) {
+            return mRelY;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Set the left/top position of the widget relative to
+     * the outer side of the container (right/bottom).
+     *
+     * @param offset      Offset of the relative position.
+     * @param orientation Orientation of the offset being set.
+     */
+    void setRelativePositioning(int offset, int orientation) {
+        if (orientation == HORIZONTAL) {
+            mRelX = offset;
+        } else if (orientation == VERTICAL) {
+            mRelY = offset;
+        }
+    }
+
+    /**
+     * Set the baseline distance relative to the top of the widget
+     *
+     * @param baseline the distance of the baseline relative to the widget's top
+     */
+    public void setBaselineDistance(int baseline) {
+        mBaselineDistance = baseline;
+        mHasBaseline = baseline > 0;
+    }
+
+    /**
+     * Set the companion widget. Typically, this would be the real widget we
+     * represent with this instance of ConstraintWidget.
+     */
+    public void setCompanionWidget(Object companion) {
+        mCompanionWidget = companion;
+    }
+
+    /**
+     * Set the skip value for this widget. This can be used when a widget is in a container,
+     * so that container can position the widget as if it was positioned further in the list
+     * of widgets. For example, with Table, this is used to skip empty cells
+     * (the widget after an empty cell will have a skip value of one)
+     */
+    public void setContainerItemSkip(int skip) {
+        if (skip >= 0) {
+            mContainerItemSkip = skip;
+        } else {
+            mContainerItemSkip = 0;
+        }
+    }
+
+    /**
+     * Accessor for the skip value
+     *
+     * @return skip value
+     */
+    public int getContainerItemSkip() {
+        return mContainerItemSkip;
+    }
+
+    /**
+     * Set the horizontal weight (only used in chains)
+     *
+     * @param horizontalWeight Floating point value weight
+     */
+    public void setHorizontalWeight(float horizontalWeight) {
+        mWeight[DIMENSION_HORIZONTAL] = horizontalWeight;
+    }
+
+    /**
+     * Set the vertical weight (only used in chains)
+     *
+     * @param verticalWeight Floating point value weight
+     */
+    public void setVerticalWeight(float verticalWeight) {
+        mWeight[DIMENSION_VERTICAL] = verticalWeight;
+    }
+
+    /**
+     * Set the chain starting from this widget to be packed.
+     * The horizontal bias will control how elements of the chain are positioned.
+     *
+     * @param horizontalChainStyle (CHAIN_SPREAD, CHAIN_SPREAD_INSIDE, CHAIN_PACKED)
+     */
+    public void setHorizontalChainStyle(int horizontalChainStyle) {
+        mHorizontalChainStyle = horizontalChainStyle;
+    }
+
+    /**
+     * get the chain starting from this widget to be packed.
+     * The horizontal bias will control how elements of the chain are positioned.
+     *
+     * @return Horizontal Chain Style
+     */
+    public int getHorizontalChainStyle() {
+        return mHorizontalChainStyle;
+    }
+
+    /**
+     * Set the chain starting from this widget to be packed.
+     * The vertical bias will control how elements of the chain are positioned.
+     *
+     * @param verticalChainStyle (CHAIN_SPREAD, CHAIN_SPREAD_INSIDE, CHAIN_PACKED)
+     */
+    public void setVerticalChainStyle(int verticalChainStyle) {
+        mVerticalChainStyle = verticalChainStyle;
+    }
+
+    /**
+     * Set the chain starting from this widget to be packed.
+     * The vertical bias will control how elements of the chain are positioned.
+     */
+    public int getVerticalChainStyle() {
+        return mVerticalChainStyle;
+    }
+
+    /**
+     * Returns true if this widget should be used in a barrier
+     */
+    public boolean allowedInBarrier() {
+        return mVisibility != GONE;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Connections
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Immediate connection to an anchor without any checks.
+     *
+     * @param startType  The type of anchor on this widget
+     * @param target     The target widget
+     * @param endType    The type of anchor on the target widget
+     * @param margin     How much margin we want to keep as
+     *                   a minimum distance between the two anchors
+     * @param goneMargin How much margin we want to keep if the target is set to {@code View.GONE}
+     */
+    public void immediateConnect(ConstraintAnchor.Type startType, ConstraintWidget target,
+            ConstraintAnchor.Type endType, int margin, int goneMargin) {
+        ConstraintAnchor startAnchor = getAnchor(startType);
+        ConstraintAnchor endAnchor = target.getAnchor(endType);
+        startAnchor.connect(endAnchor, margin, goneMargin, true);
+    }
+
+    /**
+     * Connect the given anchors together (the from anchor should be owned by this widget)
+     *
+     * @param from   the anchor we are connecting from (of this widget)
+     * @param to     the anchor we are connecting to
+     * @param margin how much margin we want to have
+     */
+    public void connect(ConstraintAnchor from, ConstraintAnchor to, int margin) {
+        if (from.getOwner() == this) {
+            connect(from.getType(), to.getOwner(), to.getType(), margin);
+        }
+    }
+
+    /**
+     * Connect a given anchor of this widget to another anchor of a target widget
+     *
+     * @param constraintFrom which anchor of this widget to connect from
+     * @param target         the target widget
+     * @param constraintTo   the target anchor on the target widget
+     */
+    public void connect(ConstraintAnchor.Type constraintFrom,
+            ConstraintWidget target,
+            ConstraintAnchor.Type constraintTo) {
+        if (DEBUG) {
+            System.out.println(this.getDebugName() + " connect "
+                    + constraintFrom + " to " + target + " " + constraintTo);
+        }
+        connect(constraintFrom, target, constraintTo, 0);
+    }
+
+    /**
+     * Connect a given anchor of this widget to another anchor of a target widget
+     *
+     * @param constraintFrom which anchor of this widget to connect from
+     * @param target         the target widget
+     * @param constraintTo   the target anchor on the target widget
+     * @param margin         how much margin we want to keep as
+     *                       a minimum distance between the two anchors
+     */
+    public void connect(ConstraintAnchor.Type constraintFrom,
+            ConstraintWidget target,
+            ConstraintAnchor.Type constraintTo, int margin) {
+        if (constraintFrom == ConstraintAnchor.Type.CENTER) {
+            // If we have center, we connect instead to the corresponding
+            // left/right or top/bottom pairs
+            if (constraintTo == ConstraintAnchor.Type.CENTER) {
+                ConstraintAnchor left = getAnchor(ConstraintAnchor.Type.LEFT);
+                ConstraintAnchor right = getAnchor(ConstraintAnchor.Type.RIGHT);
+                ConstraintAnchor top = getAnchor(ConstraintAnchor.Type.TOP);
+                ConstraintAnchor bottom = getAnchor(ConstraintAnchor.Type.BOTTOM);
+                boolean centerX = false;
+                boolean centerY = false;
+                if ((left != null && left.isConnected())
+                        || (right != null && right.isConnected())) {
+                    // don't apply center here
+                } else {
+                    connect(ConstraintAnchor.Type.LEFT, target,
+                            ConstraintAnchor.Type.LEFT, 0);
+                    connect(ConstraintAnchor.Type.RIGHT, target,
+                            ConstraintAnchor.Type.RIGHT, 0);
+                    centerX = true;
+                }
+                if ((top != null && top.isConnected())
+                        || (bottom != null && bottom.isConnected())) {
+                    // don't apply center here
+                } else {
+                    connect(ConstraintAnchor.Type.TOP, target,
+                            ConstraintAnchor.Type.TOP, 0);
+                    connect(ConstraintAnchor.Type.BOTTOM, target,
+                            ConstraintAnchor.Type.BOTTOM, 0);
+                    centerY = true;
+                }
+                if (centerX && centerY) {
+                    ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+                    center.connect(target.getAnchor(ConstraintAnchor.Type.CENTER), 0);
+                } else if (centerX) {
+                    ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER_X);
+                    center.connect(target.getAnchor(ConstraintAnchor.Type.CENTER_X), 0);
+                } else if (centerY) {
+                    ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER_Y);
+                    center.connect(target.getAnchor(ConstraintAnchor.Type.CENTER_Y), 0);
+                }
+            } else if ((constraintTo == ConstraintAnchor.Type.LEFT)
+                    || (constraintTo == ConstraintAnchor.Type.RIGHT)) {
+                connect(ConstraintAnchor.Type.LEFT, target,
+                        constraintTo, 0);
+                connect(ConstraintAnchor.Type.RIGHT, target,
+                        constraintTo, 0);
+                ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+                center.connect(target.getAnchor(constraintTo), 0);
+            } else if ((constraintTo == ConstraintAnchor.Type.TOP)
+                    || (constraintTo == ConstraintAnchor.Type.BOTTOM)) {
+                connect(ConstraintAnchor.Type.TOP, target,
+                        constraintTo, 0);
+                connect(ConstraintAnchor.Type.BOTTOM, target,
+                        constraintTo, 0);
+                ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+                center.connect(target.getAnchor(constraintTo), 0);
+            }
+        } else if (constraintFrom == ConstraintAnchor.Type.CENTER_X
+                && (constraintTo == ConstraintAnchor.Type.LEFT
+                || constraintTo == ConstraintAnchor.Type.RIGHT)) {
+            ConstraintAnchor left = getAnchor(ConstraintAnchor.Type.LEFT);
+            ConstraintAnchor targetAnchor = target.getAnchor(constraintTo);
+            ConstraintAnchor right = getAnchor(ConstraintAnchor.Type.RIGHT);
+            left.connect(targetAnchor, 0);
+            right.connect(targetAnchor, 0);
+            ConstraintAnchor centerX = getAnchor(ConstraintAnchor.Type.CENTER_X);
+            centerX.connect(targetAnchor, 0);
+        } else if (constraintFrom == ConstraintAnchor.Type.CENTER_Y
+                && (constraintTo == ConstraintAnchor.Type.TOP
+                || constraintTo == ConstraintAnchor.Type.BOTTOM)) {
+            ConstraintAnchor targetAnchor = target.getAnchor(constraintTo);
+            ConstraintAnchor top = getAnchor(ConstraintAnchor.Type.TOP);
+            top.connect(targetAnchor, 0);
+            ConstraintAnchor bottom = getAnchor(ConstraintAnchor.Type.BOTTOM);
+            bottom.connect(targetAnchor, 0);
+            ConstraintAnchor centerY = getAnchor(ConstraintAnchor.Type.CENTER_Y);
+            centerY.connect(targetAnchor, 0);
+        } else if (constraintFrom == ConstraintAnchor.Type.CENTER_X
+                && constraintTo == ConstraintAnchor.Type.CENTER_X) {
+            // Center X connection will connect left & right
+            ConstraintAnchor left = getAnchor(ConstraintAnchor.Type.LEFT);
+            ConstraintAnchor leftTarget = target.getAnchor(ConstraintAnchor.Type.LEFT);
+            left.connect(leftTarget, 0);
+            ConstraintAnchor right = getAnchor(ConstraintAnchor.Type.RIGHT);
+            ConstraintAnchor rightTarget = target.getAnchor(ConstraintAnchor.Type.RIGHT);
+            right.connect(rightTarget, 0);
+            ConstraintAnchor centerX = getAnchor(ConstraintAnchor.Type.CENTER_X);
+            centerX.connect(target.getAnchor(constraintTo), 0);
+        } else if (constraintFrom == ConstraintAnchor.Type.CENTER_Y
+                && constraintTo == ConstraintAnchor.Type.CENTER_Y) {
+            // Center Y connection will connect top & bottom.
+            ConstraintAnchor top = getAnchor(ConstraintAnchor.Type.TOP);
+            ConstraintAnchor topTarget = target.getAnchor(ConstraintAnchor.Type.TOP);
+            top.connect(topTarget, 0);
+            ConstraintAnchor bottom = getAnchor(ConstraintAnchor.Type.BOTTOM);
+            ConstraintAnchor bottomTarget = target.getAnchor(ConstraintAnchor.Type.BOTTOM);
+            bottom.connect(bottomTarget, 0);
+            ConstraintAnchor centerY = getAnchor(ConstraintAnchor.Type.CENTER_Y);
+            centerY.connect(target.getAnchor(constraintTo), 0);
+        } else {
+            ConstraintAnchor fromAnchor = getAnchor(constraintFrom);
+            ConstraintAnchor toAnchor = target.getAnchor(constraintTo);
+            if (fromAnchor.isValidConnection(toAnchor)) {
+                // make sure that the baseline takes precedence over top/bottom
+                // and reversely, reset the baseline if we are connecting top/bottom
+                if (constraintFrom == ConstraintAnchor.Type.BASELINE) {
+                    ConstraintAnchor top = getAnchor(ConstraintAnchor.Type.TOP);
+                    ConstraintAnchor bottom = getAnchor(ConstraintAnchor.Type.BOTTOM);
+                    if (top != null) {
+                        top.reset();
+                    }
+                    if (bottom != null) {
+                        bottom.reset();
+                    }
+                } else if ((constraintFrom == ConstraintAnchor.Type.TOP)
+                        || (constraintFrom == ConstraintAnchor.Type.BOTTOM)) {
+                    ConstraintAnchor baseline = getAnchor(ConstraintAnchor.Type.BASELINE);
+                    if (baseline != null) {
+                        baseline.reset();
+                    }
+                    ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+                    if (center.getTarget() != toAnchor) {
+                        center.reset();
+                    }
+                    ConstraintAnchor opposite = getAnchor(constraintFrom).getOpposite();
+                    ConstraintAnchor centerY = getAnchor(ConstraintAnchor.Type.CENTER_Y);
+                    if (centerY.isConnected()) {
+                        opposite.reset();
+                        centerY.reset();
+                    } else {
+                        if (AUTOTAG_CENTER) {
+                            // let's see if we need to mark center_y as connected
+                            if (opposite.isConnected() && opposite.getTarget().getOwner()
+                                    == toAnchor.getOwner()) {
+                                ConstraintAnchor targetCenterY = toAnchor.getOwner().getAnchor(
+                                        ConstraintAnchor.Type.CENTER_Y);
+                                centerY.connect(targetCenterY, 0);
+                            }
+                        }
+                    }
+                } else if ((constraintFrom == ConstraintAnchor.Type.LEFT)
+                        || (constraintFrom == ConstraintAnchor.Type.RIGHT)) {
+                    ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+                    if (center.getTarget() != toAnchor) {
+                        center.reset();
+                    }
+                    ConstraintAnchor opposite = getAnchor(constraintFrom).getOpposite();
+                    ConstraintAnchor centerX = getAnchor(ConstraintAnchor.Type.CENTER_X);
+                    if (centerX.isConnected()) {
+                        opposite.reset();
+                        centerX.reset();
+                    } else {
+                        if (AUTOTAG_CENTER) {
+                            // let's see if we need to mark center_x as connected
+                            if (opposite.isConnected() && opposite.getTarget().getOwner()
+                                    == toAnchor.getOwner()) {
+                                ConstraintAnchor targetCenterX = toAnchor.getOwner().getAnchor(
+                                        ConstraintAnchor.Type.CENTER_X);
+                                centerX.connect(targetCenterX, 0);
+                            }
+                        }
+                    }
+
+                }
+                fromAnchor.connect(toAnchor, margin);
+            }
+        }
+    }
+
+    /**
+     * Reset all the constraints set on this widget
+     */
+    public void resetAllConstraints() {
+        resetAnchors();
+        setVerticalBiasPercent(DEFAULT_BIAS);
+        setHorizontalBiasPercent(DEFAULT_BIAS);
+    }
+
+    /**
+     * Reset the given anchor
+     *
+     * @param anchor the anchor we want to reset
+     */
+    public void resetAnchor(ConstraintAnchor anchor) {
+        if (getParent() != null) {
+            if (getParent() instanceof ConstraintWidgetContainer) {
+                ConstraintWidgetContainer parent = (ConstraintWidgetContainer) getParent();
+                if (parent.handlesInternalConstraints()) {
+                    return;
+                }
+            }
+        }
+        ConstraintAnchor left = getAnchor(ConstraintAnchor.Type.LEFT);
+        ConstraintAnchor right = getAnchor(ConstraintAnchor.Type.RIGHT);
+        ConstraintAnchor top = getAnchor(ConstraintAnchor.Type.TOP);
+        ConstraintAnchor bottom = getAnchor(ConstraintAnchor.Type.BOTTOM);
+        ConstraintAnchor center = getAnchor(ConstraintAnchor.Type.CENTER);
+        ConstraintAnchor centerX = getAnchor(ConstraintAnchor.Type.CENTER_X);
+        ConstraintAnchor centerY = getAnchor(ConstraintAnchor.Type.CENTER_Y);
+
+        if (anchor == center) {
+            if (left.isConnected() && right.isConnected()
+                    && left.getTarget() == right.getTarget()) {
+                left.reset();
+                right.reset();
+            }
+            if (top.isConnected() && bottom.isConnected()
+                    && top.getTarget() == bottom.getTarget()) {
+                top.reset();
+                bottom.reset();
+            }
+            mHorizontalBiasPercent = 0.5f;
+            mVerticalBiasPercent = 0.5f;
+        } else if (anchor == centerX) {
+            if (left.isConnected() && right.isConnected()
+                    && left.getTarget().getOwner() == right.getTarget().getOwner()) {
+                left.reset();
+                right.reset();
+            }
+            mHorizontalBiasPercent = 0.5f;
+        } else if (anchor == centerY) {
+            if (top.isConnected() && bottom.isConnected()
+                    && top.getTarget().getOwner() == bottom.getTarget().getOwner()) {
+                top.reset();
+                bottom.reset();
+            }
+            mVerticalBiasPercent = 0.5f;
+        } else if (anchor == left || anchor == right) {
+            if (left.isConnected() && left.getTarget() == right.getTarget()) {
+                center.reset();
+            }
+        } else if (anchor == top || anchor == bottom) {
+            if (top.isConnected() && top.getTarget() == bottom.getTarget()) {
+                center.reset();
+            }
+        }
+        anchor.reset();
+    }
+
+    /**
+     * Reset all connections
+     */
+    public void resetAnchors() {
+        ConstraintWidget parent = getParent();
+        if (parent != null && parent instanceof ConstraintWidgetContainer) {
+            ConstraintWidgetContainer parentContainer = (ConstraintWidgetContainer) getParent();
+            if (parentContainer.handlesInternalConstraints()) {
+                return;
+            }
+        }
+        for (int i = 0, mAnchorsSize = mAnchors.size(); i < mAnchorsSize; i++) {
+            final ConstraintAnchor anchor = mAnchors.get(i);
+            anchor.reset();
+        }
+    }
+
+    /**
+     * Given a type of anchor, returns the corresponding anchor.
+     *
+     * @param anchorType type of the anchor (LEFT, TOP, RIGHT, BOTTOM, BASELINE, CENTER_X, CENTER_Y)
+     * @return the matching anchor
+     */
+    public ConstraintAnchor getAnchor(ConstraintAnchor.Type anchorType) {
+        switch (anchorType) {
+            case LEFT: {
+                return mLeft;
+            }
+            case TOP: {
+                return mTop;
+            }
+            case RIGHT: {
+                return mRight;
+            }
+            case BOTTOM: {
+                return mBottom;
+            }
+            case BASELINE: {
+                return mBaseline;
+            }
+            case CENTER_X: {
+                return mCenterX;
+            }
+            case CENTER_Y: {
+                return mCenterY;
+            }
+            case CENTER: {
+                return mCenter;
+            }
+            case NONE:
+                return null;
+        }
+        throw new AssertionError(anchorType.name());
+    }
+
+    /**
+     * Accessor for the horizontal dimension behaviour
+     *
+     * @return dimension behaviour
+     */
+    public DimensionBehaviour getHorizontalDimensionBehaviour() {
+        return mListDimensionBehaviors[DIMENSION_HORIZONTAL];
+    }
+
+    /**
+     * Accessor for the vertical dimension behaviour
+     *
+     * @return dimension behaviour
+     */
+    public DimensionBehaviour getVerticalDimensionBehaviour() {
+        return mListDimensionBehaviors[DIMENSION_VERTICAL];
+    }
+
+    /**
+     * Get the widget's {@link DimensionBehaviour} in an specific orientation.
+     *
+     * @return The {@link DimensionBehaviour} of the widget.
+     */
+    public DimensionBehaviour getDimensionBehaviour(int orientation) {
+        if (orientation == HORIZONTAL) {
+            return getHorizontalDimensionBehaviour();
+        } else if (orientation == VERTICAL) {
+            return getVerticalDimensionBehaviour();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Set the widget's behaviour for the horizontal dimension
+     *
+     * @param behaviour the horizontal dimension's behaviour
+     */
+    public void setHorizontalDimensionBehaviour(DimensionBehaviour behaviour) {
+        mListDimensionBehaviors[DIMENSION_HORIZONTAL] = behaviour;
+    }
+
+    /**
+     * Set the widget's behaviour for the vertical dimension
+     *
+     * @param behaviour the vertical dimension's behaviour
+     */
+    public void setVerticalDimensionBehaviour(DimensionBehaviour behaviour) {
+        mListDimensionBehaviors[DIMENSION_VERTICAL] = behaviour;
+    }
+
+    /**
+     * Test if you are in a Horizontal chain
+     *
+     * @return true if in a horizontal chain
+     */
+    public boolean isInHorizontalChain() {
+        if ((mLeft.mTarget != null && mLeft.mTarget.mTarget == mLeft)
+                || (mRight.mTarget != null && mRight.mTarget.mTarget == mRight)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return the previous chain member if one exists
+     *
+     * @param orientation HORIZONTAL or VERTICAL
+     * @return the previous chain member or null if we are the first chain element
+     */
+    public ConstraintWidget getPreviousChainMember(int orientation) {
+        if (orientation == HORIZONTAL) {
+            if (mLeft.mTarget != null && mLeft.mTarget.mTarget == mLeft) {
+                return mLeft.mTarget.mOwner;
+            }
+        } else if (orientation == VERTICAL) {
+            if (mTop.mTarget != null && mTop.mTarget.mTarget == mTop) {
+                return mTop.mTarget.mOwner;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return the next chain member if one exists
+     *
+     * @param orientation HORIZONTAL or VERTICAL
+     * @return the next chain member or null if we are the last chain element
+     */
+    public ConstraintWidget getNextChainMember(int orientation) {
+        if (orientation == HORIZONTAL) {
+            if (mRight.mTarget != null && mRight.mTarget.mTarget == mRight) {
+                return mRight.mTarget.mOwner;
+            }
+        } else if (orientation == VERTICAL) {
+            if (mBottom.mTarget != null && mBottom.mTarget.mTarget == mBottom) {
+                return mBottom.mTarget.mOwner;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * if in a horizontal chain return the left most widget in the chain.
+     *
+     * @return left most widget in chain or null
+     */
+    public ConstraintWidget getHorizontalChainControlWidget() {
+        ConstraintWidget found = null;
+        if (isInHorizontalChain()) {
+            ConstraintWidget tmp = this;
+
+            while (found == null && tmp != null) {
+                ConstraintAnchor anchor = tmp.getAnchor(ConstraintAnchor.Type.LEFT);
+                ConstraintAnchor targetOwner = (anchor == null) ? null : anchor.getTarget();
+                ConstraintWidget target = (targetOwner == null) ? null : targetOwner.getOwner();
+                if (target == getParent()) {
+                    found = tmp;
+                    break;
+                }
+                ConstraintAnchor targetAnchor = (target == null)
+                        ? null : target.getAnchor(ConstraintAnchor.Type.RIGHT).getTarget();
+                if (targetAnchor != null && targetAnchor.getOwner() != tmp) {
+                    found = tmp;
+                } else {
+                    tmp = target;
+                }
+            }
+        }
+        return found;
+    }
+
+
+    /**
+     * Test if you are in a vertical chain
+     *
+     * @return true if in a vertical chain
+     */
+    public boolean isInVerticalChain() {
+        if ((mTop.mTarget != null && mTop.mTarget.mTarget == mTop)
+                || (mBottom.mTarget != null && mBottom.mTarget.mTarget == mBottom)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * if in a vertical chain return the top most widget in the chain.
+     *
+     * @return top most widget in chain or null
+     */
+    public ConstraintWidget getVerticalChainControlWidget() {
+        ConstraintWidget found = null;
+        if (isInVerticalChain()) {
+            ConstraintWidget tmp = this;
+            while (found == null && tmp != null) {
+                ConstraintAnchor anchor = tmp.getAnchor(ConstraintAnchor.Type.TOP);
+                ConstraintAnchor targetOwner = (anchor == null) ? null : anchor.getTarget();
+                ConstraintWidget target = (targetOwner == null) ? null : targetOwner.getOwner();
+                if (target == getParent()) {
+                    found = tmp;
+                    break;
+                }
+                ConstraintAnchor targetAnchor = (target == null)
+                        ? null : target.getAnchor(ConstraintAnchor.Type.BOTTOM).getTarget();
+                if (targetAnchor != null && targetAnchor.getOwner() != tmp) {
+                    found = tmp;
+                } else {
+                    tmp = target;
+                }
+            }
+
+        }
+        return found;
+    }
+
+    /**
+     * Determine if the widget is the first element of a chain in a given orientation.
+     *
+     * @param orientation Either {@link #HORIZONTAL} or {@link #VERTICAL}
+     * @return if the widget is the head of a chain
+     */
+    private boolean isChainHead(int orientation) {
+        int offset = orientation * 2;
+        return (mListAnchors[offset].mTarget != null
+                && mListAnchors[offset].mTarget.mTarget != mListAnchors[offset])
+                && (mListAnchors[offset + 1].mTarget != null
+                && mListAnchors[offset + 1].mTarget.mTarget == mListAnchors[offset + 1]);
+    }
+
+
+    /*-----------------------------------------------------------------------*/
+    // Constraints
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Add this widget to the solver
+     *
+     * @param system   the solver we want to add the widget to
+     * @param optimize true if {@link Optimizer#OPTIMIZATION_GRAPH} is on
+     */
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("\n----------------------------------------------");
+            System.out.println("-- adding " + getDebugName() + " to the solver");
+            if (isInVirtualLayout()) {
+                System.out.println("-- note: is in virtual layout");
+            }
+            System.out.println("----------------------------------------------\n");
+        }
+
+        SolverVariable left = system.createObjectVariable(mLeft);
+        SolverVariable right = system.createObjectVariable(mRight);
+        SolverVariable top = system.createObjectVariable(mTop);
+        SolverVariable bottom = system.createObjectVariable(mBottom);
+        SolverVariable baseline = system.createObjectVariable(mBaseline);
+
+        boolean horizontalParentWrapContent = false;
+        boolean verticalParentWrapContent = false;
+        if (mParent != null) {
+            horizontalParentWrapContent = mParent != null
+                    ? mParent.mListDimensionBehaviors[DIMENSION_HORIZONTAL] == WRAP_CONTENT : false;
+            verticalParentWrapContent = mParent != null
+                    ? mParent.mListDimensionBehaviors[DIMENSION_VERTICAL] == WRAP_CONTENT : false;
+
+            switch (mWrapBehaviorInParent) {
+                case WRAP_BEHAVIOR_SKIPPED: {
+                    horizontalParentWrapContent = false;
+                    verticalParentWrapContent = false;
+                }
+                break;
+                case WRAP_BEHAVIOR_HORIZONTAL_ONLY: {
+                    verticalParentWrapContent = false;
+                }
+                break;
+                case WRAP_BEHAVIOR_VERTICAL_ONLY: {
+                    horizontalParentWrapContent = false;
+                }
+                break;
+            }
+        }
+
+        if (!(mVisibility != GONE || mAnimated || hasDependencies()
+                || mIsInBarrier[HORIZONTAL] || mIsInBarrier[VERTICAL])) {
+            return;
+        }
+
+        if (mResolvedHorizontal || mResolvedVertical) {
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("\n----------------------------------------------");
+                System.out.println("-- setting " + getDebugName()
+                        + " to " + mX + ", " + mY + " " + mWidth + " x " + mHeight);
+                System.out.println("----------------------------------------------\n");
+            }
+            // For now apply all, but that won't work for wrap/wrap layouts.
+            if (mResolvedHorizontal) {
+                system.addEquality(left, mX);
+                system.addEquality(right, mX + mWidth);
+                if (horizontalParentWrapContent && mParent != null) {
+                    if (mOptimizeWrapOnResolved) {
+                        ConstraintWidgetContainer container = (ConstraintWidgetContainer) mParent;
+                        container.addHorizontalWrapMinVariable(mLeft);
+                        container.addHorizontalWrapMaxVariable(mRight);
+                    } else {
+                        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+                        system.addGreaterThan(system.createObjectVariable(mParent.mRight),
+                                right, 0, wrapStrength);
+                    }
+                }
+            }
+            if (mResolvedVertical) {
+                system.addEquality(top, mY);
+                system.addEquality(bottom, mY + mHeight);
+                if (mBaseline.hasDependents()) {
+                    system.addEquality(baseline, mY + mBaselineDistance);
+                }
+                if (verticalParentWrapContent && mParent != null) {
+                    if (mOptimizeWrapOnResolved) {
+                        ConstraintWidgetContainer container = (ConstraintWidgetContainer) mParent;
+                        container.addVerticalWrapMinVariable(mTop);
+                        container.addVerticalWrapMaxVariable(mBottom);
+                    } else {
+                        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+                        system.addGreaterThan(system.createObjectVariable(mParent.mBottom),
+                                bottom, 0, wrapStrength);
+                    }
+                }
+            }
+            if (mResolvedHorizontal && mResolvedVertical) {
+                mResolvedHorizontal = false;
+                mResolvedVertical = false;
+                if (LinearSystem.FULL_DEBUG) {
+                    System.out.println("\n----------------------------------------------");
+                    System.out.println("-- setting COMPLETED for " + getDebugName());
+                    System.out.println("----------------------------------------------\n");
+                }
+                return;
+            }
+        }
+
+        if (LinearSystem.sMetrics != null) {
+            LinearSystem.sMetrics.widgets++;
+        }
+        if (FULL_DEBUG) {
+            if (optimize && mHorizontalRun != null && mVerticalRun != null) {
+                System.out.println("-- horizontal run : "
+                        + mHorizontalRun.start + " : " + mHorizontalRun.end);
+                System.out.println("-- vertical run : "
+                        + mVerticalRun.start + " : " + mVerticalRun.end);
+            }
+        }
+        if (optimize && mHorizontalRun != null && mVerticalRun != null
+                && mHorizontalRun.start.resolved && mHorizontalRun.end.resolved
+                && mVerticalRun.start.resolved && mVerticalRun.end.resolved) {
+
+            if (LinearSystem.sMetrics != null) {
+                LinearSystem.sMetrics.graphSolved++;
+            }
+            system.addEquality(left, mHorizontalRun.start.value);
+            system.addEquality(right, mHorizontalRun.end.value);
+            system.addEquality(top, mVerticalRun.start.value);
+            system.addEquality(bottom, mVerticalRun.end.value);
+            system.addEquality(baseline, mVerticalRun.baseline.value);
+            if (mParent != null) {
+                if (horizontalParentWrapContent
+                        && isTerminalWidget[HORIZONTAL] && !isInHorizontalChain()) {
+                    SolverVariable parentMax = system.createObjectVariable(mParent.mRight);
+                    system.addGreaterThan(parentMax, right, 0, SolverVariable.STRENGTH_FIXED);
+                }
+                if (verticalParentWrapContent
+                        && isTerminalWidget[VERTICAL] && !isInVerticalChain()) {
+                    SolverVariable parentMax = system.createObjectVariable(mParent.mBottom);
+                    system.addGreaterThan(parentMax, bottom, 0, SolverVariable.STRENGTH_FIXED);
+                }
+            }
+            mResolvedHorizontal = false;
+            mResolvedVertical = false;
+            return; // we are done here
+        }
+        if (LinearSystem.sMetrics != null) {
+            LinearSystem.sMetrics.linearSolved++;
+        }
+
+        boolean inHorizontalChain = false;
+        boolean inVerticalChain = false;
+
+        if (mParent != null) {
+            // Add this widget to a horizontal chain if it is the Head of it.
+            if (isChainHead(HORIZONTAL)) {
+                ((ConstraintWidgetContainer) mParent).addChain(this, HORIZONTAL);
+                inHorizontalChain = true;
+            } else {
+                inHorizontalChain = isInHorizontalChain();
+            }
+
+            // Add this widget to a vertical chain if it is the Head of it.
+            if (isChainHead(VERTICAL)) {
+                ((ConstraintWidgetContainer) mParent).addChain(this, VERTICAL);
+                inVerticalChain = true;
+            } else {
+                inVerticalChain = isInVerticalChain();
+            }
+
+            if (!inHorizontalChain && horizontalParentWrapContent && mVisibility != GONE
+                    && mLeft.mTarget == null && mRight.mTarget == null) {
+                if (FULL_DEBUG) {
+                    System.out.println("<>1 ADDING H WRAP GREATER FOR " + getDebugName());
+                }
+                SolverVariable parentRight = system.createObjectVariable(mParent.mRight);
+                system.addGreaterThan(parentRight, right, 0, SolverVariable.STRENGTH_LOW);
+            }
+
+            if (!inVerticalChain && verticalParentWrapContent && mVisibility != GONE
+                    && mTop.mTarget == null && mBottom.mTarget == null && mBaseline == null) {
+                if (FULL_DEBUG) {
+                    System.out.println("<>1 ADDING V WRAP GREATER FOR " + getDebugName());
+                }
+                SolverVariable parentBottom = system.createObjectVariable(mParent.mBottom);
+                system.addGreaterThan(parentBottom, bottom, 0, SolverVariable.STRENGTH_LOW);
+            }
+        }
+
+        int width = mWidth;
+        if (width < mMinWidth) {
+            width = mMinWidth;
+        }
+        int height = mHeight;
+        if (height < mMinHeight) {
+            height = mMinHeight;
+        }
+
+        // Dimensions can be either fixed (a given value)
+        // or dependent on the solver if set to MATCH_CONSTRAINT
+        boolean horizontalDimensionFixed =
+                mListDimensionBehaviors[DIMENSION_HORIZONTAL] != MATCH_CONSTRAINT;
+        boolean verticalDimensionFixed =
+                mListDimensionBehaviors[DIMENSION_VERTICAL] != MATCH_CONSTRAINT;
+
+        // We evaluate the dimension ratio here as the connections can change.
+        // TODO: have a validation pass after connection instead
+        boolean useRatio = false;
+        mResolvedDimensionRatioSide = mDimensionRatioSide;
+        mResolvedDimensionRatio = mDimensionRatio;
+
+        int matchConstraintDefaultWidth = mMatchConstraintDefaultWidth;
+        int matchConstraintDefaultHeight = mMatchConstraintDefaultHeight;
+
+        if (mDimensionRatio > 0 && mVisibility != GONE) {
+            useRatio = true;
+            if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == MATCH_CONSTRAINT
+                    && matchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                matchConstraintDefaultWidth = MATCH_CONSTRAINT_RATIO;
+            }
+            if (mListDimensionBehaviors[DIMENSION_VERTICAL] == MATCH_CONSTRAINT
+                    && matchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                matchConstraintDefaultHeight = MATCH_CONSTRAINT_RATIO;
+            }
+
+            if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == MATCH_CONSTRAINT
+                    && mListDimensionBehaviors[DIMENSION_VERTICAL] == MATCH_CONSTRAINT
+                    && matchConstraintDefaultWidth == MATCH_CONSTRAINT_RATIO
+                    && matchConstraintDefaultHeight == MATCH_CONSTRAINT_RATIO) {
+                setupDimensionRatio(horizontalParentWrapContent, verticalParentWrapContent,
+                        horizontalDimensionFixed, verticalDimensionFixed);
+            } else if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == MATCH_CONSTRAINT
+                    && matchConstraintDefaultWidth == MATCH_CONSTRAINT_RATIO) {
+                mResolvedDimensionRatioSide = HORIZONTAL;
+                width = (int) (mResolvedDimensionRatio * mHeight);
+                if (mListDimensionBehaviors[DIMENSION_VERTICAL] != MATCH_CONSTRAINT) {
+                    matchConstraintDefaultWidth = MATCH_CONSTRAINT_RATIO_RESOLVED;
+                    useRatio = false;
+                }
+            } else if (mListDimensionBehaviors[DIMENSION_VERTICAL] == MATCH_CONSTRAINT
+                    && matchConstraintDefaultHeight == MATCH_CONSTRAINT_RATIO) {
+                mResolvedDimensionRatioSide = VERTICAL;
+                if (mDimensionRatioSide == UNKNOWN) {
+                    // need to reverse the ratio as the parsing is done in horizontal mode
+                    mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+                }
+                height = (int) (mResolvedDimensionRatio * mWidth);
+                if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] != MATCH_CONSTRAINT) {
+                    matchConstraintDefaultHeight = MATCH_CONSTRAINT_RATIO_RESOLVED;
+                    useRatio = false;
+                }
+            }
+        }
+
+        mResolvedMatchConstraintDefault[HORIZONTAL] = matchConstraintDefaultWidth;
+        mResolvedMatchConstraintDefault[VERTICAL] = matchConstraintDefaultHeight;
+        mResolvedHasRatio = useRatio;
+
+        boolean useHorizontalRatio = useRatio && (mResolvedDimensionRatioSide == HORIZONTAL
+                || mResolvedDimensionRatioSide == UNKNOWN);
+
+        boolean useVerticalRatio = useRatio && (mResolvedDimensionRatioSide == VERTICAL
+                || mResolvedDimensionRatioSide == UNKNOWN);
+
+        // Horizontal resolution
+        boolean wrapContent = (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == WRAP_CONTENT)
+                && (this instanceof ConstraintWidgetContainer);
+        if (wrapContent) {
+            width = 0;
+        }
+
+        boolean applyPosition = true;
+        if (mCenter.isConnected()) {
+            applyPosition = false;
+        }
+
+        boolean isInHorizontalBarrier = mIsInBarrier[HORIZONTAL];
+        boolean isInVerticalBarrier = mIsInBarrier[VERTICAL];
+
+        if (mHorizontalResolution != DIRECT && !mResolvedHorizontal) {
+            if (!optimize || !(mHorizontalRun != null
+                    && mHorizontalRun.start.resolved && mHorizontalRun.end.resolved)) {
+                SolverVariable parentMax = mParent != null
+                        ? system.createObjectVariable(mParent.mRight) : null;
+                SolverVariable parentMin = mParent != null
+                        ? system.createObjectVariable(mParent.mLeft) : null;
+                applyConstraints(system, true, horizontalParentWrapContent,
+                        verticalParentWrapContent, isTerminalWidget[HORIZONTAL], parentMin,
+                        parentMax, mListDimensionBehaviors[DIMENSION_HORIZONTAL], wrapContent,
+                        mLeft, mRight, mX, width,
+                        mMinWidth, mMaxDimension[HORIZONTAL],
+                        mHorizontalBiasPercent, useHorizontalRatio,
+                        mListDimensionBehaviors[VERTICAL] == MATCH_CONSTRAINT,
+                        inHorizontalChain, inVerticalChain, isInHorizontalBarrier,
+                        matchConstraintDefaultWidth, matchConstraintDefaultHeight,
+                        mMatchConstraintMinWidth, mMatchConstraintMaxWidth,
+                        mMatchConstraintPercentWidth, applyPosition);
+            } else if (optimize) {
+                system.addEquality(left, mHorizontalRun.start.value);
+                system.addEquality(right, mHorizontalRun.end.value);
+                if (mParent != null) {
+                    if (horizontalParentWrapContent
+                            && isTerminalWidget[HORIZONTAL] && !isInHorizontalChain()) {
+                        if (FULL_DEBUG) {
+                            System.out.println("<>2 ADDING H WRAP GREATER FOR " + getDebugName());
+                        }
+                        SolverVariable parentMax = system.createObjectVariable(mParent.mRight);
+                        system.addGreaterThan(parentMax, right, 0, SolverVariable.STRENGTH_FIXED);
+                    }
+                }
+            }
+        }
+
+        boolean applyVerticalConstraints = true;
+        if (optimize && mVerticalRun != null
+                && mVerticalRun.start.resolved && mVerticalRun.end.resolved) {
+            system.addEquality(top, mVerticalRun.start.value);
+            system.addEquality(bottom, mVerticalRun.end.value);
+            system.addEquality(baseline, mVerticalRun.baseline.value);
+            if (mParent != null) {
+                if (!inVerticalChain && verticalParentWrapContent && isTerminalWidget[VERTICAL]) {
+                    if (FULL_DEBUG) {
+                        System.out.println("<>2 ADDING V WRAP GREATER FOR " + getDebugName());
+                    }
+                    SolverVariable parentMax = system.createObjectVariable(mParent.mBottom);
+                    system.addGreaterThan(parentMax, bottom, 0, SolverVariable.STRENGTH_FIXED);
+                }
+            }
+            applyVerticalConstraints = false;
+        }
+        if (mVerticalResolution == DIRECT) {
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("\n----------------------------------------------");
+                System.out.println("-- DONE adding " + getDebugName() + " to the solver");
+                System.out.println("-- SKIP VERTICAL RESOLUTION");
+                System.out.println("----------------------------------------------\n");
+            }
+            applyVerticalConstraints = false;
+        }
+        if (applyVerticalConstraints && !mResolvedVertical) {
+            // Vertical Resolution
+            wrapContent = (mListDimensionBehaviors[DIMENSION_VERTICAL] == WRAP_CONTENT)
+                    && (this instanceof ConstraintWidgetContainer);
+            if (wrapContent) {
+                height = 0;
+            }
+
+            SolverVariable parentMax = mParent != null
+                    ? system.createObjectVariable(mParent.mBottom) : null;
+            SolverVariable parentMin = mParent != null
+                    ? system.createObjectVariable(mParent.mTop) : null;
+
+            if (mBaselineDistance > 0 || mVisibility == GONE) {
+                // if we are GONE we might still have to deal with baseline,
+                // even if our baseline distance would be zero
+                if (mBaseline.mTarget != null) {
+                    system.addEquality(baseline, top, getBaselineDistance(),
+                            SolverVariable.STRENGTH_FIXED);
+                    SolverVariable baselineTarget = system.createObjectVariable(mBaseline.mTarget);
+                    int baselineMargin = mBaseline.getMargin();
+                    system.addEquality(baseline, baselineTarget, baselineMargin,
+                            SolverVariable.STRENGTH_FIXED);
+                    applyPosition = false;
+                    if (verticalParentWrapContent) {
+                        if (FULL_DEBUG) {
+                            System.out.println("<>3 ADDING V WRAP GREATER FOR " + getDebugName());
+                        }
+                        SolverVariable end = system.createObjectVariable(mBottom);
+                        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+                        system.addGreaterThan(parentMax, end, 0, wrapStrength);
+                    }
+                } else if (mVisibility == GONE) {
+                    // TODO: use the constraints graph here to help
+                    system.addEquality(baseline, top, mBaseline.getMargin(),
+                            SolverVariable.STRENGTH_FIXED);
+                } else {
+                    system.addEquality(baseline, top, getBaselineDistance(),
+                            SolverVariable.STRENGTH_FIXED);
+                }
+            }
+
+            applyConstraints(system, false, verticalParentWrapContent,
+                    horizontalParentWrapContent, isTerminalWidget[VERTICAL], parentMin,
+                    parentMax, mListDimensionBehaviors[DIMENSION_VERTICAL],
+                    wrapContent, mTop, mBottom, mY, height,
+                    mMinHeight, mMaxDimension[VERTICAL], mVerticalBiasPercent, useVerticalRatio,
+                    mListDimensionBehaviors[HORIZONTAL] == MATCH_CONSTRAINT,
+                    inVerticalChain, inHorizontalChain, isInVerticalBarrier,
+                    matchConstraintDefaultHeight, matchConstraintDefaultWidth,
+                    mMatchConstraintMinHeight, mMatchConstraintMaxHeight,
+                    mMatchConstraintPercentHeight, applyPosition);
+        }
+
+        if (useRatio) {
+            int strength = SolverVariable.STRENGTH_FIXED;
+            if (mResolvedDimensionRatioSide == VERTICAL) {
+                system.addRatio(bottom, top, right, left, mResolvedDimensionRatio, strength);
+            } else {
+                system.addRatio(right, left, bottom, top, mResolvedDimensionRatio, strength);
+            }
+        }
+
+        if (mCenter.isConnected()) {
+            system.addCenterPoint(this, mCenter.getTarget().getOwner(),
+                    (float) Math.toRadians(mCircleConstraintAngle + 90), mCenter.getMargin());
+        }
+
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("\n----------------------------------------------");
+            System.out.println("-- DONE adding " + getDebugName() + " to the solver");
+            System.out.println("----------------------------------------------\n");
+        }
+        mResolvedHorizontal = false;
+        mResolvedVertical = false;
+        if (LinearSystem.sMetrics != null) {
+            LinearSystem.sMetrics.mEquations = system.getNumEquations();
+            LinearSystem.sMetrics.mVariables = system.getNumVariables();
+        }
+
+    }
+
+    /**
+     * Used to select which widgets should be added to the solver first
+     */
+    boolean addFirst() {
+        return this instanceof VirtualLayout || this instanceof Guideline;
+    }
+
+    /**
+     * Resolves the dimension ratio parameters
+     * (mResolvedDimensionRatioSide & mDimensionRatio)
+     *
+     * @param hParentWrapContent       true if parent is in wrap content horizontally
+     * @param vParentWrapContent       true if parent is in wrap content vertically
+     * @param horizontalDimensionFixed true if this widget horizontal dimension is fixed
+     * @param verticalDimensionFixed   true if this widget vertical dimension is fixed
+     */
+    public void setupDimensionRatio(boolean hParentWrapContent,
+            boolean vParentWrapContent,
+            boolean horizontalDimensionFixed,
+            boolean verticalDimensionFixed) {
+        if (mResolvedDimensionRatioSide == UNKNOWN) {
+            if (horizontalDimensionFixed && !verticalDimensionFixed) {
+                mResolvedDimensionRatioSide = HORIZONTAL;
+            } else if (!horizontalDimensionFixed && verticalDimensionFixed) {
+                mResolvedDimensionRatioSide = VERTICAL;
+                if (mDimensionRatioSide == UNKNOWN) {
+                    // need to reverse the ratio as the parsing is done in horizontal mode
+                    mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+                }
+            }
+        }
+
+        if (mResolvedDimensionRatioSide == HORIZONTAL
+                && !(mTop.isConnected() && mBottom.isConnected())) {
+            mResolvedDimensionRatioSide = VERTICAL;
+        } else if (mResolvedDimensionRatioSide == VERTICAL
+                && !(mLeft.isConnected() && mRight.isConnected())) {
+            mResolvedDimensionRatioSide = HORIZONTAL;
+        }
+
+        // if dimension is still unknown... check parentWrap
+        if (mResolvedDimensionRatioSide == UNKNOWN) {
+            if (!(mTop.isConnected() && mBottom.isConnected()
+                    && mLeft.isConnected() && mRight.isConnected())) {
+                // only do that if not all connections are set
+                if (mTop.isConnected() && mBottom.isConnected()) {
+                    mResolvedDimensionRatioSide = HORIZONTAL;
+                } else if (mLeft.isConnected() && mRight.isConnected()) {
+                    mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+                    mResolvedDimensionRatioSide = VERTICAL;
+                }
+            }
+        }
+
+        if (DO_NOT_USE && mResolvedDimensionRatioSide == UNKNOWN) {
+            if (hParentWrapContent && !vParentWrapContent) {
+                mResolvedDimensionRatioSide = HORIZONTAL;
+            } else if (!hParentWrapContent && vParentWrapContent) {
+                mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+                mResolvedDimensionRatioSide = VERTICAL;
+            }
+        }
+
+        if (mResolvedDimensionRatioSide == UNKNOWN) {
+            if (mMatchConstraintMinWidth > 0 && mMatchConstraintMinHeight == 0) {
+                mResolvedDimensionRatioSide = HORIZONTAL;
+            } else if (mMatchConstraintMinWidth == 0 && mMatchConstraintMinHeight > 0) {
+                mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+                mResolvedDimensionRatioSide = VERTICAL;
+            }
+        }
+
+        if (DO_NOT_USE && mResolvedDimensionRatioSide == UNKNOWN
+                && hParentWrapContent && vParentWrapContent) {
+            mResolvedDimensionRatio = 1 / mResolvedDimensionRatio;
+            mResolvedDimensionRatioSide = VERTICAL;
+        }
+    }
+
+    /**
+     * Apply the constraints in the system depending on the existing anchors, in one dimension
+     *
+     * @param system                the linear system we are adding constraints to
+     * @param wrapContent           is the widget trying to wrap its content
+     *                              (i.e. its size will depends on its content)
+     * @param beginAnchor           the first anchor
+     * @param endAnchor             the second anchor
+     * @param beginPosition         the original position of the anchor
+     * @param dimension             the dimension
+     * @param matchPercentDimension the percentage relative to the parent,
+     *                              applied if in match constraint and percent mode
+     */
+    private void applyConstraints(LinearSystem system, boolean isHorizontal,
+            boolean parentWrapContent, boolean oppositeParentWrapContent,
+            boolean isTerminal, SolverVariable parentMin,
+            SolverVariable parentMax,
+            DimensionBehaviour dimensionBehaviour, boolean wrapContent,
+            ConstraintAnchor beginAnchor, ConstraintAnchor endAnchor,
+            int beginPosition, int dimension, int minDimension,
+            int maxDimension, float bias, boolean useRatio,
+            boolean oppositeVariable, boolean inChain,
+            boolean oppositeInChain, boolean inBarrier,
+            int matchConstraintDefault,
+            int oppositeMatchConstraintDefault,
+            int matchMinDimension, int matchMaxDimension,
+            float matchPercentDimension, boolean applyPosition) {
+        SolverVariable begin = system.createObjectVariable(beginAnchor);
+        SolverVariable end = system.createObjectVariable(endAnchor);
+        SolverVariable beginTarget = system.createObjectVariable(beginAnchor.getTarget());
+        SolverVariable endTarget = system.createObjectVariable(endAnchor.getTarget());
+
+        if (system.getMetrics() != null) {
+            system.getMetrics().nonresolvedWidgets++;
+        }
+
+        boolean isBeginConnected = beginAnchor.isConnected();
+        boolean isEndConnected = endAnchor.isConnected();
+        boolean isCenterConnected = mCenter.isConnected();
+
+        boolean variableSize = false;
+
+        int numConnections = 0;
+        if (isBeginConnected) {
+            numConnections++;
+        }
+        if (isEndConnected) {
+            numConnections++;
+        }
+        if (isCenterConnected) {
+            numConnections++;
+        }
+
+        if (useRatio) {
+            matchConstraintDefault = MATCH_CONSTRAINT_RATIO;
+        }
+        switch (dimensionBehaviour) {
+            case FIXED: {
+                variableSize = false;
+            }
+            break;
+            case WRAP_CONTENT: {
+                variableSize = false;
+            }
+            break;
+            case MATCH_PARENT: {
+                variableSize = false;
+            }
+            break;
+            case MATCH_CONSTRAINT: {
+                variableSize = matchConstraintDefault != MATCH_CONSTRAINT_RATIO_RESOLVED;
+            }
+            break;
+        }
+
+
+        if (mWidthOverride != -1 && isHorizontal) {
+            if (FULL_DEBUG) {
+                System.out.println("OVERRIDE WIDTH to " + mWidthOverride);
+            }
+            variableSize = false;
+            dimension = mWidthOverride;
+            mWidthOverride = -1;
+        }
+        if (mHeightOverride != -1 && !isHorizontal) {
+            if (FULL_DEBUG) {
+                System.out.println("OVERRIDE HEIGHT to " + mHeightOverride);
+            }
+            variableSize = false;
+            dimension = mHeightOverride;
+            mHeightOverride = -1;
+        }
+
+        if (mVisibility == ConstraintWidget.GONE) {
+            dimension = 0;
+            variableSize = false;
+        }
+
+        // First apply starting direct connections (more solver-friendly)
+        if (applyPosition) {
+            if (!isBeginConnected && !isEndConnected && !isCenterConnected) {
+                system.addEquality(begin, beginPosition);
+            } else if (isBeginConnected && !isEndConnected) {
+                system.addEquality(begin, beginTarget,
+                        beginAnchor.getMargin(), SolverVariable.STRENGTH_FIXED);
+            }
+        }
+
+        // Then apply the dimension
+        if (!variableSize) {
+            if (wrapContent) {
+                system.addEquality(end, begin, 0, SolverVariable.STRENGTH_HIGH);
+                if (minDimension > 0) {
+                    system.addGreaterThan(end, begin, minDimension, SolverVariable.STRENGTH_FIXED);
+                }
+                if (maxDimension < Integer.MAX_VALUE) {
+                    system.addLowerThan(end, begin, maxDimension, SolverVariable.STRENGTH_FIXED);
+                }
+            } else {
+                system.addEquality(end, begin, dimension, SolverVariable.STRENGTH_FIXED);
+            }
+        } else {
+            if (numConnections != 2
+                    && !useRatio
+                    && ((matchConstraintDefault == MATCH_CONSTRAINT_WRAP)
+                    || (matchConstraintDefault == MATCH_CONSTRAINT_SPREAD))) {
+                variableSize = false;
+                int d = Math.max(matchMinDimension, dimension);
+                if (matchMaxDimension > 0) {
+                    d = Math.min(matchMaxDimension, d);
+                }
+                system.addEquality(end, begin, d, SolverVariable.STRENGTH_FIXED);
+            } else {
+                if (matchMinDimension == WRAP) {
+                    matchMinDimension = dimension;
+                }
+                if (matchMaxDimension == WRAP) {
+                    matchMaxDimension = dimension;
+                }
+                if (dimension > 0
+                        && matchConstraintDefault != MATCH_CONSTRAINT_WRAP) {
+                    if (USE_WRAP_DIMENSION_FOR_SPREAD
+                            && (matchConstraintDefault == MATCH_CONSTRAINT_SPREAD)) {
+                        system.addGreaterThan(end, begin, dimension,
+                                SolverVariable.STRENGTH_HIGHEST);
+                    }
+                    dimension = 0;
+                }
+
+                if (matchMinDimension > 0) {
+                    system.addGreaterThan(end, begin, matchMinDimension,
+                            SolverVariable.STRENGTH_FIXED);
+                    dimension = Math.max(dimension, matchMinDimension);
+                }
+                if (matchMaxDimension > 0) {
+                    boolean applyLimit = true;
+                    if (parentWrapContent && matchConstraintDefault == MATCH_CONSTRAINT_WRAP) {
+                        applyLimit = false;
+                    }
+                    if (applyLimit) {
+                        system.addLowerThan(end, begin,
+                                matchMaxDimension, SolverVariable.STRENGTH_FIXED);
+                    }
+                    dimension = Math.min(dimension, matchMaxDimension);
+                }
+                if (matchConstraintDefault == MATCH_CONSTRAINT_WRAP) {
+                    if (parentWrapContent) {
+                        system.addEquality(end, begin, dimension, SolverVariable.STRENGTH_FIXED);
+                    } else if (inChain) {
+                        system.addEquality(end, begin, dimension, SolverVariable.STRENGTH_EQUALITY);
+                        system.addLowerThan(end, begin, dimension, SolverVariable.STRENGTH_FIXED);
+                    } else {
+                        system.addEquality(end, begin, dimension, SolverVariable.STRENGTH_EQUALITY);
+                        system.addLowerThan(end, begin, dimension, SolverVariable.STRENGTH_FIXED);
+                    }
+                } else if (matchConstraintDefault == MATCH_CONSTRAINT_PERCENT) {
+                    SolverVariable percentBegin = null;
+                    SolverVariable percentEnd = null;
+                    if (beginAnchor.getType() == ConstraintAnchor.Type.TOP
+                            || beginAnchor.getType() == ConstraintAnchor.Type.BOTTOM) {
+                        // vertical
+                        percentBegin = system.createObjectVariable(
+                                mParent.getAnchor(ConstraintAnchor.Type.TOP));
+                        percentEnd = system.createObjectVariable(
+                                mParent.getAnchor(ConstraintAnchor.Type.BOTTOM));
+                    } else {
+                        percentBegin = system.createObjectVariable(
+                                mParent.getAnchor(ConstraintAnchor.Type.LEFT));
+                        percentEnd = system.createObjectVariable(
+                                mParent.getAnchor(ConstraintAnchor.Type.RIGHT));
+                    }
+                    system.addConstraint(system.createRow().createRowDimensionRatio(end,
+                            begin, percentEnd, percentBegin, matchPercentDimension));
+                    if (parentWrapContent) {
+                        variableSize = false;
+                    }
+                } else {
+                    isTerminal = true;
+                }
+            }
+        }
+
+        if (!applyPosition || inChain) {
+            // If we don't need to apply the position, let's finish now.
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("only deal with dimension for " + mDebugName
+                        + ", not positioning (applyPosition: "
+                        + applyPosition + " inChain: " + inChain + ")");
+            }
+            if (numConnections < 2 && parentWrapContent && isTerminal) {
+                system.addGreaterThan(begin, parentMin, 0, SolverVariable.STRENGTH_FIXED);
+                boolean applyEnd = isHorizontal || (mBaseline.mTarget == null);
+                if (!isHorizontal && mBaseline.mTarget != null) {
+                    // generally we wouldn't take the current widget in the wrap content,
+                    // but if the connected element is a ratio widget,
+                    // then we can contribute (as the ratio widget may not be enough by itself)
+                    // to it.
+                    ConstraintWidget target = mBaseline.mTarget.mOwner;
+                    if (target.mDimensionRatio != 0
+                            && target.mListDimensionBehaviors[0] == MATCH_CONSTRAINT
+                            && target.mListDimensionBehaviors[1] == MATCH_CONSTRAINT) {
+                        applyEnd = true;
+                    } else {
+                        applyEnd = false;
+                    }
+                }
+                if (applyEnd) {
+                    if (FULL_DEBUG) {
+                        System.out.println("<>4 ADDING WRAP GREATER FOR " + getDebugName());
+                    }
+                    system.addGreaterThan(parentMax, end, 0, SolverVariable.STRENGTH_FIXED);
+                }
+            }
+            return;
+        }
+
+        // Ok, we are dealing with single or centered constraints, let's apply them
+
+        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+
+        if (!isBeginConnected && !isEndConnected && !isCenterConnected) {
+            // note we already applied the start position before, no need to redo it...
+        } else if (isBeginConnected && !isEndConnected) {
+            // note we already applied the start position before, no need to redo it...
+
+            // If we are constrained to a barrier, make sure that we are not bypassed in the wrap
+            ConstraintWidget beginWidget = beginAnchor.mTarget.mOwner;
+            if (parentWrapContent && beginWidget instanceof Barrier) {
+                wrapStrength = SolverVariable.STRENGTH_FIXED;
+            }
+        } else if (!isBeginConnected && isEndConnected) {
+            system.addEquality(end, endTarget,
+                    -endAnchor.getMargin(), SolverVariable.STRENGTH_FIXED);
+            if (parentWrapContent) {
+                if (mOptimizeWrapO && begin.isFinalValue && mParent != null) {
+                    ConstraintWidgetContainer container = (ConstraintWidgetContainer) mParent;
+                    if (isHorizontal) {
+                        container.addHorizontalWrapMinVariable(beginAnchor);
+                    } else {
+                        container.addVerticalWrapMinVariable(beginAnchor);
+                    }
+                } else {
+                    if (FULL_DEBUG) {
+                        System.out.println("<>5 ADDING WRAP GREATER FOR " + getDebugName());
+                    }
+                    system.addGreaterThan(begin, parentMin, 0, SolverVariable.STRENGTH_EQUALITY);
+                }
+            }
+        } else if (isBeginConnected && isEndConnected) {
+            boolean applyBoundsCheck = true;
+            boolean applyCentering = false;
+            boolean applyStrongChecks = false;
+            boolean applyRangeCheck = false;
+            int rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+
+            // TODO: might not need it here (it's overridden)
+            int boundsCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+            int centeringStrength = SolverVariable.STRENGTH_BARRIER;
+
+            if (parentWrapContent) {
+                rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+            }
+            ConstraintWidget beginWidget = beginAnchor.mTarget.mOwner;
+            ConstraintWidget endWidget = endAnchor.mTarget.mOwner;
+            ConstraintWidget parent = getParent();
+
+            if (variableSize) {
+                if (matchConstraintDefault == MATCH_CONSTRAINT_SPREAD) {
+                    if (matchMaxDimension == 0 && matchMinDimension == 0) {
+                        applyStrongChecks = true;
+                        rangeCheckStrength = SolverVariable.STRENGTH_FIXED;
+                        boundsCheckStrength = SolverVariable.STRENGTH_FIXED;
+                        // Optimization in case of centering in parent
+                        if (beginTarget.isFinalValue && endTarget.isFinalValue) {
+                            system.addEquality(begin, beginTarget,
+                                    beginAnchor.getMargin(), SolverVariable.STRENGTH_FIXED);
+                            system.addEquality(end, endTarget,
+                                    -endAnchor.getMargin(), SolverVariable.STRENGTH_FIXED);
+                            return;
+                        }
+                    } else {
+                        applyCentering = true;
+                        rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                        boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                        applyBoundsCheck = true;
+                        applyRangeCheck = true;
+                    }
+                    if (beginWidget instanceof Barrier || endWidget instanceof Barrier) {
+                        boundsCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+                    }
+                } else if (matchConstraintDefault == MATCH_CONSTRAINT_PERCENT) {
+                    applyCentering = true;
+                    rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                    boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                    applyBoundsCheck = true;
+                    applyRangeCheck = true;
+                    if (beginWidget instanceof Barrier || endWidget instanceof Barrier) {
+                        boundsCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+                    }
+                } else if (matchConstraintDefault == MATCH_CONSTRAINT_WRAP) {
+                    applyCentering = true;
+                    applyRangeCheck = true;
+                    rangeCheckStrength = SolverVariable.STRENGTH_FIXED;
+                } else if (matchConstraintDefault == MATCH_CONSTRAINT_RATIO) {
+                    if (mResolvedDimensionRatioSide == UNKNOWN) {
+                        applyCentering = true;
+                        applyRangeCheck = true;
+                        applyStrongChecks = true;
+                        rangeCheckStrength = SolverVariable.STRENGTH_FIXED;
+                        boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                        if (oppositeInChain) {
+                            boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                            centeringStrength = SolverVariable.STRENGTH_HIGHEST;
+                            if (parentWrapContent) {
+                                centeringStrength = SolverVariable.STRENGTH_EQUALITY;
+                            }
+                        } else {
+                            centeringStrength = SolverVariable.STRENGTH_FIXED;
+                        }
+                    } else {
+                        applyCentering = true;
+                        applyRangeCheck = true;
+                        applyStrongChecks = true;
+                        if (useRatio) {
+                            // useRatio is true
+                            // if the side we base ourselves on for the ratio is this one
+                            // if that's not the case, we need to have a stronger constraint.
+                            boolean otherSideInvariable =
+                                    oppositeMatchConstraintDefault == MATCH_CONSTRAINT_PERCENT
+                                            || oppositeMatchConstraintDefault
+                                            == MATCH_CONSTRAINT_WRAP;
+                            if (!otherSideInvariable) {
+                                rangeCheckStrength = SolverVariable.STRENGTH_FIXED;
+                                boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                            }
+                        } else {
+                            rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                            if (matchMaxDimension > 0) {
+                                boundsCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                            } else if (matchMaxDimension == 0 && matchMinDimension == 0) {
+                                if (!oppositeInChain) {
+                                    boundsCheckStrength = SolverVariable.STRENGTH_FIXED;
+                                } else {
+                                    if (beginWidget != parent && endWidget != parent) {
+                                        rangeCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+                                    } else {
+                                        rangeCheckStrength = SolverVariable.STRENGTH_EQUALITY;
+                                    }
+                                    boundsCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                applyCentering = true;
+                applyRangeCheck = true;
+
+                // Let's optimize away if we can...
+                if (beginTarget.isFinalValue && endTarget.isFinalValue) {
+                    system.addCentering(begin, beginTarget, beginAnchor.getMargin(),
+                            bias, endTarget, end, endAnchor.getMargin(),
+                            SolverVariable.STRENGTH_FIXED);
+                    if (parentWrapContent && isTerminal) {
+                        int margin = 0;
+                        if (endAnchor.mTarget != null) {
+                            margin = endAnchor.getMargin();
+                        }
+                        if (endTarget != parentMax) { // if not already applied
+                            if (FULL_DEBUG) {
+                                System.out.println("<>6 ADDING WRAP GREATER FOR " + getDebugName());
+                            }
+                            system.addGreaterThan(parentMax, end, margin, wrapStrength);
+                        }
+                    }
+                    return;
+                }
+            }
+
+            if (applyRangeCheck && beginTarget == endTarget && beginWidget != parent) {
+                // no need to apply range / bounds check if we are centered on the same anchor
+                applyRangeCheck = false;
+                applyBoundsCheck = false;
+            }
+
+            if (applyCentering) {
+                if (!variableSize && !oppositeVariable && !oppositeInChain
+                        && beginTarget == parentMin && endTarget == parentMax) {
+                    // for fixed size widgets, we can simplify the constraints
+                    centeringStrength = SolverVariable.STRENGTH_FIXED;
+                    rangeCheckStrength = SolverVariable.STRENGTH_FIXED;
+                    applyBoundsCheck = false;
+                    parentWrapContent = false;
+                }
+
+                system.addCentering(begin, beginTarget, beginAnchor.getMargin(),
+                        bias, endTarget, end, endAnchor.getMargin(), centeringStrength);
+            }
+
+            if (mVisibility == GONE && !endAnchor.hasDependents()) {
+                return;
+            }
+
+            if (applyRangeCheck) {
+                if (parentWrapContent && beginTarget != endTarget
+                        && !variableSize) {
+                    if (beginWidget instanceof Barrier || endWidget instanceof Barrier) {
+                        rangeCheckStrength = SolverVariable.STRENGTH_BARRIER;
+                    }
+                }
+                system.addGreaterThan(begin, beginTarget,
+                        beginAnchor.getMargin(), rangeCheckStrength);
+                system.addLowerThan(end, endTarget, -endAnchor.getMargin(), rangeCheckStrength);
+            }
+
+            if (parentWrapContent && inBarrier // if we are referenced by a barrier
+                    && !(beginWidget instanceof Barrier || endWidget instanceof Barrier)
+                    && !(endWidget == parent)) {
+                // ... but not directly constrained by it
+                // ... then make sure we can hold our own
+                boundsCheckStrength = SolverVariable.STRENGTH_BARRIER;
+                rangeCheckStrength = SolverVariable.STRENGTH_BARRIER;
+                applyBoundsCheck = true;
+            }
+
+            if (applyBoundsCheck) {
+                if (applyStrongChecks && (!oppositeInChain || oppositeParentWrapContent)) {
+                    int strength = boundsCheckStrength;
+                    if (beginWidget == parent || endWidget == parent) {
+                        strength = SolverVariable.STRENGTH_BARRIER;
+                    }
+                    if (beginWidget instanceof Guideline || endWidget instanceof Guideline) {
+                        strength = SolverVariable.STRENGTH_EQUALITY;
+                    }
+                    if (beginWidget instanceof Barrier || endWidget instanceof Barrier) {
+                        strength = SolverVariable.STRENGTH_EQUALITY;
+                    }
+                    if (oppositeInChain) {
+                        strength = SolverVariable.STRENGTH_EQUALITY;
+                    }
+                    boundsCheckStrength = Math.max(strength, boundsCheckStrength);
+                }
+
+                if (parentWrapContent) {
+                    boundsCheckStrength = Math.min(rangeCheckStrength, boundsCheckStrength);
+                    if (useRatio && !oppositeInChain
+                            && (beginWidget == parent || endWidget == parent)) {
+                        // When using ratio, relax some strength to allow other parts of the system
+                        // to take precedence rather than driving it
+                        boundsCheckStrength = SolverVariable.STRENGTH_HIGHEST;
+                    }
+                }
+                system.addEquality(begin, beginTarget,
+                        beginAnchor.getMargin(), boundsCheckStrength);
+                system.addEquality(end, endTarget, -endAnchor.getMargin(), boundsCheckStrength);
+            }
+
+            if (parentWrapContent) {
+                int margin = 0;
+                if (parentMin == beginTarget) {
+                    margin = beginAnchor.getMargin();
+                }
+                if (beginTarget != parentMin) { // already done otherwise
+                    if (FULL_DEBUG) {
+                        System.out.println("<>7 ADDING WRAP GREATER FOR " + getDebugName());
+                    }
+                    system.addGreaterThan(begin, parentMin, margin, wrapStrength);
+                }
+            }
+
+            if (parentWrapContent && variableSize && minDimension == 0 && matchMinDimension == 0) {
+                if (FULL_DEBUG) {
+                    System.out.println("<>8 ADDING WRAP GREATER FOR " + getDebugName());
+                }
+                if (variableSize && matchConstraintDefault == MATCH_CONSTRAINT_RATIO) {
+                    system.addGreaterThan(end, begin, 0, SolverVariable.STRENGTH_FIXED);
+                } else {
+                    system.addGreaterThan(end, begin, 0, wrapStrength);
+                }
+            }
+        }
+
+        if (parentWrapContent && isTerminal) {
+            int margin = 0;
+            if (endAnchor.mTarget != null) {
+                margin = endAnchor.getMargin();
+            }
+            if (endTarget != parentMax) { // if not already applied
+                if (mOptimizeWrapO && end.isFinalValue && mParent != null) {
+                    ConstraintWidgetContainer container = (ConstraintWidgetContainer) mParent;
+                    if (isHorizontal) {
+                        container.addHorizontalWrapMaxVariable(endAnchor);
+                    } else {
+                        container.addVerticalWrapMaxVariable(endAnchor);
+                    }
+                    return;
+                }
+                if (FULL_DEBUG) {
+                    System.out.println("<>9 ADDING WRAP GREATER FOR " + getDebugName());
+                }
+                system.addGreaterThan(parentMax, end, margin, wrapStrength);
+            }
+        }
+    }
+
+    /**
+     * Update the widget from the values generated by the solver
+     *
+     * @param system   the solver we get the values from.
+     * @param optimize true if {@link Optimizer#OPTIMIZATION_GRAPH} is on
+     */
+    public void updateFromSolver(LinearSystem system, boolean optimize) {
+        int left = system.getObjectVariableValue(mLeft);
+        int top = system.getObjectVariableValue(mTop);
+        int right = system.getObjectVariableValue(mRight);
+        int bottom = system.getObjectVariableValue(mBottom);
+
+        if (optimize && mHorizontalRun != null
+                && mHorizontalRun.start.resolved && mHorizontalRun.end.resolved) {
+            left = mHorizontalRun.start.value;
+            right = mHorizontalRun.end.value;
+        }
+        if (optimize && mVerticalRun != null
+                && mVerticalRun.start.resolved && mVerticalRun.end.resolved) {
+            top = mVerticalRun.start.value;
+            bottom = mVerticalRun.end.value;
+        }
+
+        int w = right - left;
+        int h = bottom - top;
+        if (w < 0 || h < 0
+                || left == Integer.MIN_VALUE || left == Integer.MAX_VALUE
+                || top == Integer.MIN_VALUE || top == Integer.MAX_VALUE
+                || right == Integer.MIN_VALUE || right == Integer.MAX_VALUE
+                || bottom == Integer.MIN_VALUE || bottom == Integer.MAX_VALUE) {
+            left = 0;
+            top = 0;
+            right = 0;
+            bottom = 0;
+        }
+        setFrame(left, top, right, bottom);
+        if (DEBUG) {
+            System.out.println(" *** UPDATE FROM SOLVER " + this);
+        }
+    }
+
+    // @TODO: add description
+    public void copy(ConstraintWidget src, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        // Support for direct resolution
+        mHorizontalResolution = src.mHorizontalResolution;
+        mVerticalResolution = src.mVerticalResolution;
+
+        mMatchConstraintDefaultWidth = src.mMatchConstraintDefaultWidth;
+        mMatchConstraintDefaultHeight = src.mMatchConstraintDefaultHeight;
+
+        mResolvedMatchConstraintDefault[0] = src.mResolvedMatchConstraintDefault[0];
+        mResolvedMatchConstraintDefault[1] = src.mResolvedMatchConstraintDefault[1];
+
+        mMatchConstraintMinWidth = src.mMatchConstraintMinWidth;
+        mMatchConstraintMaxWidth = src.mMatchConstraintMaxWidth;
+        mMatchConstraintMinHeight = src.mMatchConstraintMinHeight;
+        mMatchConstraintMaxHeight = src.mMatchConstraintMaxHeight;
+        mMatchConstraintPercentHeight = src.mMatchConstraintPercentHeight;
+        mIsWidthWrapContent = src.mIsWidthWrapContent;
+        mIsHeightWrapContent = src.mIsHeightWrapContent;
+
+        mResolvedDimensionRatioSide = src.mResolvedDimensionRatioSide;
+        mResolvedDimensionRatio = src.mResolvedDimensionRatio;
+
+        mMaxDimension = Arrays.copyOf(src.mMaxDimension, src.mMaxDimension.length);
+        mCircleConstraintAngle = src.mCircleConstraintAngle;
+
+        mHasBaseline = src.mHasBaseline;
+        mInPlaceholder = src.mInPlaceholder;
+
+        // The anchors available on the widget
+        // note: all anchors should be added to the mAnchors array (see addAnchors())
+
+        mLeft.reset();
+        mTop.reset();
+        mRight.reset();
+        mBottom.reset();
+        mBaseline.reset();
+        mCenterX.reset();
+        mCenterY.reset();
+        mCenter.reset();
+        mListDimensionBehaviors = Arrays.copyOf(mListDimensionBehaviors, 2);
+        mParent = (mParent == null) ? null : map.get(src.mParent);
+
+        mWidth = src.mWidth;
+        mHeight = src.mHeight;
+        mDimensionRatio = src.mDimensionRatio;
+        mDimensionRatioSide = src.mDimensionRatioSide;
+
+        mX = src.mX;
+        mY = src.mY;
+        mRelX = src.mRelX;
+        mRelY = src.mRelY;
+
+        mOffsetX = src.mOffsetX;
+        mOffsetY = src.mOffsetY;
+
+        mBaselineDistance = src.mBaselineDistance;
+        mMinWidth = src.mMinWidth;
+        mMinHeight = src.mMinHeight;
+
+        mHorizontalBiasPercent = src.mHorizontalBiasPercent;
+        mVerticalBiasPercent = src.mVerticalBiasPercent;
+
+        mCompanionWidget = src.mCompanionWidget;
+        mContainerItemSkip = src.mContainerItemSkip;
+        mVisibility = src.mVisibility;
+        mAnimated = src.mAnimated;
+        mDebugName = src.mDebugName;
+        mType = src.mType;
+
+        mDistToTop = src.mDistToTop;
+        mDistToLeft = src.mDistToLeft;
+        mDistToRight = src.mDistToRight;
+        mDistToBottom = src.mDistToBottom;
+        mLeftHasCentered = src.mLeftHasCentered;
+        mRightHasCentered = src.mRightHasCentered;
+
+        mTopHasCentered = src.mTopHasCentered;
+        mBottomHasCentered = src.mBottomHasCentered;
+
+        mHorizontalWrapVisited = src.mHorizontalWrapVisited;
+        mVerticalWrapVisited = src.mVerticalWrapVisited;
+
+        mHorizontalChainStyle = src.mHorizontalChainStyle;
+        mVerticalChainStyle = src.mVerticalChainStyle;
+        mHorizontalChainFixedPosition = src.mHorizontalChainFixedPosition;
+        mVerticalChainFixedPosition = src.mVerticalChainFixedPosition;
+        mWeight[0] = src.mWeight[0];
+        mWeight[1] = src.mWeight[1];
+
+        mListNextMatchConstraintsWidget[0] = src.mListNextMatchConstraintsWidget[0];
+        mListNextMatchConstraintsWidget[1] = src.mListNextMatchConstraintsWidget[1];
+
+        mNextChainWidget[0] = src.mNextChainWidget[0];
+        mNextChainWidget[1] = src.mNextChainWidget[1];
+
+        mHorizontalNextWidget = (src.mHorizontalNextWidget == null)
+                ? null : map.get(src.mHorizontalNextWidget);
+        mVerticalNextWidget = (src.mVerticalNextWidget == null)
+                ? null : map.get(src.mVerticalNextWidget);
+    }
+
+    // @TODO: add description
+    public void updateFromRuns(boolean updateHorizontal, boolean updateVertical) {
+        updateHorizontal &= mHorizontalRun.isResolved();
+        updateVertical &= mVerticalRun.isResolved();
+        int left = mHorizontalRun.start.value;
+        int top = mVerticalRun.start.value;
+        int right = mHorizontalRun.end.value;
+        int bottom = mVerticalRun.end.value;
+        int w = right - left;
+        int h = bottom - top;
+        if (w < 0 || h < 0
+                || left == Integer.MIN_VALUE || left == Integer.MAX_VALUE
+                || top == Integer.MIN_VALUE || top == Integer.MAX_VALUE
+                || right == Integer.MIN_VALUE || right == Integer.MAX_VALUE
+                || bottom == Integer.MIN_VALUE || bottom == Integer.MAX_VALUE) {
+            left = 0;
+            top = 0;
+            right = 0;
+            bottom = 0;
+        }
+
+        w = right - left;
+        h = bottom - top;
+
+        if (updateHorizontal) {
+            mX = left;
+        }
+        if (updateVertical) {
+            mY = top;
+        }
+
+        if (mVisibility == ConstraintWidget.GONE) {
+            mWidth = 0;
+            mHeight = 0;
+            return;
+        }
+
+        // correct dimensional instability caused by rounding errors
+        if (updateHorizontal) {
+            if (mListDimensionBehaviors[DIMENSION_HORIZONTAL]
+                    == DimensionBehaviour.FIXED && w < mWidth) {
+                w = mWidth;
+            }
+            mWidth = w;
+            if (mWidth < mMinWidth) {
+                mWidth = mMinWidth;
+            }
+        }
+
+        if (updateVertical) {
+            if (mListDimensionBehaviors[DIMENSION_VERTICAL]
+                    == DimensionBehaviour.FIXED && h < mHeight) {
+                h = mHeight;
+            }
+            mHeight = h;
+            if (mHeight < mMinHeight) {
+                mHeight = mMinHeight;
+            }
+        }
+
+    }
+
+    // @TODO: add description
+    public void addChildrenToSolverByDependency(ConstraintWidgetContainer container,
+            LinearSystem system,
+            HashSet<ConstraintWidget> widgets,
+            int orientation,
+            boolean addSelf) {
+        if (addSelf) {
+            if (!widgets.contains(this)) {
+                return;
+            }
+            Optimizer.checkMatchParent(container, system, this);
+            widgets.remove(this);
+            addToSolver(system, container.optimizeFor(Optimizer.OPTIMIZATION_GRAPH));
+        }
+        if (orientation == HORIZONTAL) {
+            HashSet<ConstraintAnchor> dependents = mLeft.getDependents();
+            if (dependents != null) {
+                for (ConstraintAnchor anchor : dependents) {
+                    anchor.mOwner.addChildrenToSolverByDependency(container,
+                            system, widgets, orientation, true);
+                }
+            }
+            dependents = mRight.getDependents();
+            if (dependents != null) {
+                for (ConstraintAnchor anchor : dependents) {
+                    anchor.mOwner.addChildrenToSolverByDependency(container,
+                            system, widgets, orientation, true);
+                }
+            }
+        } else {
+            HashSet<ConstraintAnchor> dependents = mTop.getDependents();
+            if (dependents != null) {
+                for (ConstraintAnchor anchor : dependents) {
+                    anchor.mOwner.addChildrenToSolverByDependency(container,
+                            system, widgets, orientation, true);
+                }
+            }
+            dependents = mBottom.getDependents();
+            if (dependents != null) {
+                for (ConstraintAnchor anchor : dependents) {
+                    anchor.mOwner.addChildrenToSolverByDependency(container,
+                            system, widgets, orientation, true);
+                }
+            }
+            dependents = mBaseline.getDependents();
+            if (dependents != null) {
+                for (ConstraintAnchor anchor : dependents) {
+                    anchor.mOwner.addChildrenToSolverByDependency(container,
+                            system, widgets, orientation, true);
+                }
+            }
+        }
+        // horizontal
+    }
+
+    // @TODO: add description
+    public void getSceneString(StringBuilder ret) {
+
+        ret.append("  " + stringId + ":{\n");
+        ret.append("    actualWidth:" + mWidth);
+        ret.append("\n");
+        ret.append("    actualHeight:" + mHeight);
+        ret.append("\n");
+        ret.append("    actualLeft:" + mX);
+        ret.append("\n");
+        ret.append("    actualTop:" + mY);
+        ret.append("\n");
+        getSceneString(ret, "left", mLeft);
+        getSceneString(ret, "top", mTop);
+        getSceneString(ret, "right", mRight);
+        getSceneString(ret, "bottom", mBottom);
+        getSceneString(ret, "baseline", mBaseline);
+        getSceneString(ret, "centerX", mCenterX);
+        getSceneString(ret, "centerY", mCenterY);
+        getSceneString(ret, "    width",
+                mWidth,
+                mMinWidth,
+                mMaxDimension[HORIZONTAL],
+                mWidthOverride,
+                mMatchConstraintMinWidth,
+                mMatchConstraintDefaultWidth,
+                mMatchConstraintPercentWidth,
+                mListDimensionBehaviors[HORIZONTAL],
+                mWeight[DIMENSION_HORIZONTAL]
+        );
+
+        getSceneString(ret, "    height",
+                mHeight,
+                mMinHeight,
+                mMaxDimension[VERTICAL],
+                mHeightOverride,
+                mMatchConstraintMinHeight,
+                mMatchConstraintDefaultHeight,
+                mMatchConstraintPercentHeight,
+                mListDimensionBehaviors[VERTICAL],
+                mWeight[DIMENSION_VERTICAL]);
+        serializeDimensionRatio(ret, "    dimensionRatio", mDimensionRatio, mDimensionRatioSide);
+        serializeAttribute(ret, "    horizontalBias", mHorizontalBiasPercent, DEFAULT_BIAS);
+        serializeAttribute(ret, "    verticalBias", mVerticalBiasPercent, DEFAULT_BIAS);
+        serializeAttribute(ret, "    horizontalChainStyle", mHorizontalChainStyle, CHAIN_SPREAD);
+        serializeAttribute(ret, "    verticalChainStyle", mVerticalChainStyle, CHAIN_SPREAD);
+
+        ret.append("  }");
+
+    }
+
+    private void getSceneString(StringBuilder ret, String type, int size,
+            int min, int max,
+            @SuppressWarnings("unused") int override,
+            int matchConstraintMin, int matchConstraintDefault,
+            float matchConstraintPercent,
+            DimensionBehaviour behavior,
+            @SuppressWarnings("unused") float weight) {
+        ret.append(type);
+        ret.append(" :  {\n");
+        serializeAttribute(ret, "      behavior", behavior.toString(),
+                DimensionBehaviour.FIXED.toString());
+        serializeAttribute(ret, "      size", size, 0);
+        serializeAttribute(ret, "      min", min, 0);
+        serializeAttribute(ret, "      max", max, Integer.MAX_VALUE);
+        serializeAttribute(ret, "      matchMin", matchConstraintMin, 0);
+        serializeAttribute(ret, "      matchDef", matchConstraintDefault, MATCH_CONSTRAINT_SPREAD);
+        serializeAttribute(ret, "      matchPercent", matchConstraintPercent, 1);
+        ret.append("    },\n");
+    }
+
+    private void getSceneString(StringBuilder ret, String side, ConstraintAnchor a) {
+        if (a.mTarget == null) {
+            return;
+        }
+        ret.append("    ");
+        ret.append(side);
+        ret.append(" : [ '");
+        ret.append(a.mTarget);
+        ret.append("'");
+        if (a.mGoneMargin != Integer.MIN_VALUE || a.mMargin != 0) {
+            ret.append(",");
+            ret.append(a.mMargin);
+            if (a.mGoneMargin != Integer.MIN_VALUE) {
+                ret.append(",");
+                ret.append(a.mGoneMargin);
+                ret.append(",");
+            }
+        }
+        ret.append(" ] ,\n");
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintWidgetContainer.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/ConstraintWidgetContainer.java
@@ -1,0 +1,1146 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.LinearSystem.FULL_DEBUG;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.FIXED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.Metrics;
+import androidx.constraintlayout.core.SolverVariable;
+import androidx.constraintlayout.core.widgets.analyzer.BasicMeasure;
+import androidx.constraintlayout.core.widgets.analyzer.DependencyGraph;
+import androidx.constraintlayout.core.widgets.analyzer.Direct;
+import androidx.constraintlayout.core.widgets.analyzer.Grouping;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * A container of ConstraintWidget that can layout its children
+ */
+public class ConstraintWidgetContainer extends WidgetContainer {
+
+    private static final int MAX_ITERATIONS = 8;
+
+    private static final boolean DEBUG = FULL_DEBUG;
+    private static final boolean DEBUG_LAYOUT = false;
+    static final boolean DEBUG_GRAPH = false;
+
+    BasicMeasure mBasicMeasureSolver = new BasicMeasure(this);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Graph measures
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public DependencyGraph mDependencyGraph = new DependencyGraph(this);
+    private int mPass; // number of layout passes
+
+    /**
+     * Invalidate the graph of constraints
+     */
+    public void invalidateGraph() {
+        mDependencyGraph.invalidateGraph();
+    }
+
+    /**
+     * Invalidate the widgets measures
+     */
+    public void invalidateMeasures() {
+        mDependencyGraph.invalidateMeasures();
+    }
+
+
+    // @TODO: add description
+    public boolean directMeasure(boolean optimizeWrap) {
+        return mDependencyGraph.directMeasure(optimizeWrap);
+//        int paddingLeft = getX();
+//        int paddingTop = getY();
+//        if (mDependencyGraph.directMeasureSetup(optimizeWrap)) {
+//            mDependencyGraph.measureWidgets();
+//            boolean allResolved =
+//                      mDependencyGraph.directMeasureWithOrientation(optimizeWrap, HORIZONTAL);
+//            allResolved &= mDependencyGraph.directMeasureWithOrientation(optimizeWrap, VERTICAL);
+//            for (ConstraintWidget child : mChildren) {
+//                child.setDrawX(child.getDrawX() + paddingLeft);
+//                child.setDrawY(child.getDrawY() + paddingTop);
+//            }
+//            setX(paddingLeft);
+//            setY(paddingTop);
+//            return allResolved;
+//        }
+//        return false;
+    }
+
+    // @TODO: add description
+    public boolean directMeasureSetup(boolean optimizeWrap) {
+        return mDependencyGraph.directMeasureSetup(optimizeWrap);
+    }
+
+    // @TODO: add description
+    public boolean directMeasureWithOrientation(boolean optimizeWrap, int orientation) {
+        return mDependencyGraph.directMeasureWithOrientation(optimizeWrap, orientation);
+    }
+
+    // @TODO: add description
+    public void defineTerminalWidgets() {
+        mDependencyGraph.defineTerminalWidgets(getHorizontalDimensionBehaviour(),
+                getVerticalDimensionBehaviour());
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Measure the layout
+     */
+    public long measure(int optimizationLevel, int widthMode, int widthSize,
+            int heightMode, int heightSize, int lastMeasureWidth,
+            int lastMeasureHeight, int paddingX, int paddingY) {
+        mPaddingLeft = paddingX;
+        mPaddingTop = paddingY;
+        return mBasicMeasureSolver.solverMeasure(this, optimizationLevel, paddingX, paddingY,
+                widthMode, widthSize, heightMode, heightSize,
+                lastMeasureWidth, lastMeasureHeight);
+    }
+
+    // @TODO: add description
+    public void updateHierarchy() {
+        mBasicMeasureSolver.updateHierarchy(this);
+    }
+
+    protected BasicMeasure.Measurer mMeasurer = null;
+
+    // @TODO: add description
+    public void setMeasurer(BasicMeasure.Measurer measurer) {
+        mMeasurer = measurer;
+        mDependencyGraph.setMeasurer(measurer);
+    }
+
+    public BasicMeasure.Measurer getMeasurer() {
+        return mMeasurer;
+    }
+
+    private boolean mIsRtl = false;
+    public Metrics mMetrics;
+
+    // @TODO: add description
+    public void fillMetrics(Metrics metrics) {
+        mMetrics = metrics;
+        mSystem.fillMetrics(metrics);
+    }
+
+    protected LinearSystem mSystem = new LinearSystem();
+
+    int mPaddingLeft;
+    int mPaddingTop;
+    int mPaddingRight;
+    int mPaddingBottom;
+
+    public int mHorizontalChainsSize = 0;
+    public int mVerticalChainsSize = 0;
+
+    ChainHead[] mVerticalChainsArray = new ChainHead[4];
+    ChainHead[] mHorizontalChainsArray = new ChainHead[4];
+
+    public boolean mGroupsWrapOptimized = false;
+    public boolean mHorizontalWrapOptimized = false;
+    public boolean mVerticalWrapOptimized = false;
+    public int mWrapFixedWidth = 0;
+    public int mWrapFixedHeight = 0;
+
+    private int mOptimizationLevel = Optimizer.OPTIMIZATION_STANDARD;
+    public boolean mSkipSolver = false;
+
+    private boolean mWidthMeasuredTooSmall = false;
+    private boolean mHeightMeasuredTooSmall = false;
+
+    /*-----------------------------------------------------------------------*/
+    // Construction
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Default constructor
+     */
+    public ConstraintWidgetContainer() {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param x      x position
+     * @param y      y position
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public ConstraintWidgetContainer(int x, int y, int width, int height) {
+        super(x, y, width, height);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public ConstraintWidgetContainer(int width, int height) {
+        super(width, height);
+    }
+
+    public ConstraintWidgetContainer(String debugName, int width, int height) {
+        super(width, height);
+        setDebugName(debugName);
+    }
+
+    /**
+     * Resolves the system directly when possible
+     *
+     * @param value optimization level
+     */
+    public void setOptimizationLevel(int value) {
+        mOptimizationLevel = value;
+        mSystem.USE_DEPENDENCY_ORDERING = optimizeFor(Optimizer.OPTIMIZATION_DEPENDENCY_ORDERING);
+    }
+
+    /**
+     * Returns the current optimization level
+     */
+    public int getOptimizationLevel() {
+        return mOptimizationLevel;
+    }
+
+    /**
+     * Returns true if the given feature should be optimized
+     */
+    public boolean optimizeFor(int feature) {
+        return (mOptimizationLevel & feature) == feature;
+    }
+
+    /**
+     * Specify the xml type for the container
+     */
+    @Override
+    public String getType() {
+        return "ConstraintLayout";
+    }
+
+    @Override
+    public void reset() {
+        mSystem.reset();
+        mPaddingLeft = 0;
+        mPaddingRight = 0;
+        mPaddingTop = 0;
+        mPaddingBottom = 0;
+        mSkipSolver = false;
+        super.reset();
+    }
+
+    /**
+     * Return true if the width given is too small for the content laid out
+     */
+    public boolean isWidthMeasuredTooSmall() {
+        return mWidthMeasuredTooSmall;
+    }
+
+    /**
+     * Return true if the height given is too small for the content laid out
+     */
+    public boolean isHeightMeasuredTooSmall() {
+        return mHeightMeasuredTooSmall;
+    }
+
+    int mDebugSolverPassCount = 0;
+
+    private WeakReference<ConstraintAnchor> mVerticalWrapMin = null;
+    private WeakReference<ConstraintAnchor> mHorizontalWrapMin = null;
+    private WeakReference<ConstraintAnchor> mVerticalWrapMax = null;
+    private WeakReference<ConstraintAnchor> mHorizontalWrapMax = null;
+
+    void addVerticalWrapMinVariable(ConstraintAnchor top) {
+        if (mVerticalWrapMin == null || mVerticalWrapMin.get() == null
+                || top.getFinalValue() > mVerticalWrapMin.get().getFinalValue()) {
+            mVerticalWrapMin = new WeakReference<>(top);
+        }
+    }
+
+    // @TODO: add description
+    public void addHorizontalWrapMinVariable(ConstraintAnchor left) {
+        if (mHorizontalWrapMin == null || mHorizontalWrapMin.get() == null
+                || left.getFinalValue() > mHorizontalWrapMin.get().getFinalValue()) {
+            mHorizontalWrapMin = new WeakReference<>(left);
+        }
+    }
+
+    void addVerticalWrapMaxVariable(ConstraintAnchor bottom) {
+        if (mVerticalWrapMax == null || mVerticalWrapMax.get() == null
+                || bottom.getFinalValue() > mVerticalWrapMax.get().getFinalValue()) {
+            mVerticalWrapMax = new WeakReference<>(bottom);
+        }
+    }
+
+    // @TODO: add description
+    public void addHorizontalWrapMaxVariable(ConstraintAnchor right) {
+        if (mHorizontalWrapMax == null || mHorizontalWrapMax.get() == null
+                || right.getFinalValue() > mHorizontalWrapMax.get().getFinalValue()) {
+            mHorizontalWrapMax = new WeakReference<>(right);
+        }
+    }
+
+    private void addMinWrap(ConstraintAnchor constraintAnchor, SolverVariable parentMin) {
+        SolverVariable variable = mSystem.createObjectVariable(constraintAnchor);
+        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+        mSystem.addGreaterThan(variable, parentMin, 0, wrapStrength);
+    }
+
+    private void addMaxWrap(ConstraintAnchor constraintAnchor, SolverVariable parentMax) {
+        SolverVariable variable = mSystem.createObjectVariable(constraintAnchor);
+        int wrapStrength = SolverVariable.STRENGTH_EQUALITY;
+        mSystem.addGreaterThan(parentMax, variable, 0, wrapStrength);
+    }
+
+    HashSet<ConstraintWidget> mWidgetsToAdd = new HashSet<>();
+
+    /**
+     * Add this widget to the solver
+     *
+     * @param system the solver we want to add the widget to
+     */
+    public boolean addChildrenToSolver(LinearSystem system) {
+        if (DEBUG) {
+            System.out.println("\n#######################################");
+            System.out.println("##    ADD CHILDREN TO SOLVER  (" + mDebugSolverPassCount + ") ##");
+            System.out.println("#######################################\n");
+            mDebugSolverPassCount++;
+        }
+
+        boolean optimize = optimizeFor(Optimizer.OPTIMIZATION_GRAPH);
+        addToSolver(system, optimize);
+        final int count = mChildren.size();
+
+        boolean hasBarriers = false;
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            widget.setInBarrier(HORIZONTAL, false);
+            widget.setInBarrier(VERTICAL, false);
+            if (widget instanceof Barrier) {
+                hasBarriers = true;
+            }
+        }
+
+        if (hasBarriers) {
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget widget = mChildren.get(i);
+                if (widget instanceof Barrier) {
+                    ((Barrier) widget).markWidgets();
+                }
+            }
+        }
+
+        mWidgetsToAdd.clear();
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            if (widget.addFirst()) {
+                if (widget instanceof VirtualLayout) {
+                    mWidgetsToAdd.add(widget);
+                } else {
+                    widget.addToSolver(system, optimize);
+                }
+            }
+        }
+
+        // If we have virtual layouts, we need to add them to the solver in the correct
+        // order (in case they reference one another)
+        while (mWidgetsToAdd.size() > 0) {
+            int numLayouts = mWidgetsToAdd.size();
+            VirtualLayout layout = null;
+            for (ConstraintWidget widget : mWidgetsToAdd) {
+                layout = (VirtualLayout) widget;
+
+                // we'll go through the virtual layouts that references others first, to give
+                // them a shot at setting their constraints.
+                if (layout.contains(mWidgetsToAdd)) {
+                    layout.addToSolver(system, optimize);
+                    mWidgetsToAdd.remove(layout);
+                    break;
+                }
+            }
+            if (numLayouts == mWidgetsToAdd.size()) {
+                // looks we didn't find anymore dependency, let's add everything.
+                for (ConstraintWidget widget : mWidgetsToAdd) {
+                    widget.addToSolver(system, optimize);
+                }
+                mWidgetsToAdd.clear();
+            }
+        }
+
+        if (LinearSystem.USE_DEPENDENCY_ORDERING) {
+            HashSet<ConstraintWidget> widgetsToAdd = new HashSet<>();
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget widget = mChildren.get(i);
+                if (!widget.addFirst()) {
+                    widgetsToAdd.add(widget);
+                }
+            }
+            int orientation = VERTICAL;
+            if (getHorizontalDimensionBehaviour() == WRAP_CONTENT) {
+                orientation = HORIZONTAL;
+            }
+            addChildrenToSolverByDependency(this, system, widgetsToAdd, orientation, false);
+            for (ConstraintWidget widget : widgetsToAdd) {
+                Optimizer.checkMatchParent(this, system, widget);
+                widget.addToSolver(system, optimize);
+            }
+        } else {
+
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget widget = mChildren.get(i);
+                if (widget instanceof ConstraintWidgetContainer) {
+                    DimensionBehaviour horizontalBehaviour =
+                            widget.mListDimensionBehaviors[DIMENSION_HORIZONTAL];
+                    DimensionBehaviour verticalBehaviour =
+                            widget.mListDimensionBehaviors[DIMENSION_VERTICAL];
+                    if (horizontalBehaviour == WRAP_CONTENT) {
+                        widget.setHorizontalDimensionBehaviour(FIXED);
+                    }
+                    if (verticalBehaviour == WRAP_CONTENT) {
+                        widget.setVerticalDimensionBehaviour(FIXED);
+                    }
+                    widget.addToSolver(system, optimize);
+                    if (horizontalBehaviour == WRAP_CONTENT) {
+                        widget.setHorizontalDimensionBehaviour(horizontalBehaviour);
+                    }
+                    if (verticalBehaviour == WRAP_CONTENT) {
+                        widget.setVerticalDimensionBehaviour(verticalBehaviour);
+                    }
+                } else {
+                    Optimizer.checkMatchParent(this, system, widget);
+                    if (!widget.addFirst()) {
+                        widget.addToSolver(system, optimize);
+                    }
+                }
+            }
+        }
+
+        if (mHorizontalChainsSize > 0) {
+            Chain.applyChainConstraints(this, system, null, HORIZONTAL);
+        }
+        if (mVerticalChainsSize > 0) {
+            Chain.applyChainConstraints(this, system, null, VERTICAL);
+        }
+        return true;
+    }
+
+    /**
+     * Update the frame of the layout and its children from the solver
+     *
+     * @param system the solver we get the values from.
+     * @param flags  the flag set associated with this solver
+     */
+    public boolean updateChildrenFromSolver(LinearSystem system, boolean[] flags) {
+        flags[Optimizer.FLAG_RECOMPUTE_BOUNDS] = false;
+        boolean optimize = optimizeFor(Optimizer.OPTIMIZATION_GRAPH);
+        updateFromSolver(system, optimize);
+        final int count = mChildren.size();
+        boolean hasOverride = false;
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            widget.updateFromSolver(system, optimize);
+            if (widget.hasDimensionOverride()) {
+                hasOverride = true;
+            }
+        }
+        return hasOverride;
+    }
+
+    @Override
+    public void updateFromRuns(boolean updateHorizontal, boolean updateVertical) {
+        super.updateFromRuns(updateHorizontal, updateVertical);
+        final int count = mChildren.size();
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            widget.updateFromRuns(updateHorizontal, updateVertical);
+        }
+    }
+
+    /**
+     * Set the padding on this container. It will apply to the position of the children.
+     *
+     * @param left   left padding
+     * @param top    top padding
+     * @param right  right padding
+     * @param bottom bottom padding
+     */
+    public void setPadding(int left, int top, int right, int bottom) {
+        mPaddingLeft = left;
+        mPaddingTop = top;
+        mPaddingRight = right;
+        mPaddingBottom = bottom;
+    }
+
+    /**
+     * Set the rtl status. This has implications for Chains.
+     *
+     * @param isRtl true if we are in RTL.
+     */
+    public void setRtl(boolean isRtl) {
+        mIsRtl = isRtl;
+    }
+
+    /**
+     * Returns the rtl status.
+     *
+     * @return true if in RTL, false otherwise.
+     */
+    public boolean isRtl() {
+        return mIsRtl;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Overloaded methods from ConstraintWidget
+    /*-----------------------------------------------------------------------*/
+
+    public BasicMeasure.Measure mMeasure = new BasicMeasure.Measure();
+
+    // @TODO: add description
+    public static boolean measure(int level,
+            ConstraintWidget widget,
+            BasicMeasure.Measurer measurer,
+            BasicMeasure.Measure measure,
+            int measureStrategy) {
+        if (DEBUG) {
+            System.out.println(Direct.ls(level) + "(M) call to measure " + widget.getDebugName());
+        }
+        if (measurer == null) {
+            return false;
+        }
+        if (widget.getVisibility() == GONE
+                || widget instanceof Guideline
+                || widget instanceof Barrier) {
+            if (DEBUG) {
+                System.out.println(Direct.ls(level)
+                        + "(M) no measure needed for " + widget.getDebugName());
+            }
+            measure.measuredWidth = 0;
+            measure.measuredHeight = 0;
+            return false;
+        }
+
+        measure.horizontalBehavior = widget.getHorizontalDimensionBehaviour();
+        measure.verticalBehavior = widget.getVerticalDimensionBehaviour();
+        measure.horizontalDimension = widget.getWidth();
+        measure.verticalDimension = widget.getHeight();
+        measure.measuredNeedsSolverPass = false;
+        measure.measureStrategy = measureStrategy;
+
+        boolean horizontalMatchConstraints =
+                (measure.horizontalBehavior == DimensionBehaviour.MATCH_CONSTRAINT);
+        boolean verticalMatchConstraints =
+                (measure.verticalBehavior == DimensionBehaviour.MATCH_CONSTRAINT);
+
+        boolean horizontalUseRatio = horizontalMatchConstraints && widget.mDimensionRatio > 0;
+        boolean verticalUseRatio = verticalMatchConstraints && widget.mDimensionRatio > 0;
+
+        if (horizontalMatchConstraints && widget.hasDanglingDimension(HORIZONTAL)
+                && widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD
+                && !horizontalUseRatio) {
+            horizontalMatchConstraints = false;
+            measure.horizontalBehavior = WRAP_CONTENT;
+            if (verticalMatchConstraints
+                    && widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                // if match x match, size would be zero.
+                measure.horizontalBehavior = FIXED;
+            }
+        }
+
+        if (verticalMatchConstraints && widget.hasDanglingDimension(VERTICAL)
+                && widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD
+                && !verticalUseRatio) {
+            verticalMatchConstraints = false;
+            measure.verticalBehavior = WRAP_CONTENT;
+            if (horizontalMatchConstraints
+                    && widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                // if match x match, size would be zero.
+                measure.verticalBehavior = FIXED;
+            }
+        }
+
+        if (widget.isResolvedHorizontally()) {
+            horizontalMatchConstraints = false;
+            measure.horizontalBehavior = FIXED;
+        }
+        if (widget.isResolvedVertically()) {
+            verticalMatchConstraints = false;
+            measure.verticalBehavior = FIXED;
+        }
+
+        if (horizontalUseRatio) {
+            if (widget.mResolvedMatchConstraintDefault[HORIZONTAL]
+                    == ConstraintWidget.MATCH_CONSTRAINT_RATIO_RESOLVED) {
+                measure.horizontalBehavior = FIXED;
+            } else if (!verticalMatchConstraints) {
+                // let's measure here
+                int measuredHeight;
+                if (measure.verticalBehavior == FIXED) {
+                    measuredHeight = measure.verticalDimension;
+                } else {
+                    measure.horizontalBehavior = WRAP_CONTENT;
+                    measurer.measure(widget, measure);
+                    measuredHeight = measure.measuredHeight;
+                }
+                measure.horizontalBehavior = FIXED;
+                // regardless of which side we are using for the ratio, getDimensionRatio() already
+                // made sure that it's expressed in WxH format, so we can simply go and multiply
+                measure.horizontalDimension = (int) (widget.getDimensionRatio() * measuredHeight);
+                if (DEBUG) {
+                    System.out.println("(M) Measured once for ratio on horizontal side...");
+                }
+            }
+        }
+        if (verticalUseRatio) {
+            if (widget.mResolvedMatchConstraintDefault[VERTICAL]
+                    == ConstraintWidget.MATCH_CONSTRAINT_RATIO_RESOLVED) {
+                measure.verticalBehavior = FIXED;
+            } else if (!horizontalMatchConstraints) {
+                // let's measure here
+                int measuredWidth;
+                if (measure.horizontalBehavior == FIXED) {
+                    measuredWidth = measure.horizontalDimension;
+                } else {
+                    measure.verticalBehavior = WRAP_CONTENT;
+                    measurer.measure(widget, measure);
+                    measuredWidth = measure.measuredWidth;
+                }
+                measure.verticalBehavior = FIXED;
+                if (widget.getDimensionRatioSide() == -1) {
+                    // regardless of which side we are using for the ratio,
+                    //  getDimensionRatio() already
+                    // made sure that it's expressed in WxH format,
+                    //  so we can simply go and divide
+                    measure.verticalDimension = (int) (measuredWidth / widget.getDimensionRatio());
+                } else {
+                    // getDimensionRatio() already got reverted, so we can simply multiply
+                    measure.verticalDimension = (int) (widget.getDimensionRatio() * measuredWidth);
+                }
+                if (DEBUG) {
+                    System.out.println("(M) Measured once for ratio on vertical side...");
+                }
+            }
+        }
+
+        measurer.measure(widget, measure);
+        widget.setWidth(measure.measuredWidth);
+        widget.setHeight(measure.measuredHeight);
+        widget.setHasBaseline(measure.measuredHasBaseline);
+        widget.setBaselineDistance(measure.measuredBaseline);
+        measure.measureStrategy = BasicMeasure.Measure.SELF_DIMENSIONS;
+        if (DEBUG) {
+            System.out.println("(M) Measured " + widget.getDebugName() + " with : "
+                    + widget.getHorizontalDimensionBehaviour() + " x "
+                    + widget.getVerticalDimensionBehaviour() + " => "
+                    + widget.getWidth() + " x " + widget.getHeight());
+        }
+        return measure.measuredNeedsSolverPass;
+    }
+
+    static int sMyCounter = 0;
+
+    /**
+     * Layout the tree of widgets
+     */
+    @Override
+    public void layout() {
+        if (DEBUG) {
+            System.out.println("\n#####################################");
+            System.out.println("##          CL LAYOUT PASS           ##");
+            System.out.println("#####################################\n");
+            mDebugSolverPassCount = 0;
+        }
+
+        mX = 0;
+        mY = 0;
+
+        mWidthMeasuredTooSmall = false;
+        mHeightMeasuredTooSmall = false;
+        final int count = mChildren.size();
+
+        int preW = Math.max(0, getWidth());
+        int preH = Math.max(0, getHeight());
+        DimensionBehaviour originalVerticalDimensionBehaviour =
+                mListDimensionBehaviors[DIMENSION_VERTICAL];
+        DimensionBehaviour originalHorizontalDimensionBehaviour =
+                mListDimensionBehaviors[DIMENSION_HORIZONTAL];
+
+        if (DEBUG_LAYOUT) {
+            System.out.println("layout with preW: " + preW + " ("
+                    + mListDimensionBehaviors[DIMENSION_HORIZONTAL] + ") preH: " + preH
+                    + " (" + mListDimensionBehaviors[DIMENSION_VERTICAL] + ")");
+        }
+
+        if (mMetrics != null) {
+            mMetrics.layouts++;
+        }
+
+
+        boolean wrap_override = false;
+
+        if (FULL_DEBUG) {
+            System.out.println("OPTIMIZATION LEVEL " + mOptimizationLevel);
+        }
+
+        // Only try the direct optimization in the first layout pass
+        if (mPass == 0 && Optimizer.enabled(mOptimizationLevel, Optimizer.OPTIMIZATION_DIRECT)) {
+            if (FULL_DEBUG) {
+                System.out.println("Direct pass " + sMyCounter++);
+            }
+            Direct.solvingPass(this, getMeasurer());
+            if (FULL_DEBUG) {
+                System.out.println("Direct pass done.");
+            }
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget child = mChildren.get(i);
+                if (FULL_DEBUG) {
+                    if (child.isInHorizontalChain()) {
+                        System.out.print("H");
+                    } else {
+                        System.out.print(" ");
+                    }
+                    if (child.isInVerticalChain()) {
+                        System.out.print("V");
+                    } else {
+                        System.out.print(" ");
+                    }
+                    if (child.isResolvedHorizontally() && child.isResolvedVertically()) {
+                        System.out.print("*");
+                    } else {
+                        System.out.print(" ");
+                    }
+                    System.out.println("[" + i + "] child " + child.getDebugName()
+                            + " H: " + child.isResolvedHorizontally()
+                            + " V: " + child.isResolvedVertically());
+                }
+                if (child.isMeasureRequested()
+                        && !(child instanceof Guideline)
+                        && !(child instanceof Barrier)
+                        && !(child instanceof VirtualLayout)
+                        && !child.isInVirtualLayout()) {
+                    DimensionBehaviour widthBehavior = child.getDimensionBehaviour(HORIZONTAL);
+                    DimensionBehaviour heightBehavior = child.getDimensionBehaviour(VERTICAL);
+
+                    boolean skip = widthBehavior == DimensionBehaviour.MATCH_CONSTRAINT
+                            && child.mMatchConstraintDefaultWidth != MATCH_CONSTRAINT_WRAP
+                            && heightBehavior == DimensionBehaviour.MATCH_CONSTRAINT
+                            && child.mMatchConstraintDefaultHeight != MATCH_CONSTRAINT_WRAP;
+                    if (!skip) {
+                        BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                        ConstraintWidgetContainer.measure(0, child, mMeasurer,
+                                measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                    }
+                }
+            }
+            // let's measure children
+            if (FULL_DEBUG) {
+                System.out.println("Direct pass all done.");
+            }
+        } else {
+            if (FULL_DEBUG) {
+                System.out.println("No DIRECT PASS");
+            }
+        }
+
+        if (count > 2 && (originalHorizontalDimensionBehaviour == WRAP_CONTENT
+                || originalVerticalDimensionBehaviour == WRAP_CONTENT)
+                && Optimizer.enabled(mOptimizationLevel, Optimizer.OPTIMIZATION_GROUPING)) {
+            if (Grouping.simpleSolvingPass(this, getMeasurer())) {
+                if (originalHorizontalDimensionBehaviour == WRAP_CONTENT) {
+                    if (preW < getWidth() && preW > 0) {
+                        if (DEBUG_LAYOUT) {
+                            System.out.println("Override width " + getWidth() + " to " + preH);
+                        }
+                        setWidth(preW);
+                        mWidthMeasuredTooSmall = true;
+                    } else {
+                        preW = getWidth();
+                    }
+                }
+                if (originalVerticalDimensionBehaviour == WRAP_CONTENT) {
+                    if (preH < getHeight() && preH > 0) {
+                        if (DEBUG_LAYOUT) {
+                            System.out.println("Override height " + getHeight() + " to " + preH);
+                        }
+                        setHeight(preH);
+                        mHeightMeasuredTooSmall = true;
+                    } else {
+                        preH = getHeight();
+                    }
+                }
+                wrap_override = true;
+                if (DEBUG_LAYOUT) {
+                    System.out.println("layout post opt, preW: " + preW
+                            + " (" + mListDimensionBehaviors[DIMENSION_HORIZONTAL]
+                            + ") preH: " + preH + " (" + mListDimensionBehaviors[DIMENSION_VERTICAL]
+                            + "), new size " + getWidth() + " x " + getHeight());
+                }
+            }
+        }
+        boolean useGraphOptimizer = optimizeFor(Optimizer.OPTIMIZATION_GRAPH)
+                || optimizeFor(Optimizer.OPTIMIZATION_GRAPH_WRAP);
+
+        mSystem.graphOptimizer = false;
+        mSystem.newgraphOptimizer = false;
+
+        if (mOptimizationLevel != Optimizer.OPTIMIZATION_NONE
+                && useGraphOptimizer) {
+            mSystem.newgraphOptimizer = true;
+        }
+
+        @SuppressWarnings("unused") int countSolve = 0;
+        final List<ConstraintWidget> allChildren = mChildren;
+        boolean hasWrapContent = getHorizontalDimensionBehaviour() == WRAP_CONTENT
+                || getVerticalDimensionBehaviour() == WRAP_CONTENT;
+
+        // Reset the chains before iterating on our children
+        resetChains();
+        countSolve = 0;
+
+        // Before we solve our system, we should call layout() on any
+        // of our children that is a container.
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            if (widget instanceof WidgetContainer) {
+                ((WidgetContainer) widget).layout();
+            }
+        }
+        boolean optimize = optimizeFor(Optimizer.OPTIMIZATION_GRAPH);
+
+        // Now let's solve our system as usual
+        boolean needsSolving = true;
+        while (needsSolving) {
+            countSolve++;
+            try {
+                mSystem.reset();
+                resetChains();
+                if (DEBUG) {
+                    String debugName = getDebugName();
+                    if (debugName == null) {
+                        debugName = "root";
+                    }
+                    setDebugSolverName(mSystem, debugName);
+                    for (int i = 0; i < count; i++) {
+                        ConstraintWidget widget = mChildren.get(i);
+                        if (widget.getDebugName() != null) {
+                            widget.setDebugSolverName(mSystem, widget.getDebugName());
+                        }
+                    }
+                } else {
+                    createObjectVariables(mSystem);
+                    for (int i = 0; i < count; i++) {
+                        ConstraintWidget widget = mChildren.get(i);
+                        widget.createObjectVariables(mSystem);
+                    }
+                }
+                needsSolving = addChildrenToSolver(mSystem);
+                if (mVerticalWrapMin != null && mVerticalWrapMin.get() != null) {
+                    addMinWrap(mVerticalWrapMin.get(), mSystem.createObjectVariable(mTop));
+                    mVerticalWrapMin = null;
+                }
+                if (mVerticalWrapMax != null && mVerticalWrapMax.get() != null) {
+                    addMaxWrap(mVerticalWrapMax.get(), mSystem.createObjectVariable(mBottom));
+                    mVerticalWrapMax = null;
+                }
+                if (mHorizontalWrapMin != null && mHorizontalWrapMin.get() != null) {
+                    addMinWrap(mHorizontalWrapMin.get(), mSystem.createObjectVariable(mLeft));
+                    mHorizontalWrapMin = null;
+                }
+                if (mHorizontalWrapMax != null && mHorizontalWrapMax.get() != null) {
+                    addMaxWrap(mHorizontalWrapMax.get(), mSystem.createObjectVariable(mRight));
+                    mHorizontalWrapMax = null;
+                }
+                if (needsSolving) {
+                    mSystem.minimize();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.out.println("EXCEPTION : " + e);
+            }
+            if (needsSolving) {
+                needsSolving = updateChildrenFromSolver(mSystem, Optimizer.sFlags);
+            } else {
+                updateFromSolver(mSystem, optimize);
+                for (int i = 0; i < count; i++) {
+                    ConstraintWidget widget = mChildren.get(i);
+                    widget.updateFromSolver(mSystem, optimize);
+                }
+                needsSolving = false;
+            }
+
+            if (hasWrapContent && countSolve < MAX_ITERATIONS
+                    && Optimizer.sFlags[Optimizer.FLAG_RECOMPUTE_BOUNDS]) {
+                // let's get the new bounds
+                int maxX = 0;
+                int maxY = 0;
+                for (int i = 0; i < count; i++) {
+                    ConstraintWidget widget = mChildren.get(i);
+                    maxX = Math.max(maxX, widget.mX + widget.getWidth());
+                    maxY = Math.max(maxY, widget.mY + widget.getHeight());
+                }
+                maxX = Math.max(mMinWidth, maxX);
+                maxY = Math.max(mMinHeight, maxY);
+                if (originalHorizontalDimensionBehaviour == WRAP_CONTENT) {
+                    if (getWidth() < maxX) {
+                        if (DEBUG_LAYOUT) {
+                            System.out.println( countSolve +
+                                    "layout override width from " + getWidth() + " vs " + maxX);
+                        }
+                        setWidth(maxX);
+                        // force using the solver
+                        mListDimensionBehaviors[DIMENSION_HORIZONTAL] = WRAP_CONTENT;
+                        wrap_override = true;
+                        needsSolving = true;
+                    }
+                }
+                if (originalVerticalDimensionBehaviour == WRAP_CONTENT) {
+                    if (getHeight() < maxY) {
+                        if (DEBUG_LAYOUT) {
+                            System.out.println(
+                                    "layout override height from " + getHeight() + " vs " + maxY);
+                        }
+                        setHeight(maxY);
+                        // force using the solver
+                        mListDimensionBehaviors[DIMENSION_VERTICAL] = WRAP_CONTENT;
+                        wrap_override = true;
+                        needsSolving = true;
+                    }
+                }
+            }
+            if (true) {
+                int width = Math.max(mMinWidth, getWidth());
+                if (width > getWidth()) {
+                    if (DEBUG_LAYOUT) {
+                        System.out.println(
+                                "layout override 2, width from " + getWidth() + " vs " + width);
+                    }
+                    setWidth(width);
+                    mListDimensionBehaviors[DIMENSION_HORIZONTAL] = FIXED;
+                    wrap_override = true;
+                    needsSolving = true;
+                }
+                int height = Math.max(mMinHeight, getHeight());
+                if (height > getHeight()) {
+                    if (DEBUG_LAYOUT) {
+                        System.out.println(
+                                "layout override 2, height from " + getHeight() + " vs " + height);
+                    }
+                    setHeight(height);
+                    mListDimensionBehaviors[DIMENSION_VERTICAL] = FIXED;
+                    wrap_override = true;
+                    needsSolving = true;
+                }
+
+                if (!wrap_override) {
+                    if (mListDimensionBehaviors[DIMENSION_HORIZONTAL] == WRAP_CONTENT
+                            && preW > 0) {
+                        if (getWidth() > preW) {
+                            if (DEBUG_LAYOUT) {
+                                System.out.println(
+                                        "layout override 3, width from " + getWidth() + " vs "
+                                                + preW);
+                            }
+                            mWidthMeasuredTooSmall = true;
+                            wrap_override = true;
+                            mListDimensionBehaviors[DIMENSION_HORIZONTAL] = FIXED;
+                            setWidth(preW);
+                            needsSolving = true;
+                        }
+                    }
+                    if (mListDimensionBehaviors[DIMENSION_VERTICAL] == WRAP_CONTENT
+                            && preH > 0) {
+                        if (getHeight() > preH) {
+                            if (DEBUG_LAYOUT) {
+                                System.out.println(
+                                        "layout override 3, height from " + getHeight() + " vs "
+                                                + preH);
+                            }
+                            mHeightMeasuredTooSmall = true;
+                            wrap_override = true;
+                            mListDimensionBehaviors[DIMENSION_VERTICAL] = FIXED;
+                            setHeight(preH);
+                            needsSolving = true;
+                        }
+                    }
+                }
+
+                if (countSolve > MAX_ITERATIONS) {
+                    needsSolving = false;
+                }
+            }
+        }
+        if (DEBUG_LAYOUT) {
+            System.out.println(
+                    "Solved system in " + countSolve + " iterations (" + getWidth() + " x "
+                            + getHeight() + ")");
+        }
+
+        mChildren = (ArrayList<ConstraintWidget>) allChildren;
+
+        if (wrap_override) {
+            mListDimensionBehaviors[DIMENSION_HORIZONTAL] = originalHorizontalDimensionBehaviour;
+            mListDimensionBehaviors[DIMENSION_VERTICAL] = originalVerticalDimensionBehaviour;
+        }
+
+        resetSolverVariables(mSystem.getCache());
+    }
+
+    /**
+     * Indicates if the container knows how to layout its content on its own
+     *
+     * @return true if the container does the layout, false otherwise
+     */
+    public boolean handlesInternalConstraints() {
+        return false;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Guidelines
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Accessor to the vertical guidelines contained in the table.
+     *
+     * @return array of guidelines
+     */
+    public ArrayList<Guideline> getVerticalGuidelines() {
+        ArrayList<Guideline> guidelines = new ArrayList<>();
+        for (int i = 0, mChildrenSize = mChildren.size(); i < mChildrenSize; i++) {
+            final ConstraintWidget widget = mChildren.get(i);
+            if (widget instanceof Guideline) {
+                Guideline guideline = (Guideline) widget;
+                if (guideline.getOrientation() == Guideline.VERTICAL) {
+                    guidelines.add(guideline);
+                }
+            }
+        }
+        return guidelines;
+    }
+
+    /**
+     * Accessor to the horizontal guidelines contained in the table.
+     *
+     * @return array of guidelines
+     */
+    public ArrayList<Guideline> getHorizontalGuidelines() {
+        ArrayList<Guideline> guidelines = new ArrayList<>();
+        for (int i = 0, mChildrenSize = mChildren.size(); i < mChildrenSize; i++) {
+            final ConstraintWidget widget = mChildren.get(i);
+            if (widget instanceof Guideline) {
+                Guideline guideline = (Guideline) widget;
+                if (guideline.getOrientation() == Guideline.HORIZONTAL) {
+                    guidelines.add(guideline);
+                }
+            }
+        }
+        return guidelines;
+    }
+
+    public LinearSystem getSystem() {
+        return mSystem;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Chains
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Reset the chains array. Need to be called before layout.
+     */
+    private void resetChains() {
+        mHorizontalChainsSize = 0;
+        mVerticalChainsSize = 0;
+    }
+
+    /**
+     * Add the chain which constraintWidget is part of. Called by ConstraintWidget::addToSolver()
+     *
+     * @param type HORIZONTAL or VERTICAL chain
+     */
+    void addChain(ConstraintWidget constraintWidget, int type) {
+        ConstraintWidget widget = constraintWidget;
+        if (type == HORIZONTAL) {
+            addHorizontalChain(widget);
+        } else if (type == VERTICAL) {
+            addVerticalChain(widget);
+        }
+    }
+
+    /**
+     * Add a widget to the list of horizontal chains. The widget is the left-most widget
+     * of the chain which doesn't have a left dual connection.
+     *
+     * @param widget widget starting the chain
+     */
+    private void addHorizontalChain(ConstraintWidget widget) {
+        if (mHorizontalChainsSize + 1 >= mHorizontalChainsArray.length) {
+            mHorizontalChainsArray = Arrays
+                    .copyOf(mHorizontalChainsArray, mHorizontalChainsArray.length * 2);
+        }
+        mHorizontalChainsArray[mHorizontalChainsSize] = new ChainHead(widget, HORIZONTAL, isRtl());
+        mHorizontalChainsSize++;
+    }
+
+    /**
+     * Add a widget to the list of vertical chains. The widget is the top-most widget
+     * of the chain which doesn't have a top dual connection.
+     *
+     * @param widget widget starting the chain
+     */
+    private void addVerticalChain(ConstraintWidget widget) {
+        if (mVerticalChainsSize + 1 >= mVerticalChainsArray.length) {
+            mVerticalChainsArray = Arrays
+                    .copyOf(mVerticalChainsArray, mVerticalChainsArray.length * 2);
+        }
+        mVerticalChainsArray[mVerticalChainsSize] = new ChainHead(widget, VERTICAL, isRtl());
+        mVerticalChainsSize++;
+    }
+
+    /**
+     * Keep track of the # of passes
+     */
+    public void setPass(int pass) {
+        this.mPass = pass;
+    }
+
+    // @TODO: add description
+    @Override
+    public void getSceneString(StringBuilder ret) {
+
+        ret.append(stringId + ":{\n");
+        ret.append("  actualWidth:" + mWidth);
+        ret.append("\n");
+        ret.append("  actualHeight:" + mHeight);
+        ret.append("\n");
+
+        ArrayList<ConstraintWidget> children = getChildren();
+        for (ConstraintWidget child : children) {
+            child.getSceneString(ret);
+            ret.append(",\n");
+        }
+        ret.append("}");
+
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Flow.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Flow.java
@@ -1,0 +1,1486 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.AT_MOST;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.EXACTLY;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.UNSPECIFIED;
+
+import androidx.constraintlayout.core.LinearSystem;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Implements the Flow virtual layout.
+ */
+public class Flow extends VirtualLayout {
+
+    public static final int HORIZONTAL_ALIGN_START = 0;
+    public static final int HORIZONTAL_ALIGN_END = 1;
+    public static final int HORIZONTAL_ALIGN_CENTER = 2;
+
+    public static final int VERTICAL_ALIGN_TOP = 0;
+    public static final int VERTICAL_ALIGN_BOTTOM = 1;
+    public static final int VERTICAL_ALIGN_CENTER = 2;
+    public static final int VERTICAL_ALIGN_BASELINE = 3;
+
+    public static final int WRAP_NONE = 0;
+    public static final int WRAP_CHAIN = 1;
+    public static final int WRAP_ALIGNED = 2;
+    public static final int WRAP_CHAIN_NEW = 3;
+
+    private int mHorizontalStyle = UNKNOWN;
+    private int mVerticalStyle = UNKNOWN;
+    private int mFirstHorizontalStyle = UNKNOWN;
+    private int mFirstVerticalStyle = UNKNOWN;
+    private int mLastHorizontalStyle = UNKNOWN;
+    private int mLastVerticalStyle = UNKNOWN;
+
+    private float mHorizontalBias = 0.5f;
+    private float mVerticalBias = 0.5f;
+    private float mFirstHorizontalBias = 0.5f;
+    private float mFirstVerticalBias = 0.5f;
+    private float mLastHorizontalBias = 0.5f;
+    private float mLastVerticalBias = 0.5f;
+
+    private int mHorizontalGap = 0;
+    private int mVerticalGap = 0;
+
+    private int mHorizontalAlign = HORIZONTAL_ALIGN_CENTER;
+    private int mVerticalAlign = VERTICAL_ALIGN_CENTER;
+    private int mWrapMode = WRAP_NONE;
+
+    private int mMaxElementsWrap = UNKNOWN;
+
+    private int mOrientation = HORIZONTAL;
+
+    private ArrayList<WidgetsList> mChainList = new ArrayList<>();
+
+    // Aligned management
+
+    private ConstraintWidget[] mAlignedBiggestElementsInRows = null;
+    private ConstraintWidget[] mAlignedBiggestElementsInCols = null;
+    private int[] mAlignedDimensions = null;
+    private ConstraintWidget[] mDisplayedWidgets;
+    private int mDisplayedWidgetsCount = 0;
+
+
+    @Override
+    public void copy(ConstraintWidget src, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        super.copy(src, map);
+        Flow srcFLow = (Flow) src;
+
+        mHorizontalStyle = srcFLow.mHorizontalStyle;
+        mVerticalStyle = srcFLow.mVerticalStyle;
+        mFirstHorizontalStyle = srcFLow.mFirstHorizontalStyle;
+        mFirstVerticalStyle = srcFLow.mFirstVerticalStyle;
+        mLastHorizontalStyle = srcFLow.mLastHorizontalStyle;
+        mLastVerticalStyle = srcFLow.mLastVerticalStyle;
+
+        mHorizontalBias = srcFLow.mHorizontalBias;
+        mVerticalBias = srcFLow.mVerticalBias;
+        mFirstHorizontalBias = srcFLow.mFirstHorizontalBias;
+        mFirstVerticalBias = srcFLow.mFirstVerticalBias;
+        mLastHorizontalBias = srcFLow.mLastHorizontalBias;
+        mLastVerticalBias = srcFLow.mLastVerticalBias;
+
+        mHorizontalGap = srcFLow.mHorizontalGap;
+        mVerticalGap = srcFLow.mVerticalGap;
+
+        mHorizontalAlign = srcFLow.mHorizontalAlign;
+        mVerticalAlign = srcFLow.mVerticalAlign;
+        mWrapMode = srcFLow.mWrapMode;
+
+        mMaxElementsWrap = srcFLow.mMaxElementsWrap;
+
+        mOrientation = srcFLow.mOrientation;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Accessors
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    public void setOrientation(int value) {
+        mOrientation = value;
+    }
+
+    public void setFirstHorizontalStyle(int value) {
+        mFirstHorizontalStyle = value;
+    }
+
+    public void setFirstVerticalStyle(int value) {
+        mFirstVerticalStyle = value;
+    }
+
+    public void setLastHorizontalStyle(int value) {
+        mLastHorizontalStyle = value;
+    }
+
+    public void setLastVerticalStyle(int value) {
+        mLastVerticalStyle = value;
+    }
+
+    public void setHorizontalStyle(int value) {
+        mHorizontalStyle = value;
+    }
+
+    public void setVerticalStyle(int value) {
+        mVerticalStyle = value;
+    }
+
+    public void setHorizontalBias(float value) {
+        mHorizontalBias = value;
+    }
+
+    public void setVerticalBias(float value) {
+        mVerticalBias = value;
+    }
+
+    public void setFirstHorizontalBias(float value) {
+        mFirstHorizontalBias = value;
+    }
+
+    public void setFirstVerticalBias(float value) {
+        mFirstVerticalBias = value;
+    }
+
+    public void setLastHorizontalBias(float value) {
+        mLastHorizontalBias = value;
+    }
+
+    public void setLastVerticalBias(float value) {
+        mLastVerticalBias = value;
+    }
+
+    public void setHorizontalAlign(int value) {
+        mHorizontalAlign = value;
+    }
+
+    public void setVerticalAlign(int value) {
+        mVerticalAlign = value;
+    }
+
+    public void setWrapMode(int value) {
+        mWrapMode = value;
+    }
+
+    public void setHorizontalGap(int value) {
+        mHorizontalGap = value;
+    }
+
+    public void setVerticalGap(int value) {
+        mVerticalGap = value;
+    }
+
+    public void setMaxElementsWrap(int value) {
+        mMaxElementsWrap = value;
+    }
+
+    public float getMaxElementsWrap() {
+        return mMaxElementsWrap;
+    }
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Utility methods
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    private int getWidgetWidth(ConstraintWidget widget, int max) {
+        if (widget == null) {
+            return 0;
+        }
+        if (widget.getHorizontalDimensionBehaviour() == DimensionBehaviour.MATCH_CONSTRAINT) {
+            if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                return 0;
+            } else if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_PERCENT) {
+                int value = (int) (widget.mMatchConstraintPercentWidth * max);
+                if (value != widget.getWidth()) {
+                    widget.setMeasureRequested(true);
+                    measure(widget, DimensionBehaviour.FIXED, value,
+                            widget.getVerticalDimensionBehaviour(), widget.getHeight());
+                }
+                return value;
+            } else if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP) {
+                return widget.getWidth();
+            } else if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_RATIO) {
+                return (int) (widget.getHeight() * widget.mDimensionRatio + 0.5f);
+            }
+        }
+        return widget.getWidth();
+    }
+
+    private int getWidgetHeight(ConstraintWidget widget, int max) {
+        if (widget == null) {
+            return 0;
+        }
+        if (widget.getVerticalDimensionBehaviour() == DimensionBehaviour.MATCH_CONSTRAINT) {
+            if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                return 0;
+            } else if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_PERCENT) {
+                int value = (int) (widget.mMatchConstraintPercentHeight * max);
+                if (value != widget.getHeight()) {
+                    widget.setMeasureRequested(true);
+                    measure(widget, widget.getHorizontalDimensionBehaviour(),
+                            widget.getWidth(), DimensionBehaviour.FIXED, value);
+                }
+                return value;
+            } else if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP) {
+                return widget.getHeight();
+            } else if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_RATIO) {
+                return (int) (widget.getWidth() * widget.mDimensionRatio + 0.5f);
+            }
+        }
+        return widget.getHeight();
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    // @TODO: add description
+    @Override
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        if (mWidgetsCount > 0 && !measureChildren()) {
+            setMeasure(0, 0);
+            needsCallbackFromSolver(false);
+            return;
+        }
+
+        @SuppressWarnings("unused") int width = 0;
+        @SuppressWarnings("unused") int height = 0;
+        int paddingLeft = getPaddingLeft();
+        int paddingRight = getPaddingRight();
+        int paddingTop = getPaddingTop();
+        int paddingBottom = getPaddingBottom();
+
+        int[] measured = new int[2];
+        int max = widthSize - paddingLeft - paddingRight;
+        if (mOrientation == VERTICAL) {
+            max = heightSize - paddingTop - paddingBottom;
+        }
+
+        if (mOrientation == HORIZONTAL) {
+            if (mHorizontalStyle == UNKNOWN) {
+                mHorizontalStyle = CHAIN_SPREAD;
+            }
+            if (mVerticalStyle == UNKNOWN) {
+                mVerticalStyle = CHAIN_SPREAD;
+            }
+        } else {
+            if (mHorizontalStyle == UNKNOWN) {
+                mHorizontalStyle = CHAIN_SPREAD;
+            }
+            if (mVerticalStyle == UNKNOWN) {
+                mVerticalStyle = CHAIN_SPREAD;
+            }
+        }
+
+        ConstraintWidget[] widgets = mWidgets;
+
+        int gone = 0;
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (widget.getVisibility() == GONE) {
+                gone++;
+            }
+        }
+        int count = mWidgetsCount;
+        if (gone > 0) {
+            widgets = new ConstraintWidget[mWidgetsCount - gone];
+            int j = 0;
+            for (int i = 0; i < mWidgetsCount; i++) {
+                ConstraintWidget widget = mWidgets[i];
+                if (widget.getVisibility() != GONE) {
+                    widgets[j] = widget;
+                    j++;
+                }
+            }
+            count = j;
+        }
+        mDisplayedWidgets = widgets;
+        mDisplayedWidgetsCount = count;
+        switch (mWrapMode) {
+            case WRAP_ALIGNED: {
+                measureAligned(widgets, count, mOrientation, max, measured);
+            }
+            break;
+            case WRAP_CHAIN: {
+                measureChainWrap(widgets, count, mOrientation, max, measured);
+            }
+            break;
+            case WRAP_NONE: {
+                measureNoWrap(widgets, count, mOrientation, max, measured);
+            }
+            break;
+            case WRAP_CHAIN_NEW: {
+                measureChainWrap_new(widgets, count, mOrientation, max, measured);
+            }
+            break;
+
+        }
+
+        width = measured[HORIZONTAL] + paddingLeft + paddingRight;
+        height = measured[VERTICAL] + paddingTop + paddingBottom;
+
+        int measuredWidth = 0;
+        int measuredHeight = 0;
+
+        if (widthMode == EXACTLY) {
+            measuredWidth = widthSize;
+        } else if (widthMode == AT_MOST) {
+            measuredWidth = Math.min(width, widthSize);
+        } else if (widthMode == UNSPECIFIED) {
+            measuredWidth = width;
+        }
+
+        if (heightMode == EXACTLY) {
+            measuredHeight = heightSize;
+        } else if (heightMode == AT_MOST) {
+            measuredHeight = Math.min(height, heightSize);
+        } else if (heightMode == UNSPECIFIED) {
+            measuredHeight = height;
+        }
+
+        setMeasure(measuredWidth, measuredHeight);
+        setWidth(measuredWidth);
+        setHeight(measuredHeight);
+        needsCallbackFromSolver(mWidgetsCount > 0);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Utility class representing a single chain
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    private class WidgetsList {
+        private int mOrientation = HORIZONTAL;
+        private ConstraintWidget mBiggest = null;
+        int mBiggestDimension = 0;
+        private ConstraintAnchor mLeft;
+        private ConstraintAnchor mTop;
+        private ConstraintAnchor mRight;
+        private ConstraintAnchor mBottom;
+        private int mPaddingLeft = 0;
+        private int mPaddingTop = 0;
+        private int mPaddingRight = 0;
+        private int mPaddingBottom = 0;
+        private int mWidth = 0;
+        private int mHeight = 0;
+        private int mStartIndex = 0;
+        private int mCount = 0;
+        private int mNbMatchConstraintsWidgets = 0;
+        private int mMax = 0;
+
+        WidgetsList(int orientation,
+                ConstraintAnchor left, ConstraintAnchor top,
+                ConstraintAnchor right, ConstraintAnchor bottom,
+                int max) {
+            mOrientation = orientation;
+            mLeft = left;
+            mTop = top;
+            mRight = right;
+            mBottom = bottom;
+            mPaddingLeft = getPaddingLeft();
+            mPaddingTop = getPaddingTop();
+            mPaddingRight = getPaddingRight();
+            mPaddingBottom = getPaddingBottom();
+            mMax = max;
+        }
+
+        public void setup(int orientation, ConstraintAnchor left, ConstraintAnchor top,
+                ConstraintAnchor right, ConstraintAnchor bottom,
+                int paddingLeft, int paddingTop, int paddingRight, int paddingBottom,
+                int max) {
+            mOrientation = orientation;
+            mLeft = left;
+            mTop = top;
+            mRight = right;
+            mBottom = bottom;
+            mPaddingLeft = paddingLeft;
+            mPaddingTop = paddingTop;
+            mPaddingRight = paddingRight;
+            mPaddingBottom = paddingBottom;
+            mMax = max;
+        }
+
+        public void clear() {
+            mBiggestDimension = 0;
+            mBiggest = null;
+            mWidth = 0;
+            mHeight = 0;
+            mStartIndex = 0;
+            mCount = 0;
+            mNbMatchConstraintsWidgets = 0;
+        }
+
+        public void setStartIndex(int value) {
+            mStartIndex = value;
+        }
+
+        public int getWidth() {
+            if (mOrientation == HORIZONTAL) {
+                return mWidth - mHorizontalGap;
+            }
+            return mWidth;
+        }
+
+        public int getHeight() {
+            if (mOrientation == VERTICAL) {
+                return mHeight - mVerticalGap;
+            }
+            return mHeight;
+        }
+
+        public void add(ConstraintWidget widget) {
+            if (mOrientation == HORIZONTAL) {
+                int width = getWidgetWidth(widget, mMax);
+                if (widget.getHorizontalDimensionBehaviour()
+                        == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    mNbMatchConstraintsWidgets++;
+                    width = 0;
+                }
+                int gap = mHorizontalGap;
+                if (widget.getVisibility() == GONE) {
+                    gap = 0;
+                }
+                mWidth += width + gap;
+                int height = getWidgetHeight(widget, mMax);
+                if (mBiggest == null || mBiggestDimension < height) {
+                    mBiggest = widget;
+                    mBiggestDimension = height;
+                    mHeight = height;
+                }
+            } else {
+                int width = getWidgetWidth(widget, mMax);
+                int height = getWidgetHeight(widget, mMax);
+                if (widget.getVerticalDimensionBehaviour() == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    mNbMatchConstraintsWidgets++;
+                    height = 0;
+                }
+                int gap = mVerticalGap;
+                if (widget.getVisibility() == GONE) {
+                    gap = 0;
+                }
+                mHeight += height + gap;
+                if (mBiggest == null || mBiggestDimension < width) {
+                    mBiggest = widget;
+                    mBiggestDimension = width;
+                    mWidth = width;
+                }
+            }
+            mCount++;
+        }
+
+        public void createConstraints(boolean isInRtl, int chainIndex, boolean isLastChain) {
+            final int count = mCount;
+            for (int i = 0; i < count; i++) {
+                if (mStartIndex + i >= mDisplayedWidgetsCount) {
+                    break;
+                }
+                ConstraintWidget widget = mDisplayedWidgets[mStartIndex + i];
+                if (widget != null) {
+                    widget.resetAnchors();
+                }
+            }
+            if (count == 0 || mBiggest == null) {
+                return;
+            }
+
+            boolean singleChain = isLastChain && chainIndex == 0;
+            int firstVisible = -1;
+            int lastVisible = -1;
+            for (int i = 0; i < count; i++) {
+                int index = i;
+                if (isInRtl) {
+                    index = count - 1 - i;
+                }
+                if (mStartIndex + index >= mDisplayedWidgetsCount) {
+                    break;
+                }
+                ConstraintWidget widget = mDisplayedWidgets[mStartIndex + index];
+                if (widget != null && widget.getVisibility() == VISIBLE) {
+                    if (firstVisible == -1) {
+                        firstVisible = i;
+                    }
+                    lastVisible = i;
+                }
+            }
+
+            ConstraintWidget previous = null;
+            if (mOrientation == HORIZONTAL) {
+                ConstraintWidget verticalWidget = mBiggest;
+                verticalWidget.setVerticalChainStyle(mVerticalStyle);
+                int padding = mPaddingTop;
+                if (chainIndex > 0) {
+                    padding += mVerticalGap;
+                }
+                verticalWidget.mTop.connect(mTop, padding);
+                if (isLastChain) {
+                    verticalWidget.mBottom.connect(mBottom, mPaddingBottom);
+                }
+                if (chainIndex > 0) {
+                    ConstraintAnchor bottom = mTop.mOwner.mBottom;
+                    bottom.connect(verticalWidget.mTop, 0);
+                }
+
+                ConstraintWidget baselineVerticalWidget = verticalWidget;
+                if (mVerticalAlign == VERTICAL_ALIGN_BASELINE && !verticalWidget.hasBaseline()) {
+                    for (int i = 0; i < count; i++) {
+                        int index = i;
+                        if (isInRtl) {
+                            index = count - 1 - i;
+                        }
+                        if (mStartIndex + index >= mDisplayedWidgetsCount) {
+                            break;
+                        }
+                        ConstraintWidget widget = mDisplayedWidgets[mStartIndex + index];
+                        if (widget.hasBaseline()) {
+                            baselineVerticalWidget = widget;
+                            break;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < count; i++) {
+                    int index = i;
+                    if (isInRtl) {
+                        index = count - 1 - i;
+                    }
+                    if (mStartIndex + index >= mDisplayedWidgetsCount) {
+                        break;
+                    }
+                    ConstraintWidget widget = mDisplayedWidgets[mStartIndex + index];
+                    if (widget == null) {
+                        continue;
+                    }
+                    if (i == 0) {
+                        widget.connect(widget.mLeft, mLeft, mPaddingLeft);
+                    }
+
+                    // ChainHead is always based on index, not i.
+                    // E.g. RTL would have head at the right most widget.
+                    if (index == 0) {
+                        int style = mHorizontalStyle;
+                        float bias = isInRtl ? (1 - mHorizontalBias) : mHorizontalBias;
+                        if (mStartIndex == 0 && mFirstHorizontalStyle != UNKNOWN) {
+                            style = mFirstHorizontalStyle;
+                            bias = isInRtl ? (1 - mFirstHorizontalBias) : mFirstHorizontalBias;
+                        } else if (isLastChain && mLastHorizontalStyle != UNKNOWN) {
+                            style = mLastHorizontalStyle;
+                            bias = isInRtl ? (1 - mLastHorizontalBias) : mLastHorizontalBias;
+                        }
+                        widget.setHorizontalChainStyle(style);
+                        widget.setHorizontalBiasPercent(bias);
+                    }
+                    if (i == count - 1) {
+                        widget.connect(widget.mRight, mRight, mPaddingRight);
+                    }
+                    if (previous != null) {
+                        widget.mLeft.connect(previous.mRight, mHorizontalGap);
+                        if (i == firstVisible) {
+                            widget.mLeft.setGoneMargin(mPaddingLeft);
+                        }
+                        previous.mRight.connect(widget.mLeft, 0);
+                        if (i == lastVisible + 1) {
+                            previous.mRight.setGoneMargin(mPaddingRight);
+                        }
+                    }
+                    if (widget != verticalWidget) {
+                        if (mVerticalAlign == VERTICAL_ALIGN_BASELINE
+                                && baselineVerticalWidget.hasBaseline()
+                                && widget != baselineVerticalWidget
+                                && widget.hasBaseline()) {
+                            widget.mBaseline.connect(baselineVerticalWidget.mBaseline, 0);
+                        } else {
+                            switch (mVerticalAlign) {
+                                case VERTICAL_ALIGN_TOP: {
+                                    widget.mTop.connect(verticalWidget.mTop, 0);
+                                }
+                                break;
+                                case VERTICAL_ALIGN_BOTTOM: {
+                                    widget.mBottom.connect(verticalWidget.mBottom, 0);
+                                }
+                                break;
+                                case VERTICAL_ALIGN_CENTER:
+                                default: {
+                                    if (singleChain) {
+                                        widget.mTop.connect(mTop, mPaddingTop);
+                                        widget.mBottom.connect(mBottom, mPaddingBottom);
+                                    } else {
+                                        widget.mTop.connect(verticalWidget.mTop, 0);
+                                        widget.mBottom.connect(verticalWidget.mBottom, 0);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    previous = widget;
+                }
+            } else {
+                ConstraintWidget horizontalWidget = mBiggest;
+                horizontalWidget.setHorizontalChainStyle(mHorizontalStyle);
+                int padding = mPaddingLeft;
+                if (chainIndex > 0) {
+                    padding += mHorizontalGap;
+                }
+                if (isInRtl) {
+                    horizontalWidget.mRight.connect(mRight, padding);
+                    if (isLastChain) {
+                        horizontalWidget.mLeft.connect(mLeft, mPaddingRight);
+                    }
+                    if (chainIndex > 0) {
+                        ConstraintAnchor left = mRight.mOwner.mLeft;
+                        left.connect(horizontalWidget.mRight, 0);
+                    }
+                } else {
+                    horizontalWidget.mLeft.connect(mLeft, padding);
+                    if (isLastChain) {
+                        horizontalWidget.mRight.connect(mRight, mPaddingRight);
+                    }
+                    if (chainIndex > 0) {
+                        ConstraintAnchor right = mLeft.mOwner.mRight;
+                        right.connect(horizontalWidget.mLeft, 0);
+                    }
+                }
+                for (int i = 0; i < count; i++) {
+                    if (mStartIndex + i >= mDisplayedWidgetsCount) {
+                        break;
+                    }
+                    ConstraintWidget widget = mDisplayedWidgets[mStartIndex + i];
+                    if (widget == null) {
+                        continue;
+                    }
+                    if (i == 0) {
+                        widget.connect(widget.mTop, mTop, mPaddingTop);
+                        int style = mVerticalStyle;
+                        float bias = mVerticalBias;
+                        if (mStartIndex == 0 && mFirstVerticalStyle != UNKNOWN) {
+                            style = mFirstVerticalStyle;
+                            bias = mFirstVerticalBias;
+                        } else if (isLastChain && mLastVerticalStyle != UNKNOWN) {
+                            style = mLastVerticalStyle;
+                            bias = mLastVerticalBias;
+                        }
+                        widget.setVerticalChainStyle(style);
+                        widget.setVerticalBiasPercent(bias);
+                    }
+                    if (i == count - 1) {
+                        widget.connect(widget.mBottom, mBottom, mPaddingBottom);
+                    }
+                    if (previous != null) {
+                        widget.mTop.connect(previous.mBottom, mVerticalGap);
+                        if (i == firstVisible) {
+                            widget.mTop.setGoneMargin(mPaddingTop);
+                        }
+                        previous.mBottom.connect(widget.mTop, 0);
+                        if (i == lastVisible + 1) {
+                            previous.mBottom.setGoneMargin(mPaddingBottom);
+                        }
+                    }
+                    if (widget != horizontalWidget) {
+                        if (isInRtl) {
+                            switch (mHorizontalAlign) {
+                                case HORIZONTAL_ALIGN_START: {
+                                    widget.mRight.connect(horizontalWidget.mRight, 0);
+                                }
+                                break;
+                                case HORIZONTAL_ALIGN_CENTER: {
+                                    widget.mLeft.connect(horizontalWidget.mLeft, 0);
+                                    widget.mRight.connect(horizontalWidget.mRight, 0);
+                                }
+                                break;
+                                case HORIZONTAL_ALIGN_END: {
+                                    widget.mLeft.connect(horizontalWidget.mLeft, 0);
+                                }
+                                break;
+                            }
+                        } else {
+                            switch (mHorizontalAlign) {
+                                case HORIZONTAL_ALIGN_START: {
+                                    widget.mLeft.connect(horizontalWidget.mLeft, 0);
+                                }
+                                break;
+                                case HORIZONTAL_ALIGN_CENTER: {
+                                    if (singleChain) {
+                                        widget.mLeft.connect(mLeft, mPaddingLeft);
+                                        widget.mRight.connect(mRight, mPaddingRight);
+                                    } else {
+                                        widget.mLeft.connect(horizontalWidget.mLeft, 0);
+                                        widget.mRight.connect(horizontalWidget.mRight, 0);
+                                    }
+                                }
+                                break;
+                                case HORIZONTAL_ALIGN_END: {
+                                    widget.mRight.connect(horizontalWidget.mRight, 0);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    previous = widget;
+                }
+            }
+        }
+
+        public void measureMatchConstraints(int availableSpace) {
+            if (mNbMatchConstraintsWidgets == 0) {
+                return;
+            }
+            final int count = mCount;
+
+            // that's completely incorrect and only works for spread with no weights?
+            int widgetSize = availableSpace / mNbMatchConstraintsWidgets;
+            for (int i = 0; i < count; i++) {
+                if (mStartIndex + i >= mDisplayedWidgetsCount) {
+                    break;
+                }
+                ConstraintWidget widget = mDisplayedWidgets[mStartIndex + i];
+                if (mOrientation == HORIZONTAL) {
+                    if (widget != null && widget.getHorizontalDimensionBehaviour()
+                            == DimensionBehaviour.MATCH_CONSTRAINT) {
+                        if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                            measure(widget, DimensionBehaviour.FIXED, widgetSize,
+                                    widget.getVerticalDimensionBehaviour(), widget.getHeight());
+                        }
+                    }
+                } else {
+                    if (widget != null && widget.getVerticalDimensionBehaviour()
+                            == DimensionBehaviour.MATCH_CONSTRAINT) {
+                        if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                            measure(widget, widget.getHorizontalDimensionBehaviour(),
+                                    widget.getWidth(), DimensionBehaviour.FIXED, widgetSize);
+                        }
+                    }
+                }
+            }
+            recomputeDimensions();
+        }
+
+        private void recomputeDimensions() {
+            mWidth = 0;
+            mHeight = 0;
+            mBiggest = null;
+            mBiggestDimension = 0;
+            final int count = mCount;
+            for (int i = 0; i < count; i++) {
+                if (mStartIndex + i >= mDisplayedWidgetsCount) {
+                    break;
+                }
+                ConstraintWidget widget = mDisplayedWidgets[mStartIndex + i];
+                if (mOrientation == HORIZONTAL) {
+                    int width = widget.getWidth();
+                    int gap = mHorizontalGap;
+                    if (widget.getVisibility() == GONE) {
+                        gap = 0;
+                    }
+                    mWidth += width + gap;
+                    int height = getWidgetHeight(widget, mMax);
+                    if (mBiggest == null || mBiggestDimension < height) {
+                        mBiggest = widget;
+                        mBiggestDimension = height;
+                        mHeight = height;
+                    }
+                } else {
+                    int width = getWidgetWidth(widget, mMax);
+                    int height = getWidgetHeight(widget, mMax);
+                    int gap = mVerticalGap;
+                    if (widget.getVisibility() == GONE) {
+                        gap = 0;
+                    }
+                    mHeight += height + gap;
+                    if (mBiggest == null || mBiggestDimension < width) {
+                        mBiggest = widget;
+                        mBiggestDimension = width;
+                        mWidth = width;
+                    }
+                }
+            }
+        }
+
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure Chain Wrap
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Measure the virtual layout using a list of chains for the children
+     *
+     * @param widgets     list of widgets
+     * @param orientation the layout orientation (horizontal or vertical)
+     * @param max         the maximum available space
+     * @param measured    output parameters -- will contain the resulting measure
+     */
+    private void measureChainWrap(ConstraintWidget[] widgets,
+            int count,
+            int orientation,
+            int max,
+            int[] measured) {
+        if (count == 0) {
+            return;
+        }
+
+        mChainList.clear();
+        WidgetsList list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+        mChainList.add(list);
+
+        int nbMatchConstraintsWidgets = 0;
+
+        if (orientation == HORIZONTAL) {
+            int width = 0;
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget widget = widgets[i];
+                int w = getWidgetWidth(widget, max);
+                if (widget.getHorizontalDimensionBehaviour()
+                        == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    nbMatchConstraintsWidgets++;
+                }
+                boolean doWrap = (width == max || (width + mHorizontalGap + w) > max)
+                        && list.mBiggest != null;
+                if (!doWrap && i > 0 && mMaxElementsWrap > 0 && (i % mMaxElementsWrap == 0)) {
+                    doWrap = true;
+                }
+                if (doWrap) {
+                    width = w;
+                    list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+                    list.setStartIndex(i);
+                    mChainList.add(list);
+                } else {
+                    if (i > 0) {
+                        width += mHorizontalGap + w;
+                    } else {
+                        width = w;
+                    }
+                }
+                list.add(widget);
+            }
+        } else {
+            int height = 0;
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget widget = widgets[i];
+                int h = getWidgetHeight(widget, max);
+                if (widget.getVerticalDimensionBehaviour() == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    nbMatchConstraintsWidgets++;
+                }
+                boolean doWrap = (height == max || (height + mVerticalGap + h) > max)
+                        && list.mBiggest != null;
+                if (!doWrap && i > 0 && mMaxElementsWrap > 0 && (i % mMaxElementsWrap == 0)) {
+                    doWrap = true;
+                }
+                if (doWrap) {
+                    height = h;
+                    list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+                    list.setStartIndex(i);
+                    mChainList.add(list);
+                } else {
+                    if (i > 0) {
+                        height += mVerticalGap + h;
+                    } else {
+                        height = h;
+                    }
+                }
+                list.add(widget);
+            }
+        }
+        final int listCount = mChainList.size();
+
+        ConstraintAnchor left = mLeft;
+        ConstraintAnchor top = mTop;
+        ConstraintAnchor right = mRight;
+        ConstraintAnchor bottom = mBottom;
+
+        int paddingLeft = getPaddingLeft();
+        int paddingTop = getPaddingTop();
+        int paddingRight = getPaddingRight();
+        int paddingBottom = getPaddingBottom();
+
+        int maxWidth = 0;
+        int maxHeight = 0;
+
+        boolean needInternalMeasure =
+                getHorizontalDimensionBehaviour() == DimensionBehaviour.WRAP_CONTENT
+                        || getVerticalDimensionBehaviour() == DimensionBehaviour.WRAP_CONTENT;
+
+        if (nbMatchConstraintsWidgets > 0 && needInternalMeasure) {
+            // we have to remeasure them.
+            for (int i = 0; i < listCount; i++) {
+                WidgetsList current = mChainList.get(i);
+                if (orientation == HORIZONTAL) {
+                    current.measureMatchConstraints(max - current.getWidth());
+                } else {
+                    current.measureMatchConstraints(max - current.getHeight());
+                }
+            }
+        }
+
+        for (int i = 0; i < listCount; i++) {
+            WidgetsList current = mChainList.get(i);
+            if (orientation == HORIZONTAL) {
+                if (i < listCount - 1) {
+                    WidgetsList next = mChainList.get(i + 1);
+                    bottom = next.mBiggest.mTop;
+                    paddingBottom = 0;
+                } else {
+                    bottom = mBottom;
+                    paddingBottom = getPaddingBottom();
+                }
+                ConstraintAnchor currentBottom = current.mBiggest.mBottom;
+                current.setup(orientation, left, top, right, bottom,
+                        paddingLeft, paddingTop, paddingRight, paddingBottom, max);
+                top = currentBottom;
+                paddingTop = 0;
+                maxWidth = Math.max(maxWidth, current.getWidth());
+                maxHeight += current.getHeight();
+                if (i > 0) {
+                    maxHeight += mVerticalGap;
+                }
+            } else {
+                if (i < listCount - 1) {
+                    WidgetsList next = mChainList.get(i + 1);
+                    right = next.mBiggest.mLeft;
+                    paddingRight = 0;
+                } else {
+                    right = mRight;
+                    paddingRight = getPaddingRight();
+                }
+                ConstraintAnchor currentRight = current.mBiggest.mRight;
+                current.setup(orientation, left, top, right, bottom,
+                        paddingLeft, paddingTop, paddingRight, paddingBottom, max);
+                left = currentRight;
+                paddingLeft = 0;
+                maxWidth += current.getWidth();
+                maxHeight = Math.max(maxHeight, current.getHeight());
+                if (i > 0) {
+                    maxWidth += mHorizontalGap;
+                }
+            }
+        }
+        measured[HORIZONTAL] = maxWidth;
+        measured[VERTICAL] = maxHeight;
+    }
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure Chain Wrap new
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Measure the virtual layout using a list of chains for the children in new "fixed way"
+     *
+     * @param widgets     list of widgets
+     * @param orientation the layout orientation (horizontal or vertical)
+     * @param max         the maximum available space
+     * @param measured    output parameters -- will contain the resulting measure
+     */
+    private void measureChainWrap_new(ConstraintWidget[] widgets,
+            int count,
+            int orientation,
+            int max,
+            int[] measured) {
+        if (count == 0) {
+            return;
+        }
+
+        mChainList.clear();
+        WidgetsList list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+        mChainList.add(list);
+
+        int nbMatchConstraintsWidgets = 0;
+
+        if (orientation == HORIZONTAL) {
+            int width = 0;
+            int col = 0;
+            for (int i = 0; i < count; i++) {
+                col++;
+                ConstraintWidget widget = widgets[i];
+                int w = getWidgetWidth(widget, max);
+                if (widget.getHorizontalDimensionBehaviour()
+                        == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    nbMatchConstraintsWidgets++;
+                }
+                boolean doWrap = (width == max || (width + mHorizontalGap + w) > max)
+                        && list.mBiggest != null;
+                if (!doWrap && i > 0 && mMaxElementsWrap > 0 && (col > mMaxElementsWrap)) {
+                    doWrap = true;
+                }
+                if (doWrap) {
+                    col = 1;
+                    width = w;
+                    list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+                    list.setStartIndex(i);
+                    mChainList.add(list);
+                } else {
+                    if (i > 0) {
+                        width += mHorizontalGap + w;
+                    } else {
+                        width = w;
+                    }
+                }
+                list.add(widget);
+            }
+        } else {
+            int height = 0;
+            int row = 0;
+            for (int i = 0; i < count; i++) {
+                row++;
+                ConstraintWidget widget = widgets[i];
+                int h = getWidgetHeight(widget, max);
+                if (widget.getVerticalDimensionBehaviour() == DimensionBehaviour.MATCH_CONSTRAINT) {
+                    nbMatchConstraintsWidgets++;
+                }
+                boolean doWrap = (height == max || (height + mVerticalGap + h) > max)
+                        && list.mBiggest != null;
+                if (!doWrap && i > 0 && mMaxElementsWrap > 0 && (row > mMaxElementsWrap)) {
+                    doWrap = true;
+                }
+                if (doWrap) {
+                    row = 1;
+                    height = h;
+                    list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+                    list.setStartIndex(i);
+                    mChainList.add(list);
+                } else {
+                    if (i > 0) {
+                        height += mVerticalGap + h;
+                    } else {
+                        height = h;
+                    }
+                }
+                list.add(widget);
+            }
+        }
+        final int listCount = mChainList.size();
+
+        ConstraintAnchor left = mLeft;
+        ConstraintAnchor top = mTop;
+        ConstraintAnchor right = mRight;
+        ConstraintAnchor bottom = mBottom;
+
+        int paddingLeft = getPaddingLeft();
+        int paddingTop = getPaddingTop();
+        int paddingRight = getPaddingRight();
+        int paddingBottom = getPaddingBottom();
+
+        int maxWidth = 0;
+        int maxHeight = 0;
+
+        boolean needInternalMeasure =
+                getHorizontalDimensionBehaviour() == DimensionBehaviour.WRAP_CONTENT
+                        || getVerticalDimensionBehaviour() == DimensionBehaviour.WRAP_CONTENT;
+
+        if (nbMatchConstraintsWidgets > 0 && needInternalMeasure) {
+            // we have to remeasure them.
+            for (int i = 0; i < listCount; i++) {
+                WidgetsList current = mChainList.get(i);
+                if (orientation == HORIZONTAL) {
+                    current.measureMatchConstraints(max - current.getWidth());
+                } else {
+                    current.measureMatchConstraints(max - current.getHeight());
+                }
+            }
+        }
+
+        for (int i = 0; i < listCount; i++) {
+            WidgetsList current = mChainList.get(i);
+            if (orientation == HORIZONTAL) {
+                if (i < listCount - 1) {
+                    WidgetsList next = mChainList.get(i + 1);
+                    bottom = next.mBiggest.mTop;
+                    paddingBottom = 0;
+                } else {
+                    bottom = mBottom;
+                    paddingBottom = getPaddingBottom();
+                }
+                ConstraintAnchor currentBottom = current.mBiggest.mBottom;
+                current.setup(orientation, left, top, right, bottom,
+                        paddingLeft, paddingTop, paddingRight, paddingBottom, max);
+                top = currentBottom;
+                paddingTop = 0;
+                maxWidth = Math.max(maxWidth, current.getWidth());
+                maxHeight += current.getHeight();
+                if (i > 0) {
+                    maxHeight += mVerticalGap;
+                }
+            } else {
+                if (i < listCount - 1) {
+                    WidgetsList next = mChainList.get(i + 1);
+                    right = next.mBiggest.mLeft;
+                    paddingRight = 0;
+                } else {
+                    right = mRight;
+                    paddingRight = getPaddingRight();
+                }
+                ConstraintAnchor currentRight = current.mBiggest.mRight;
+                current.setup(orientation, left, top, right, bottom,
+                        paddingLeft, paddingTop, paddingRight, paddingBottom, max);
+                left = currentRight;
+                paddingLeft = 0;
+                maxWidth += current.getWidth();
+                maxHeight = Math.max(maxHeight, current.getHeight());
+                if (i > 0) {
+                    maxWidth += mHorizontalGap;
+                }
+            }
+        }
+        measured[HORIZONTAL] = maxWidth;
+        measured[VERTICAL] = maxHeight;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure No Wrap
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Measure the virtual layout using a single chain for the children
+     *
+     * @param widgets     list of widgets
+     * @param orientation the layout orientation (horizontal or vertical)
+     * @param max         the maximum available space
+     * @param measured    output parameters -- will contain the resulting measure
+     */
+    private void measureNoWrap(ConstraintWidget[] widgets,
+            int count,
+            int orientation,
+            int max,
+            int[] measured) {
+        if (count == 0) {
+            return;
+        }
+        WidgetsList list = null;
+        if (mChainList.size() == 0) {
+            list = new WidgetsList(orientation, mLeft, mTop, mRight, mBottom, max);
+            mChainList.add(list);
+        } else {
+            list = mChainList.get(0);
+            list.clear();
+            list.setup(orientation, mLeft, mTop, mRight, mBottom,
+                    getPaddingLeft(), getPaddingTop(), getPaddingRight(), getPaddingBottom(), max);
+        }
+
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = widgets[i];
+            list.add(widget);
+        }
+
+        measured[HORIZONTAL] = list.getWidth();
+        measured[VERTICAL] = list.getHeight();
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure Aligned
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Measure the virtual layout arranging the children in a regular grid
+     *
+     * @param widgets     list of widgets
+     * @param orientation the layout orientation (horizontal or vertical)
+     * @param max         the maximum available space
+     * @param measured    output parameters -- will contain the resulting measure
+     */
+    private void measureAligned(ConstraintWidget[] widgets,
+            int count,
+            int orientation,
+            int max,
+            int[] measured) {
+        boolean done = false;
+        int rows = 0;
+        int cols = 0;
+
+        if (orientation == HORIZONTAL) {
+            cols = mMaxElementsWrap;
+            if (cols <= 0) {
+                // let's initialize cols with an acceptable value
+                int w = 0;
+                cols = 0;
+                for (int i = 0; i < count; i++) {
+                    if (i > 0) {
+                        w += mHorizontalGap;
+                    }
+                    ConstraintWidget widget = widgets[i];
+                    if (widget == null) {
+                        continue;
+                    }
+                    w += getWidgetWidth(widget, max);
+                    if (w > max) {
+                        break;
+                    }
+                    cols++;
+                }
+            }
+        } else {
+            rows = mMaxElementsWrap;
+            if (rows <= 0) {
+                // let's initialize rows with an acceptable value
+                int h = 0;
+                rows = 0;
+                for (int i = 0; i < count; i++) {
+                    if (i > 0) {
+                        h += mVerticalGap;
+                    }
+                    ConstraintWidget widget = widgets[i];
+                    if (widget == null) {
+                        continue;
+                    }
+                    h += getWidgetHeight(widget, max);
+                    if (h > max) {
+                        break;
+                    }
+                    rows++;
+                }
+            }
+        }
+
+        if (mAlignedDimensions == null) {
+            mAlignedDimensions = new int[2];
+        }
+
+        if ((rows == 0 && orientation == VERTICAL)
+                || (cols == 0 && orientation == HORIZONTAL)) {
+            done = true;
+        }
+
+        while (!done) {
+            // get a num of rows (or cols)
+            // get for each row and cols the chain of biggest elements
+
+            if (orientation == HORIZONTAL) {
+                rows = (int) Math.ceil(count / (float) cols);
+            } else {
+                cols = (int) Math.ceil(count / (float) rows);
+            }
+
+            if (mAlignedBiggestElementsInCols == null
+                    || mAlignedBiggestElementsInCols.length < cols) {
+                mAlignedBiggestElementsInCols = new ConstraintWidget[cols];
+            } else {
+                Arrays.fill(mAlignedBiggestElementsInCols, null);
+            }
+            if (mAlignedBiggestElementsInRows == null
+                    || mAlignedBiggestElementsInRows.length < rows) {
+                mAlignedBiggestElementsInRows = new ConstraintWidget[rows];
+            } else {
+                Arrays.fill(mAlignedBiggestElementsInRows, null);
+            }
+
+            for (int i = 0; i < cols; i++) {
+                for (int j = 0; j < rows; j++) {
+                    int index = j * cols + i;
+                    if (orientation == VERTICAL) {
+                        index = i * rows + j;
+                    }
+                    if (index >= widgets.length) {
+                        continue;
+                    }
+                    ConstraintWidget widget = widgets[index];
+                    if (widget == null) {
+                        continue;
+                    }
+                    int w = getWidgetWidth(widget, max);
+                    if (mAlignedBiggestElementsInCols[i] == null
+                            || mAlignedBiggestElementsInCols[i].getWidth() < w) {
+                        mAlignedBiggestElementsInCols[i] = widget;
+                    }
+                    int h = getWidgetHeight(widget, max);
+                    if (mAlignedBiggestElementsInRows[j] == null
+                            || mAlignedBiggestElementsInRows[j].getHeight() < h) {
+                        mAlignedBiggestElementsInRows[j] = widget;
+                    }
+                }
+            }
+
+            int w = 0;
+            for (int i = 0; i < cols; i++) {
+                ConstraintWidget widget = mAlignedBiggestElementsInCols[i];
+                if (widget != null) {
+                    if (i > 0) {
+                        w += mHorizontalGap;
+                    }
+                    w += getWidgetWidth(widget, max);
+                }
+            }
+            int h = 0;
+            for (int j = 0; j < rows; j++) {
+                ConstraintWidget widget = mAlignedBiggestElementsInRows[j];
+                if (widget != null) {
+                    if (j > 0) {
+                        h += mVerticalGap;
+                    }
+                    h += getWidgetHeight(widget, max);
+                }
+            }
+            measured[HORIZONTAL] = w;
+            measured[VERTICAL] = h;
+
+            if (orientation == HORIZONTAL) {
+                if (w > max) {
+                    if (cols > 1) {
+                        cols--;
+                    } else {
+                        done = true;
+                    }
+                } else {
+                    done = true;
+                }
+            } else { // VERTICAL
+                if (h > max) {
+                    if (rows > 1) {
+                        rows--;
+                    } else {
+                        done = true;
+                    }
+                } else {
+                    done = true;
+                }
+            }
+        }
+        mAlignedDimensions[HORIZONTAL] = cols;
+        mAlignedDimensions[VERTICAL] = rows;
+    }
+
+    private void createAlignedConstraints(boolean isInRtl) {
+        if (mAlignedDimensions == null
+                || mAlignedBiggestElementsInCols == null
+                || mAlignedBiggestElementsInRows == null) {
+            return;
+        }
+
+        for (int i = 0; i < mDisplayedWidgetsCount; i++) {
+            ConstraintWidget widget = mDisplayedWidgets[i];
+            widget.resetAnchors();
+        }
+
+        int cols = mAlignedDimensions[HORIZONTAL];
+        int rows = mAlignedDimensions[VERTICAL];
+
+        ConstraintWidget previous = null;
+        float horizontalBias = mHorizontalBias;
+        for (int i = 0; i < cols; i++) {
+            int index = i;
+            if (isInRtl) {
+                index = cols - i - 1;
+                horizontalBias = 1 - mHorizontalBias;
+            }
+            ConstraintWidget widget = mAlignedBiggestElementsInCols[index];
+            if (widget == null || widget.getVisibility() == GONE) {
+                continue;
+            }
+            if (i == 0) {
+                widget.connect(widget.mLeft, mLeft, getPaddingLeft());
+                widget.setHorizontalChainStyle(mHorizontalStyle);
+                widget.setHorizontalBiasPercent(horizontalBias);
+            }
+            if (i == cols - 1) {
+                widget.connect(widget.mRight, mRight, getPaddingRight());
+            }
+            if (i > 0 && previous != null) {
+                widget.connect(widget.mLeft, previous.mRight, mHorizontalGap);
+                previous.connect(previous.mRight, widget.mLeft, 0);
+            }
+            previous = widget;
+        }
+        for (int j = 0; j < rows; j++) {
+            ConstraintWidget widget = mAlignedBiggestElementsInRows[j];
+            if (widget == null || widget.getVisibility() == GONE) {
+                continue;
+            }
+            if (j == 0) {
+                widget.connect(widget.mTop, mTop, getPaddingTop());
+                widget.setVerticalChainStyle(mVerticalStyle);
+                widget.setVerticalBiasPercent(mVerticalBias);
+            }
+            if (j == rows - 1) {
+                widget.connect(widget.mBottom, mBottom, getPaddingBottom());
+            }
+            if (j > 0 && previous != null) {
+                widget.connect(widget.mTop, previous.mBottom, mVerticalGap);
+                previous.connect(previous.mBottom, widget.mTop, 0);
+            }
+            previous = widget;
+        }
+
+        for (int i = 0; i < cols; i++) {
+            for (int j = 0; j < rows; j++) {
+                int index = j * cols + i;
+                if (mOrientation == VERTICAL) {
+                    index = i * rows + j;
+                }
+                if (index >= mDisplayedWidgets.length) {
+                    continue;
+                }
+                ConstraintWidget widget = mDisplayedWidgets[index];
+                if (widget == null || widget.getVisibility() == GONE) {
+                    continue;
+                }
+                ConstraintWidget biggestInCol = mAlignedBiggestElementsInCols[i];
+                ConstraintWidget biggestInRow = mAlignedBiggestElementsInRows[j];
+                if (widget != biggestInCol) {
+                    widget.connect(widget.mLeft, biggestInCol.mLeft, 0);
+                    widget.connect(widget.mRight, biggestInCol.mRight, 0);
+                }
+                if (widget != biggestInRow) {
+                    widget.connect(widget.mTop, biggestInRow.mTop, 0);
+                    widget.connect(widget.mBottom, biggestInRow.mBottom, 0);
+                }
+            }
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Add constraints to solver
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Add this widget to the solver
+     *
+     * @param system   the solver we want to add the widget to
+     * @param optimize true if {@link Optimizer#OPTIMIZATION_GRAPH} is on
+     */
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        super.addToSolver(system, optimize);
+
+        boolean isInRtl = getParent() != null && ((ConstraintWidgetContainer) getParent()).isRtl();
+        switch (mWrapMode) {
+            case WRAP_CHAIN: {
+                final int count = mChainList.size();
+                for (int i = 0; i < count; i++) {
+                    WidgetsList list = mChainList.get(i);
+                    list.createConstraints(isInRtl, i, i == count - 1);
+                }
+            }
+            break;
+            case WRAP_NONE: {
+                if (mChainList.size() > 0) {
+                    WidgetsList list = mChainList.get(0);
+                    list.createConstraints(isInRtl, 0, true);
+                }
+            }
+            break;
+            case WRAP_ALIGNED: {
+                createAlignedConstraints(isInRtl);
+            }
+            break;
+            case WRAP_CHAIN_NEW: {
+                final int count = mChainList.size();
+                for (int i = 0; i < count; i++) {
+                    WidgetsList list = mChainList.get(i);
+                    list.createConstraints(isInRtl, i, i == count - 1);
+                }
+            }
+            break;
+        }
+        needsCallbackFromSolver(false);
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Guideline.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Guideline.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.SolverVariable;
+
+import java.util.HashMap;
+
+/**
+ * Guideline
+ */
+public class Guideline extends ConstraintWidget {
+    public static final int HORIZONTAL = 0;
+    public static final int VERTICAL = 1;
+
+    public static final int RELATIVE_PERCENT = 0;
+    public static final int RELATIVE_BEGIN = 1;
+    public static final int RELATIVE_END = 2;
+    public static final int RELATIVE_UNKNOWN = -1;
+
+    protected float mRelativePercent = -1;
+    protected int mRelativeBegin = -1;
+    protected int mRelativeEnd = -1;
+    protected boolean mGuidelineUseRtl = true;
+
+    private ConstraintAnchor mAnchor = mTop;
+    private int mOrientation = HORIZONTAL;
+    private int mMinimumPosition = 0;
+    private boolean mResolved;
+
+    public Guideline() {
+        mAnchors.clear();
+        mAnchors.add(mAnchor);
+        final int count = mListAnchors.length;
+        for (int i = 0; i < count; i++) {
+            mListAnchors[i] = mAnchor;
+        }
+    }
+
+    @Override
+    public void copy(ConstraintWidget src, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        super.copy(src, map);
+        Guideline srcGuideline = (Guideline) src;
+        mRelativePercent = srcGuideline.mRelativePercent;
+        mRelativeBegin = srcGuideline.mRelativeBegin;
+        mRelativeEnd = srcGuideline.mRelativeEnd;
+        mGuidelineUseRtl = srcGuideline.mGuidelineUseRtl;
+        setOrientation(srcGuideline.mOrientation);
+    }
+
+    @Override
+    public boolean allowedInBarrier() {
+        return true;
+    }
+
+    // @TODO: add description
+    public int getRelativeBehaviour() {
+        if (mRelativePercent != -1) {
+            return RELATIVE_PERCENT;
+        }
+        if (mRelativeBegin != -1) {
+            return RELATIVE_BEGIN;
+        }
+        if (mRelativeEnd != -1) {
+            return RELATIVE_END;
+        }
+        return RELATIVE_UNKNOWN;
+    }
+
+    // @TODO: add description
+    public void setOrientation(int orientation) {
+        if (mOrientation == orientation) {
+            return;
+        }
+        mOrientation = orientation;
+        mAnchors.clear();
+        if (mOrientation == VERTICAL) {
+            mAnchor = mLeft;
+        } else {
+            mAnchor = mTop;
+        }
+        mAnchors.add(mAnchor);
+        final int count = mListAnchors.length;
+        for (int i = 0; i < count; i++) {
+            mListAnchors[i] = mAnchor;
+        }
+    }
+
+    public ConstraintAnchor getAnchor() {
+        return mAnchor;
+    }
+
+    /**
+     * Specify the xml type for the container
+     */
+    @Override
+    public String getType() {
+        return "Guideline";
+    }
+
+    /**
+     * get the orientation VERTICAL or HORIZONTAL
+     * @return orientation
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * set the minimum position
+     * @param minimum
+     */
+    public void setMinimumPosition(int minimum) {
+        mMinimumPosition = minimum;
+    }
+
+    /**
+     * Get the Minimum Position
+     * @return the Minimum Position
+     */
+    public int getMinimumPosition() {
+        return mMinimumPosition;
+    }
+
+    @Override
+    public ConstraintAnchor getAnchor(ConstraintAnchor.Type anchorType) {
+        switch (anchorType) {
+            case LEFT:
+            case RIGHT: {
+                if (mOrientation == VERTICAL) {
+                    return mAnchor;
+                }
+            }
+            break;
+            case TOP:
+            case BOTTOM: {
+                if (mOrientation == HORIZONTAL) {
+                    return mAnchor;
+                }
+            }
+            break;
+            case BASELINE:
+            case CENTER:
+            case CENTER_X:
+            case CENTER_Y:
+            case NONE:
+                return null;
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public void setGuidePercent(int value) {
+        setGuidePercent(value / 100f);
+    }
+
+    // @TODO: add description
+    public void setGuidePercent(float value) {
+        if (value > -1) {
+            mRelativePercent = value;
+            mRelativeBegin = -1;
+            mRelativeEnd = -1;
+        }
+    }
+
+    // @TODO: add description
+    public void setGuideBegin(int value) {
+        if (value > -1) {
+            mRelativePercent = -1;
+            mRelativeBegin = value;
+            mRelativeEnd = -1;
+        }
+    }
+
+    // @TODO: add description
+    public void setGuideEnd(int value) {
+        if (value > -1) {
+            mRelativePercent = -1;
+            mRelativeBegin = -1;
+            mRelativeEnd = value;
+        }
+    }
+
+    public float getRelativePercent() {
+        return mRelativePercent;
+    }
+
+    public int getRelativeBegin() {
+        return mRelativeBegin;
+    }
+
+    public int getRelativeEnd() {
+        return mRelativeEnd;
+    }
+
+    // @TODO: add description
+    public void setFinalValue(int position) {
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("*** SET FINAL GUIDELINE VALUE "
+                    + position + " FOR " + getDebugName());
+        }
+        mAnchor.setFinalValue(position);
+        mResolved = true;
+    }
+
+    @Override
+    public boolean isResolvedHorizontally() {
+        return mResolved;
+    }
+
+    @Override
+    public boolean isResolvedVertically() {
+        return mResolved;
+    }
+
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("\n----------------------------------------------");
+            System.out.println("-- adding " + getDebugName() + " to the solver");
+            System.out.println("----------------------------------------------\n");
+        }
+
+        ConstraintWidgetContainer parent = (ConstraintWidgetContainer) getParent();
+        if (parent == null) {
+            return;
+        }
+        ConstraintAnchor begin = parent.getAnchor(ConstraintAnchor.Type.LEFT);
+        ConstraintAnchor end = parent.getAnchor(ConstraintAnchor.Type.RIGHT);
+        boolean parentWrapContent = mParent != null
+                ? mParent.mListDimensionBehaviors[DIMENSION_HORIZONTAL] == WRAP_CONTENT : false;
+        if (mOrientation == HORIZONTAL) {
+            begin = parent.getAnchor(ConstraintAnchor.Type.TOP);
+            end = parent.getAnchor(ConstraintAnchor.Type.BOTTOM);
+            parentWrapContent = mParent != null
+                    ? mParent.mListDimensionBehaviors[DIMENSION_VERTICAL] == WRAP_CONTENT : false;
+        }
+        if (mResolved && mAnchor.hasFinalValue()) {
+            SolverVariable guide = system.createObjectVariable(mAnchor);
+            if (LinearSystem.FULL_DEBUG) {
+                System.out.println("*** SET FINAL POSITION FOR GUIDELINE "
+                        + getDebugName() + " TO " + mAnchor.getFinalValue());
+            }
+            system.addEquality(guide, mAnchor.getFinalValue());
+            if (mRelativeBegin != -1) {
+                if (parentWrapContent) {
+                    system.addGreaterThan(system.createObjectVariable(end), guide,
+                            0, SolverVariable.STRENGTH_EQUALITY);
+                }
+            } else if (mRelativeEnd != -1) {
+                if (parentWrapContent) {
+                    SolverVariable parentRight = system.createObjectVariable(end);
+                    system.addGreaterThan(guide, system.createObjectVariable(begin),
+                            0, SolverVariable.STRENGTH_EQUALITY);
+                    system.addGreaterThan(parentRight, guide, 0, SolverVariable.STRENGTH_EQUALITY);
+                }
+            }
+            mResolved = false;
+            return;
+        }
+        if (mRelativeBegin != -1) {
+            SolverVariable guide = system.createObjectVariable(mAnchor);
+            SolverVariable parentLeft = system.createObjectVariable(begin);
+            system.addEquality(guide, parentLeft, mRelativeBegin, SolverVariable.STRENGTH_FIXED);
+            if (parentWrapContent) {
+                system.addGreaterThan(system.createObjectVariable(end),
+                        guide, 0, SolverVariable.STRENGTH_EQUALITY);
+            }
+        } else if (mRelativeEnd != -1) {
+            SolverVariable guide = system.createObjectVariable(mAnchor);
+            SolverVariable parentRight = system.createObjectVariable(end);
+            system.addEquality(guide, parentRight, -mRelativeEnd, SolverVariable.STRENGTH_FIXED);
+            if (parentWrapContent) {
+                system.addGreaterThan(guide, system.createObjectVariable(begin),
+                        0, SolverVariable.STRENGTH_EQUALITY);
+                system.addGreaterThan(parentRight, guide, 0, SolverVariable.STRENGTH_EQUALITY);
+            }
+        } else if (mRelativePercent != -1) {
+            SolverVariable guide = system.createObjectVariable(mAnchor);
+            SolverVariable parentRight = system.createObjectVariable(end);
+            system.addConstraint(LinearSystem
+                    .createRowDimensionPercent(system, guide, parentRight,
+                            mRelativePercent));
+        }
+    }
+
+    @Override
+    public void updateFromSolver(LinearSystem system, boolean optimize) {
+        if (getParent() == null) {
+            return;
+        }
+        int value = system.getObjectVariableValue(mAnchor);
+        if (mOrientation == VERTICAL) {
+            setX(value);
+            setY(0);
+            setHeight(getParent().getHeight());
+            setWidth(0);
+        } else {
+            setX(0);
+            setY(value);
+            setWidth(getParent().getWidth());
+            setHeight(0);
+        }
+    }
+
+    void inferRelativePercentPosition() {
+        float percent = (getX() / (float) getParent().getWidth());
+        if (mOrientation == HORIZONTAL) {
+            percent = (getY() / (float) getParent().getHeight());
+        }
+        setGuidePercent(percent);
+    }
+
+    void inferRelativeBeginPosition() {
+        int position = getX();
+        if (mOrientation == HORIZONTAL) {
+            position = getY();
+        }
+        setGuideBegin(position);
+    }
+
+    void inferRelativeEndPosition() {
+        int position = getParent().getWidth() - getX();
+        if (mOrientation == HORIZONTAL) {
+            position = getParent().getHeight() - getY();
+        }
+        setGuideEnd(position);
+    }
+
+    // @TODO: add description
+    public void cyclePosition() {
+        if (mRelativeBegin != -1) {
+            // cycle to percent-based position
+            inferRelativePercentPosition();
+        } else if (mRelativePercent != -1) {
+            // cycle to end-based position
+            inferRelativeEndPosition();
+        } else if (mRelativeEnd != -1) {
+            // cycle to begin-based position
+            inferRelativeBeginPosition();
+        }
+    }
+
+    public boolean isPercent() {
+        return mRelativePercent != -1 && mRelativeBegin == -1 && mRelativeEnd == -1;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Helper.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Helper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+/**
+ * interface to virtual objects
+ */
+
+public interface Helper {
+    // @TODO: add description
+    void updateConstraints(ConstraintWidgetContainer container);
+
+    // @TODO: add description
+    void add(ConstraintWidget widget);
+
+    // @TODO: add description
+    void removeAllIds();
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/HelperWidget.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/HelperWidget.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import androidx.constraintlayout.core.widgets.analyzer.Grouping;
+import androidx.constraintlayout.core.widgets.analyzer.WidgetGroup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * HelperWidget class
+ */
+public class HelperWidget extends ConstraintWidget implements Helper {
+    public ConstraintWidget[] mWidgets = new ConstraintWidget[4];
+    public int mWidgetsCount = 0;
+
+    @Override
+    public void updateConstraints(ConstraintWidgetContainer container) {
+        // nothing here
+    }
+
+    /**
+     * Add a widget to the helper
+     *
+     * @param widget a widget
+     */
+    @Override
+    public void add(ConstraintWidget widget) {
+        if (widget == this || widget == null) {
+            return;
+        }
+        if (mWidgetsCount + 1 > mWidgets.length) {
+            mWidgets = Arrays.copyOf(mWidgets, mWidgets.length * 2);
+        }
+        mWidgets[mWidgetsCount] = widget;
+        mWidgetsCount++;
+    }
+
+    @Override
+    public void copy(ConstraintWidget src, HashMap<ConstraintWidget, ConstraintWidget> map) {
+        super.copy(src, map);
+        HelperWidget srcHelper = (HelperWidget) src;
+        mWidgetsCount = 0;
+        final int count = srcHelper.mWidgetsCount;
+        for (int i = 0; i < count; i++) {
+            add(map.get(srcHelper.mWidgets[i]));
+        }
+    }
+
+    /**
+     * Reset the widgets list contained by this helper
+     */
+    @Override
+    public void removeAllIds() {
+        mWidgetsCount = 0;
+        Arrays.fill(mWidgets, null);
+    }
+
+    // @TODO: add description
+    public void addDependents(ArrayList<WidgetGroup> dependencyLists,
+            int orientation,
+            WidgetGroup group) {
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            group.add(widget);
+        }
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            Grouping.findDependents(widget, orientation, dependencyLists, group);
+        }
+    }
+
+    // @TODO: add description
+    public int findGroupInDependents(int orientation) {
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (orientation == HORIZONTAL && widget.horizontalGroup != -1) {
+                return widget.horizontalGroup;
+            }
+            if (orientation == VERTICAL && widget.verticalGroup != -1) {
+                return widget.verticalGroup;
+            }
+        }
+        return -1;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Optimizer.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Optimizer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DIMENSION_HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DIMENSION_VERTICAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
+import androidx.constraintlayout.core.LinearSystem;
+
+/**
+ * Implements direct resolution without using the solver
+ */
+public class Optimizer {
+
+    // Optimization levels (mask)
+    public static final int OPTIMIZATION_NONE = 0;
+    public static final int OPTIMIZATION_DIRECT = 1;
+    public static final int OPTIMIZATION_BARRIER = 1 << 1;
+    public static final int OPTIMIZATION_CHAIN = 1 << 2;
+    public static final int OPTIMIZATION_DIMENSIONS = 1 << 3;
+    public static final int OPTIMIZATION_RATIO = 1 << 4;
+    public static final int OPTIMIZATION_GROUPS = 1 << 5;
+    public static final int OPTIMIZATION_GRAPH = 1 << 6;
+    public static final int OPTIMIZATION_GRAPH_WRAP = 1 << 7;
+    public static final int OPTIMIZATION_CACHE_MEASURES = 1 << 8;
+    public static final int OPTIMIZATION_DEPENDENCY_ORDERING = 1 << 9;
+    public static final int OPTIMIZATION_GROUPING = 1 << 10;
+    public static final int OPTIMIZATION_STANDARD = OPTIMIZATION_DIRECT
+            /* | OPTIMIZATION_GROUPING */
+            /* | OPTIMIZATION_DEPENDENCY_ORDERING */
+            | OPTIMIZATION_CACHE_MEASURES
+            /* | OPTIMIZATION_GRAPH */
+            /* | OPTIMIZATION_GRAPH_WRAP */
+            /* | OPTIMIZATION_DIMENSIONS */;
+
+    // Internal use.
+    static boolean[] sFlags = new boolean[3];
+    static final int FLAG_USE_OPTIMIZE = 0; // simple enough to use optimizer
+    static final int FLAG_CHAIN_DANGLING = 1;
+    static final int FLAG_RECOMPUTE_BOUNDS = 2;
+
+    /**
+     * Looks at optimizing match_parent
+     */
+    static void checkMatchParent(ConstraintWidgetContainer container,
+            LinearSystem system,
+            ConstraintWidget widget) {
+        widget.mHorizontalResolution = UNKNOWN;
+        widget.mVerticalResolution = UNKNOWN;
+        if (container.mListDimensionBehaviors[DIMENSION_HORIZONTAL]
+                != ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+                && widget.mListDimensionBehaviors[DIMENSION_HORIZONTAL]
+                == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
+
+            int left = widget.mLeft.mMargin;
+            int right = container.getWidth() - widget.mRight.mMargin;
+
+            widget.mLeft.mSolverVariable = system.createObjectVariable(widget.mLeft);
+            widget.mRight.mSolverVariable = system.createObjectVariable(widget.mRight);
+            system.addEquality(widget.mLeft.mSolverVariable, left);
+            system.addEquality(widget.mRight.mSolverVariable, right);
+            widget.mHorizontalResolution = ConstraintWidget.DIRECT;
+            widget.setHorizontalDimension(left, right);
+        }
+        if (container.mListDimensionBehaviors[DIMENSION_VERTICAL]
+                != ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+                && widget.mListDimensionBehaviors[DIMENSION_VERTICAL]
+                == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
+
+            int top = widget.mTop.mMargin;
+            int bottom = container.getHeight() - widget.mBottom.mMargin;
+
+            widget.mTop.mSolverVariable = system.createObjectVariable(widget.mTop);
+            widget.mBottom.mSolverVariable = system.createObjectVariable(widget.mBottom);
+            system.addEquality(widget.mTop.mSolverVariable, top);
+            system.addEquality(widget.mBottom.mSolverVariable, bottom);
+            if (widget.mBaselineDistance > 0 || widget.getVisibility() == ConstraintWidget.GONE) {
+                widget.mBaseline.mSolverVariable = system.createObjectVariable(widget.mBaseline);
+                system.addEquality(widget.mBaseline.mSolverVariable,
+                        top + widget.mBaselineDistance);
+            }
+            widget.mVerticalResolution = ConstraintWidget.DIRECT;
+            widget.setVerticalDimension(top, bottom);
+        }
+    }
+
+    // @TODO: add description
+    public static final boolean enabled(int optimizationLevel, int optimization) {
+        return (optimizationLevel & optimization) == optimization;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Placeholder.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Placeholder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.AT_MOST;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.EXACTLY;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.UNSPECIFIED;
+
+import androidx.constraintlayout.core.LinearSystem;
+
+/**
+ * Simple VirtualLayout that center the first referenced widget onto itself.
+ */
+public class Placeholder extends VirtualLayout {
+
+    // @TODO: add description
+    @Override
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        int width = 0;
+        int height = 0;
+        int paddingLeft = getPaddingLeft();
+        int paddingRight = getPaddingRight();
+        int paddingTop = getPaddingTop();
+        int paddingBottom = getPaddingBottom();
+
+        width += paddingLeft + paddingRight;
+        height += paddingTop + paddingBottom;
+
+        if (mWidgetsCount > 0) {
+            // grab the first referenced widget size in case we are ourselves in wrap_content
+            width += mWidgets[0].getWidth();
+            height += mWidgets[0].getHeight();
+        }
+        width = Math.max(getMinWidth(), width);
+        height = Math.max(getMinHeight(), height);
+
+        int measuredWidth = 0;
+        int measuredHeight = 0;
+
+        if (widthMode == EXACTLY) {
+            measuredWidth = widthSize;
+        } else if (widthMode == AT_MOST) {
+            measuredWidth = Math.min(width, widthSize);
+        } else if (widthMode == UNSPECIFIED) {
+            measuredWidth = width;
+        }
+
+        if (heightMode == EXACTLY) {
+            measuredHeight = heightSize;
+        } else if (heightMode == AT_MOST) {
+            measuredHeight = Math.min(height, heightSize);
+        } else if (heightMode == UNSPECIFIED) {
+            measuredHeight = height;
+        }
+
+        setMeasure(measuredWidth, measuredHeight);
+        setWidth(measuredWidth);
+        setHeight(measuredHeight);
+        needsCallbackFromSolver(mWidgetsCount > 0);
+    }
+
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        super.addToSolver(system, optimize);
+
+        if (mWidgetsCount > 0) {
+            ConstraintWidget widget = mWidgets[0];
+            widget.resetAllConstraints();
+            widget.connect(ConstraintAnchor.Type.LEFT, this, ConstraintAnchor.Type.LEFT);
+            widget.connect(ConstraintAnchor.Type.RIGHT, this, ConstraintAnchor.Type.RIGHT);
+            widget.connect(ConstraintAnchor.Type.TOP, this, ConstraintAnchor.Type.TOP);
+            widget.connect(ConstraintAnchor.Type.BOTTOM, this, ConstraintAnchor.Type.BOTTOM);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Rectangle.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/Rectangle.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+/**
+ * Simple rect class
+ */
+public class Rectangle {
+    public int x;
+    public int y;
+    public int width;
+    public int height;
+
+    // @TODO: add description
+    public void setBounds(int x, int y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    void grow(int w, int h) {
+        x -= w;
+        y -= h;
+        width += 2 * w;
+        height += 2 * h;
+    }
+
+    boolean intersects(Rectangle bounds) {
+        return x >= bounds.x && x < bounds.x + bounds.width
+                && y >= bounds.y && y < bounds.y + bounds.height;
+    }
+
+    // @TODO: add description
+    public boolean contains(int x, int y) {
+        return x >= this.x && x < this.x + this.width
+                && y >= this.y && y < this.y + this.height;
+    }
+
+    public int getCenterX() {
+        return (x + width) / 2;
+    }
+
+    public int getCenterY() {
+        return (y + height) / 2;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/VirtualLayout.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/VirtualLayout.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets;
+
+import androidx.constraintlayout.core.widgets.analyzer.BasicMeasure;
+
+import java.util.HashSet;
+
+/**
+ * Base class for Virtual layouts
+ */
+public class VirtualLayout extends HelperWidget {
+
+    private int mPaddingTop = 0;
+    private int mPaddingBottom = 0;
+    @SuppressWarnings("unused") private int mPaddingLeft = 0;
+    @SuppressWarnings("unused") private int mPaddingRight = 0;
+    @SuppressWarnings("unused") private int mPaddingStart = 0;
+    private int mPaddingEnd = 0;
+    private int mResolvedPaddingLeft = 0;
+    private int mResolvedPaddingRight = 0;
+
+    private boolean mNeedsCallFromSolver = false;
+    private int mMeasuredWidth = 0;
+    private int mMeasuredHeight = 0;
+
+    protected BasicMeasure.Measure mMeasure = new BasicMeasure.Measure();
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Accessors
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    // @TODO: add description
+    public void setPadding(int value) {
+        mPaddingLeft = value;
+        mPaddingTop = value;
+        mPaddingRight = value;
+        mPaddingBottom = value;
+        mPaddingStart = value;
+        mPaddingEnd = value;
+    }
+
+    // @TODO: add description
+    public void setPaddingStart(int value) {
+        mPaddingStart = value;
+        mResolvedPaddingLeft = value;
+        mResolvedPaddingRight = value;
+    }
+
+    public void setPaddingEnd(int value) {
+        mPaddingEnd = value;
+    }
+
+    // @TODO: add description
+    public void setPaddingLeft(int value) {
+        mPaddingLeft = value;
+        mResolvedPaddingLeft = value;
+    }
+
+    // @TODO: add description
+    public void applyRtl(boolean isRtl) {
+        if (mPaddingStart > 0 || mPaddingEnd > 0) {
+            if (isRtl) {
+                mResolvedPaddingLeft = mPaddingEnd;
+                mResolvedPaddingRight = mPaddingStart;
+            } else {
+                mResolvedPaddingLeft = mPaddingStart;
+                mResolvedPaddingRight = mPaddingEnd;
+            }
+        }
+    }
+
+    public void setPaddingTop(int value) {
+        mPaddingTop = value;
+    }
+
+    // @TODO: add description
+    public void setPaddingRight(int value) {
+        mPaddingRight = value;
+        mResolvedPaddingRight = value;
+    }
+
+    public void setPaddingBottom(int value) {
+        mPaddingBottom = value;
+    }
+
+    public int getPaddingTop() {
+        return mPaddingTop;
+    }
+
+    public int getPaddingBottom() {
+        return mPaddingBottom;
+    }
+
+    public int getPaddingLeft() {
+        return mResolvedPaddingLeft;
+    }
+
+    public int getPaddingRight() {
+        return mResolvedPaddingRight;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Solver callback
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    protected void needsCallbackFromSolver(boolean value) {
+        mNeedsCallFromSolver = value;
+    }
+
+    // @TODO: add description
+    public boolean needSolverPass() {
+        return mNeedsCallFromSolver;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Measure
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    // @TODO: add description
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        // nothing
+    }
+
+    @Override
+    public void updateConstraints(ConstraintWidgetContainer container) {
+        captureWidgets();
+    }
+
+    // @TODO: add description
+    public void captureWidgets() {
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (widget != null) {
+                widget.setInVirtualLayout(true);
+            }
+        }
+    }
+
+    public int getMeasuredWidth() {
+        return mMeasuredWidth;
+    }
+
+    public int getMeasuredHeight() {
+        return mMeasuredHeight;
+    }
+
+    // @TODO: add description
+    public void setMeasure(int width, int height) {
+        mMeasuredWidth = width;
+        mMeasuredHeight = height;
+    }
+
+    protected boolean measureChildren() {
+        BasicMeasure.Measurer measurer = null;
+        if (mParent != null) {
+            measurer = ((ConstraintWidgetContainer) mParent).getMeasurer();
+        }
+        if (measurer == null) {
+            return false;
+        }
+
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (widget == null) {
+                continue;
+            }
+
+            if (widget instanceof Guideline) {
+                continue;
+            }
+
+            DimensionBehaviour widthBehavior = widget.getDimensionBehaviour(HORIZONTAL);
+            DimensionBehaviour heightBehavior = widget.getDimensionBehaviour(VERTICAL);
+
+            boolean skip = widthBehavior == DimensionBehaviour.MATCH_CONSTRAINT
+                    && widget.mMatchConstraintDefaultWidth != MATCH_CONSTRAINT_WRAP
+                    && heightBehavior == DimensionBehaviour.MATCH_CONSTRAINT
+                    && widget.mMatchConstraintDefaultHeight != MATCH_CONSTRAINT_WRAP;
+
+            if (skip) {
+                // we don't need to measure here as the dimension of the widget
+                // will be completely computed by the solver.
+                continue;
+            }
+
+            if (widthBehavior == DimensionBehaviour.MATCH_CONSTRAINT) {
+                widthBehavior = DimensionBehaviour.WRAP_CONTENT;
+            }
+            if (heightBehavior == DimensionBehaviour.MATCH_CONSTRAINT) {
+                heightBehavior = DimensionBehaviour.WRAP_CONTENT;
+            }
+            mMeasure.horizontalBehavior = widthBehavior;
+            mMeasure.verticalBehavior = heightBehavior;
+            mMeasure.horizontalDimension = widget.getWidth();
+            mMeasure.verticalDimension = widget.getHeight();
+            measurer.measure(widget, mMeasure);
+            widget.setWidth(mMeasure.measuredWidth);
+            widget.setHeight(mMeasure.measuredHeight);
+            widget.setBaselineDistance(mMeasure.measuredBaseline);
+        }
+        return true;
+    }
+
+    BasicMeasure.Measurer mMeasurer = null;
+
+    protected void measure(ConstraintWidget widget,
+            ConstraintWidget.DimensionBehaviour horizontalBehavior,
+            int horizontalDimension,
+            ConstraintWidget.DimensionBehaviour verticalBehavior,
+            int verticalDimension) {
+        while (mMeasurer == null && getParent() != null) {
+            ConstraintWidgetContainer parent = (ConstraintWidgetContainer) getParent();
+            mMeasurer = parent.getMeasurer();
+        }
+        mMeasure.horizontalBehavior = horizontalBehavior;
+        mMeasure.verticalBehavior = verticalBehavior;
+        mMeasure.horizontalDimension = horizontalDimension;
+        mMeasure.verticalDimension = verticalDimension;
+        mMeasurer.measure(widget, mMeasure);
+        widget.setWidth(mMeasure.measuredWidth);
+        widget.setHeight(mMeasure.measuredHeight);
+        widget.setHasBaseline(mMeasure.measuredHasBaseline);
+        widget.setBaselineDistance(mMeasure.measuredBaseline);
+    }
+
+    // @TODO: add description
+    public boolean contains(HashSet<ConstraintWidget> widgets) {
+        for (int i = 0; i < mWidgetsCount; i++) {
+            ConstraintWidget widget = mWidgets[i];
+            if (widgets.contains(widget)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/WidgetContainer.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/WidgetContainer.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import androidx.constraintlayout.core.Cache;
+
+import java.util.ArrayList;
+
+/**
+ * A container of ConstraintWidget
+ */
+public class WidgetContainer extends ConstraintWidget {
+    public ArrayList<ConstraintWidget> mChildren = new ArrayList<>();
+
+    /*-----------------------------------------------------------------------*/
+    // Construction
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Default constructor
+     */
+    public WidgetContainer() {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param x      x position
+     * @param y      y position
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public WidgetContainer(int x, int y, int width, int height) {
+        super(x, y, width, height);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param width  width of the layout
+     * @param height height of the layout
+     */
+    public WidgetContainer(int width, int height) {
+        super(width, height);
+    }
+
+    @Override
+    public void reset() {
+        mChildren.clear();
+        super.reset();
+    }
+
+    /**
+     * Add a child widget
+     *
+     * @param widget to add
+     */
+    public void add(ConstraintWidget widget) {
+        mChildren.add(widget);
+        if (widget.getParent() != null) {
+            WidgetContainer container = (WidgetContainer) widget.getParent();
+            container.remove(widget);
+        }
+        widget.setParent(this);
+    }
+
+    /**
+     * Add multiple child widgets.
+     *
+     * @param widgets to add
+     */
+    public void add(ConstraintWidget... widgets) {
+        final int count = widgets.length;
+        for (int i = 0; i < count; i++) {
+            add(widgets[i]);
+        }
+    }
+
+    /**
+     * Remove a child widget
+     *
+     * @param widget to remove
+     */
+    public void remove(ConstraintWidget widget) {
+        mChildren.remove(widget);
+        widget.reset();
+    }
+
+    /**
+     * Access the children
+     *
+     * @return the array of children
+     */
+    public ArrayList<ConstraintWidget> getChildren() {
+        return mChildren;
+    }
+
+    /**
+     * Return the top-level ConstraintWidgetContainer
+     *
+     * @return top-level ConstraintWidgetContainer
+     */
+    public ConstraintWidgetContainer getRootConstraintContainer() {
+        ConstraintWidget item = this;
+        ConstraintWidget parent = item.getParent();
+        ConstraintWidgetContainer container = null;
+        if (item instanceof ConstraintWidgetContainer) {
+            container = (ConstraintWidgetContainer) this;
+        }
+        while (parent != null) {
+            item = parent;
+            parent = item.getParent();
+            if (item instanceof ConstraintWidgetContainer) {
+                container = (ConstraintWidgetContainer) item;
+            }
+        }
+        return container;
+    }
+
+    /*-----------------------------------------------------------------------*/
+    // Overloaded methods from ConstraintWidget
+    /*-----------------------------------------------------------------------*/
+
+    /**
+     * Set the offset of this widget relative to the root widget.
+     * We then set the offset of our children as well.
+     *
+     * @param x horizontal offset
+     * @param y vertical offset
+     */
+    @Override
+    public void setOffset(int x, int y) {
+        super.setOffset(x, y);
+        final int count = mChildren.size();
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            widget.setOffset(getRootX(), getRootY());
+        }
+    }
+
+    /**
+     * Function implemented by ConstraintWidgetContainer
+     */
+    public void layout() {
+        if (mChildren == null) {
+            return;
+        }
+        final int count = mChildren.size();
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            if (widget instanceof WidgetContainer) {
+                ((WidgetContainer) widget).layout();
+            }
+        }
+    }
+
+    @Override
+    public void resetSolverVariables(Cache cache) {
+        super.resetSolverVariables(cache);
+        final int count = mChildren.size();
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget widget = mChildren.get(i);
+            widget.resetSolverVariables(cache);
+        }
+    }
+
+    // @TODO: add description
+    public void removeAllChildren() {
+        mChildren.clear();
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/BaselineDimensionDependency.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/BaselineDimensionDependency.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+class BaselineDimensionDependency extends DimensionDependency {
+
+    BaselineDimensionDependency(WidgetRun run) {
+        super(run);
+    }
+
+    public void update(DependencyNode node) {
+        VerticalWidgetRun verticalRun = (VerticalWidgetRun) mRun;
+        verticalRun.baseline.mMargin = mRun.mWidget.getBaselineDistance();
+        resolved = true;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/BasicMeasure.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/BasicMeasure.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.GONE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.Guideline;
+import androidx.constraintlayout.core.widgets.Helper;
+import androidx.constraintlayout.core.widgets.Optimizer;
+import androidx.constraintlayout.core.widgets.VirtualLayout;
+
+import java.util.ArrayList;
+
+/**
+ * Implements basic measure for linear resolution
+ */
+public class BasicMeasure {
+
+    private static final boolean DEBUG = false;
+    private static final boolean DO_NOT_USE = false;
+    private static final int MODE_SHIFT = 30;
+    public static final int UNSPECIFIED = 0;
+    public static final int EXACTLY = 1 << MODE_SHIFT;
+    public static final int AT_MOST = 2 << MODE_SHIFT;
+
+    public static final int MATCH_PARENT = -1;
+    public static final int WRAP_CONTENT = -2;
+    public static final int FIXED = -3;
+
+    private final ArrayList<ConstraintWidget> mVariableDimensionsWidgets = new ArrayList<>();
+    private Measure mMeasure = new Measure();
+
+    // @TODO: add description
+    public void updateHierarchy(ConstraintWidgetContainer layout) {
+        mVariableDimensionsWidgets.clear();
+        final int childCount = layout.mChildren.size();
+        for (int i = 0; i < childCount; i++) {
+            ConstraintWidget widget = layout.mChildren.get(i);
+            if (widget.getHorizontalDimensionBehaviour()
+                    == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                    || widget.getVerticalDimensionBehaviour()
+                    == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+                mVariableDimensionsWidgets.add(widget);
+            }
+        }
+        layout.invalidateGraph();
+    }
+
+    private ConstraintWidgetContainer mConstraintWidgetContainer;
+
+    public BasicMeasure(ConstraintWidgetContainer constraintWidgetContainer) {
+        this.mConstraintWidgetContainer = constraintWidgetContainer;
+    }
+
+    private void measureChildren(ConstraintWidgetContainer layout) {
+        final int childCount = layout.mChildren.size();
+        boolean optimize = layout.optimizeFor(Optimizer.OPTIMIZATION_GRAPH);
+        Measurer measurer = layout.getMeasurer();
+        for (int i = 0; i < childCount; i++) {
+            ConstraintWidget child = layout.mChildren.get(i);
+            if (child instanceof Guideline) {
+                continue;
+            }
+            if (child instanceof Barrier) {
+                continue;
+            }
+            if (child.isInVirtualLayout()) {
+                continue;
+            }
+
+            if (optimize && child.mHorizontalRun != null && child.mVerticalRun != null
+                    && child.mHorizontalRun.mDimension.resolved
+                    && child.mVerticalRun.mDimension.resolved) {
+                continue;
+            }
+
+            ConstraintWidget.DimensionBehaviour widthBehavior =
+                    child.getDimensionBehaviour(HORIZONTAL);
+            ConstraintWidget.DimensionBehaviour heightBehavior =
+                    child.getDimensionBehaviour(VERTICAL);
+
+            boolean skip = widthBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                    && child.mMatchConstraintDefaultWidth != MATCH_CONSTRAINT_WRAP
+                    && heightBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                    && child.mMatchConstraintDefaultHeight != MATCH_CONSTRAINT_WRAP;
+
+            if (!skip && layout.optimizeFor(Optimizer.OPTIMIZATION_DIRECT)
+                    && !(child instanceof VirtualLayout)) {
+                if (widthBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && child.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD
+                        && heightBehavior != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && !child.isInHorizontalChain()) {
+                    skip = true;
+                }
+
+                if (heightBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && child.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD
+                        && widthBehavior != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && !child.isInHorizontalChain()) {
+                    skip = true;
+                }
+
+                // Don't measure yet -- let the direct solver have a shot at it.
+                if ((widthBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        || heightBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT)
+                        && child.mDimensionRatio > 0) {
+                    skip = true;
+                }
+            }
+
+            if (skip) {
+                // we don't need to measure here as the dimension of the widget
+                // will be completely computed by the solver.
+                continue;
+            }
+
+            measure(measurer, child, Measure.SELF_DIMENSIONS);
+            if (layout.mMetrics != null) {
+                layout.mMetrics.measuredWidgets++;
+            }
+        }
+        measurer.didMeasures();
+    }
+
+    private void solveLinearSystem(ConstraintWidgetContainer layout,
+            String reason,
+            int pass,
+            int w,
+            int h) {
+        long startLayout = 0;
+        if (layout.mMetrics != null) {
+            startLayout = System.nanoTime();
+        }
+
+        int minWidth = layout.getMinWidth();
+        int minHeight = layout.getMinHeight();
+        layout.setMinWidth(0);
+        layout.setMinHeight(0);
+        layout.setWidth(w);
+        layout.setHeight(h);
+        layout.setMinWidth(minWidth);
+        layout.setMinHeight(minHeight);
+        if (DEBUG) {
+            System.out.println("### Solve <" + reason + "> ###");
+        }
+        mConstraintWidgetContainer.setPass(pass);
+        mConstraintWidgetContainer.layout();
+        if (layout.mMetrics != null) {
+            long endLayout = System.nanoTime();
+            layout.mMetrics.mSolverPasses++;
+            layout.mMetrics.measuresLayoutDuration += (endLayout - startLayout);
+        }
+    }
+
+    /**
+     * Called by ConstraintLayout onMeasure()
+     */
+    public long solverMeasure(ConstraintWidgetContainer layout,
+            int optimizationLevel,
+            int paddingX, int paddingY,
+            int widthMode, int widthSize,
+            int heightMode, int heightSize,
+            int lastMeasureWidth,
+            int lastMeasureHeight) {
+        Measurer measurer = layout.getMeasurer();
+        long layoutTime = 0;
+
+        final int childCount = layout.mChildren.size();
+        int startingWidth = layout.getWidth();
+        int startingHeight = layout.getHeight();
+
+        boolean optimizeWrap =
+                Optimizer.enabled(optimizationLevel, Optimizer.OPTIMIZATION_GRAPH_WRAP);
+        boolean optimize = optimizeWrap
+                || Optimizer.enabled(optimizationLevel, Optimizer.OPTIMIZATION_GRAPH);
+
+        if (optimize) {
+            for (int i = 0; i < childCount; i++) {
+                ConstraintWidget child = layout.mChildren.get(i);
+                boolean matchWidth = child.getHorizontalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+                boolean matchHeight = child.getVerticalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+                boolean ratio = matchWidth && matchHeight && child.getDimensionRatio() > 0;
+                if (child.isInHorizontalChain() && ratio) {
+                    optimize = false;
+                    break;
+                }
+                if (child.isInVerticalChain() && ratio) {
+                    optimize = false;
+                    break;
+                }
+                if (child instanceof VirtualLayout) {
+                    optimize = false;
+                    break;
+                }
+                if (child.isInHorizontalChain()
+                        || child.isInVerticalChain()) {
+                    optimize = false;
+                    break;
+                }
+            }
+        }
+
+        if (optimize && LinearSystem.sMetrics != null) {
+            LinearSystem.sMetrics.measures++;
+        }
+
+        boolean allSolved = false;
+
+        optimize &= (widthMode == EXACTLY && heightMode == EXACTLY) || optimizeWrap;
+
+        int computations = 0;
+
+        if (optimize) {
+            // For non-optimizer this doesn't seem to be a problem.
+            // For both cases, having the width address max size early seems to work
+            //  (which makes sense).
+            // Putting it specific to optimizer to reduce unnecessary risk.
+            widthSize = Math.min(layout.getMaxWidth(), widthSize);
+            heightSize = Math.min(layout.getMaxHeight(), heightSize);
+
+            if (widthMode == EXACTLY && layout.getWidth() != widthSize) {
+                layout.setWidth(widthSize);
+                layout.invalidateGraph();
+            }
+            if (heightMode == EXACTLY && layout.getHeight() != heightSize) {
+                layout.setHeight(heightSize);
+                layout.invalidateGraph();
+            }
+            if (widthMode == EXACTLY && heightMode == EXACTLY) {
+                allSolved = layout.directMeasure(optimizeWrap);
+                computations = 2;
+            } else {
+                allSolved = layout.directMeasureSetup(optimizeWrap);
+                if (widthMode == EXACTLY) {
+                    allSolved &= layout.directMeasureWithOrientation(optimizeWrap, HORIZONTAL);
+                    computations++;
+                }
+                if (heightMode == EXACTLY) {
+                    allSolved &= layout.directMeasureWithOrientation(optimizeWrap, VERTICAL);
+                    computations++;
+                }
+            }
+            if (allSolved) {
+                layout.updateFromRuns(widthMode == EXACTLY, heightMode == EXACTLY);
+            }
+        } else {
+            if (false) {
+                layout.mHorizontalRun.clear();
+                layout.mVerticalRun.clear();
+                for (ConstraintWidget child : layout.getChildren()) {
+                    child.mHorizontalRun.clear();
+                    child.mVerticalRun.clear();
+                }
+            }
+        }
+
+        if (!allSolved || computations != 2) {
+            int optimizations = layout.getOptimizationLevel();
+            if (childCount > 0) {
+                measureChildren(layout);
+            }
+            if (layout.mMetrics != null) {
+                layoutTime = System.nanoTime();
+            }
+
+            updateHierarchy(layout);
+
+            // let's update the size dependent widgets if any...
+            final int sizeDependentWidgetsCount = mVariableDimensionsWidgets.size();
+
+            // let's solve the linear system.
+            if (childCount > 0) {
+                solveLinearSystem(layout, "First pass", 0, startingWidth, startingHeight);
+            }
+
+            if (DEBUG) {
+                System.out.println("size dependent widgets: " + sizeDependentWidgetsCount);
+            }
+
+            if (sizeDependentWidgetsCount > 0) {
+                boolean needSolverPass = false;
+                boolean containerWrapWidth = layout.getHorizontalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+                boolean containerWrapHeight = layout.getVerticalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+                int minWidth = Math.max(layout.getWidth(),
+                        mConstraintWidgetContainer.getMinWidth());
+                int minHeight = Math.max(layout.getHeight(),
+                        mConstraintWidgetContainer.getMinHeight());
+
+                ////////////////////////////////////////////////////////////////////////////////////
+                // Let's first apply sizes for VirtualLayouts if any
+                ////////////////////////////////////////////////////////////////////////////////////
+                for (int i = 0; i < sizeDependentWidgetsCount; i++) {
+                    ConstraintWidget widget = mVariableDimensionsWidgets.get(i);
+                    if (!(widget instanceof VirtualLayout)) {
+                        continue;
+                    }
+                    int preWidth = widget.getWidth();
+                    int preHeight = widget.getHeight();
+                    needSolverPass |= measure(measurer, widget, Measure.TRY_GIVEN_DIMENSIONS);
+                    if (layout.mMetrics != null) {
+                        layout.mMetrics.measuredMatchWidgets++;
+                    }
+                    int measuredWidth = widget.getWidth();
+                    int measuredHeight = widget.getHeight();
+                    if (measuredWidth != preWidth) {
+                        widget.setWidth(measuredWidth);
+                        if (containerWrapWidth && widget.getRight() > minWidth) {
+                            int w = widget.getRight()
+                                    + widget.getAnchor(ConstraintAnchor.Type.RIGHT).getMargin();
+                            minWidth = Math.max(minWidth, w);
+                        }
+                        needSolverPass = true;
+                    }
+                    if (measuredHeight != preHeight) {
+                        widget.setHeight(measuredHeight);
+                        if (containerWrapHeight && widget.getBottom() > minHeight) {
+                            int h = widget.getBottom()
+                                    + widget.getAnchor(ConstraintAnchor.Type.BOTTOM).getMargin();
+                            minHeight = Math.max(minHeight, h);
+                        }
+                        needSolverPass = true;
+                    }
+                    VirtualLayout virtualLayout = (VirtualLayout) widget;
+                    needSolverPass |= virtualLayout.needSolverPass();
+                }
+                ////////////////////////////////////////////////////////////////////////////////////
+
+                int maxIterations = 2;
+                for (int j = 0; j < maxIterations; j++) {
+                    for (int i = 0; i < sizeDependentWidgetsCount; i++) {
+                        ConstraintWidget widget = mVariableDimensionsWidgets.get(i);
+                        if ((widget instanceof Helper && !(widget instanceof VirtualLayout))
+                                || widget instanceof Guideline) {
+                            continue;
+                        }
+                        if (widget.getVisibility() == GONE) {
+                            continue;
+                        }
+                        if (optimize && widget.mHorizontalRun.mDimension.resolved
+                                && widget.mVerticalRun.mDimension.resolved) {
+                            continue;
+                        }
+                        if (widget instanceof VirtualLayout) {
+                            continue;
+                        }
+
+                        int preWidth = widget.getWidth();
+                        int preHeight = widget.getHeight();
+                        int preBaselineDistance = widget.getBaselineDistance();
+
+                        int measureStrategy = Measure.TRY_GIVEN_DIMENSIONS;
+                        if (j == maxIterations - 1) {
+                            measureStrategy = Measure.USE_GIVEN_DIMENSIONS;
+                        }
+                        boolean hasMeasure = measure(measurer, widget, measureStrategy);
+                        if (DO_NOT_USE && !widget.hasDependencies()) {
+                            hasMeasure = false;
+                        }
+                        needSolverPass |= hasMeasure;
+                        if (DEBUG && hasMeasure) {
+                            System.out.println("{#} Needs Solver pass as measure true for "
+                                    + widget.getDebugName());
+                        }
+                        if (layout.mMetrics != null) {
+                            layout.mMetrics.measuredMatchWidgets++;
+                        }
+
+                        int measuredWidth = widget.getWidth();
+                        int measuredHeight = widget.getHeight();
+
+                        if (measuredWidth != preWidth) {
+                            widget.setWidth(measuredWidth);
+                            if (containerWrapWidth && widget.getRight() > minWidth) {
+                                int w = widget.getRight()
+                                        + widget.getAnchor(ConstraintAnchor.Type.RIGHT).getMargin();
+                                minWidth = Math.max(minWidth, w);
+                            }
+                            if (DEBUG) {
+                                System.out.println("{#} Needs Solver pass as Width for "
+                                        + widget.getDebugName() + " changed: "
+                                        + measuredWidth + " != " + preWidth);
+                            }
+                            needSolverPass = true;
+                        }
+                        if (measuredHeight != preHeight) {
+                            widget.setHeight(measuredHeight);
+                            if (containerWrapHeight && widget.getBottom() > minHeight) {
+                                int h = widget.getBottom()
+                                        + widget.getAnchor(ConstraintAnchor.Type.BOTTOM)
+                                        .getMargin();
+                                minHeight = Math.max(minHeight, h);
+                            }
+                            if (DEBUG) {
+                                System.out.println("{#} Needs Solver pass as Height for "
+                                        + widget.getDebugName() + " changed: "
+                                        + measuredHeight + " != " + preHeight);
+                            }
+                            needSolverPass = true;
+                        }
+                        if (widget.hasBaseline()
+                                && preBaselineDistance != widget.getBaselineDistance()) {
+                            if (DEBUG) {
+                                System.out.println("{#} Needs Solver pass as Baseline for "
+                                        + widget.getDebugName() + " changed: "
+                                        + widget.getBaselineDistance() + " != "
+                                        + preBaselineDistance);
+                            }
+                            needSolverPass = true;
+                        }
+                    }
+                    if (needSolverPass) {
+                        solveLinearSystem(layout, "intermediate pass",
+                                1 + j, startingWidth, startingHeight);
+                        needSolverPass = false;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            layout.setOptimizationLevel(optimizations);
+        }
+        if (layout.mMetrics != null) {
+            layoutTime = (System.nanoTime() - layoutTime);
+        }
+        return layoutTime;
+    }
+
+    /**
+     * Convenience function to fill in the measure spec
+     *
+     * @param measurer        the measurer callback
+     * @param widget          the widget to measure
+     * @param measureStrategy how to use the current ConstraintWidget dimensions during the measure
+     * @return true if needs another solver pass
+     */
+    private boolean measure(Measurer measurer, ConstraintWidget widget, int measureStrategy) {
+        mMeasure.horizontalBehavior = widget.getHorizontalDimensionBehaviour();
+        mMeasure.verticalBehavior = widget.getVerticalDimensionBehaviour();
+        mMeasure.horizontalDimension = widget.getWidth();
+        mMeasure.verticalDimension = widget.getHeight();
+        mMeasure.measuredNeedsSolverPass = false;
+        mMeasure.measureStrategy = measureStrategy;
+
+        boolean horizontalMatchConstraints = (mMeasure.horizontalBehavior
+                == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT);
+        boolean verticalMatchConstraints = (mMeasure.verticalBehavior
+                == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT);
+        boolean horizontalUseRatio = horizontalMatchConstraints && widget.mDimensionRatio > 0;
+        boolean verticalUseRatio = verticalMatchConstraints && widget.mDimensionRatio > 0;
+
+        if (horizontalUseRatio) {
+            if (widget.mResolvedMatchConstraintDefault[HORIZONTAL]
+                    == ConstraintWidget.MATCH_CONSTRAINT_RATIO_RESOLVED) {
+                mMeasure.horizontalBehavior = ConstraintWidget.DimensionBehaviour.FIXED;
+            }
+        }
+        if (verticalUseRatio) {
+            if (widget.mResolvedMatchConstraintDefault[VERTICAL]
+                    == ConstraintWidget.MATCH_CONSTRAINT_RATIO_RESOLVED) {
+                mMeasure.verticalBehavior = ConstraintWidget.DimensionBehaviour.FIXED;
+            }
+        }
+
+        measurer.measure(widget, mMeasure);
+        widget.setWidth(mMeasure.measuredWidth);
+        widget.setHeight(mMeasure.measuredHeight);
+        widget.setHasBaseline(mMeasure.measuredHasBaseline);
+        widget.setBaselineDistance(mMeasure.measuredBaseline);
+        mMeasure.measureStrategy = Measure.SELF_DIMENSIONS;
+        return mMeasure.measuredNeedsSolverPass;
+    }
+
+    public interface Measurer {
+        // @TODO: add description
+        void measure(ConstraintWidget widget, Measure measure);
+
+        // @TODO: add description
+        void didMeasures();
+    }
+
+    public static class Measure {
+        public static int SELF_DIMENSIONS = 0;
+        public static int TRY_GIVEN_DIMENSIONS = 1;
+        public static int USE_GIVEN_DIMENSIONS = 2;
+        public ConstraintWidget.DimensionBehaviour horizontalBehavior;
+        public ConstraintWidget.DimensionBehaviour verticalBehavior;
+        public int horizontalDimension;
+        public int verticalDimension;
+        public int measuredWidth;
+        public int measuredHeight;
+        public int measuredBaseline;
+        public boolean measuredHasBaseline;
+        public boolean measuredNeedsSolverPass;
+        public int measureStrategy;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/ChainRun.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/ChainRun.java
@@ -1,0 +1,581 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.GONE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+
+import java.util.ArrayList;
+
+public class ChainRun extends WidgetRun {
+    ArrayList<WidgetRun> mWidgets = new ArrayList<>();
+    private int mChainStyle;
+
+    public ChainRun(ConstraintWidget widget, int orientation) {
+        super(widget);
+        this.orientation = orientation;
+        build();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder log = new StringBuilder("ChainRun ");
+        log.append((orientation == HORIZONTAL ? "horizontal : " : "vertical : "));
+        for (WidgetRun run : mWidgets) {
+            log.append("<");
+            log.append(run);
+            log.append("> ");
+        }
+        return log.toString();
+    }
+
+    @Override
+    boolean supportsWrapComputation() {
+        final int count = mWidgets.size();
+        for (int i = 0; i < count; i++) {
+            WidgetRun run = mWidgets.get(i);
+            if (!run.supportsWrapComputation()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // @TODO: add description
+    @Override
+    public long getWrapDimension() {
+        final int count = mWidgets.size();
+        long wrapDimension = 0;
+        for (int i = 0; i < count; i++) {
+            WidgetRun run = mWidgets.get(i);
+            wrapDimension += run.start.mMargin;
+            wrapDimension += run.getWrapDimension();
+            wrapDimension += run.end.mMargin;
+        }
+        return wrapDimension;
+    }
+
+    private void build() {
+        ConstraintWidget current = mWidget;
+        ConstraintWidget previous = current.getPreviousChainMember(orientation);
+        while (previous != null) {
+            current = previous;
+            previous = current.getPreviousChainMember(orientation);
+        }
+        mWidget = current; // first element of the chain
+        mWidgets.add(current.getRun(orientation));
+        ConstraintWidget next = current.getNextChainMember(orientation);
+        while (next != null) {
+            current = next;
+            mWidgets.add(current.getRun(orientation));
+            next = current.getNextChainMember(orientation);
+        }
+        for (WidgetRun run : mWidgets) {
+            if (orientation == HORIZONTAL) {
+                run.mWidget.horizontalChainRun = this;
+            } else if (orientation == ConstraintWidget.VERTICAL) {
+                run.mWidget.verticalChainRun = this;
+            }
+        }
+        boolean isInRtl = (orientation == HORIZONTAL)
+                && ((ConstraintWidgetContainer) mWidget.getParent()).isRtl();
+        if (isInRtl && mWidgets.size() > 1) {
+            mWidget = mWidgets.get(mWidgets.size() - 1).mWidget;
+        }
+        mChainStyle = orientation == HORIZONTAL
+                ? mWidget.getHorizontalChainStyle() : mWidget.getVerticalChainStyle();
+    }
+
+
+    @Override
+    void clear() {
+        mRunGroup = null;
+        for (WidgetRun run : mWidgets) {
+            run.clear();
+        }
+    }
+
+    @Override
+    void reset() {
+        start.resolved = false;
+        end.resolved = false;
+    }
+
+    @Override
+    public void update(Dependency dependency) {
+        if (!(start.resolved && end.resolved)) {
+            return;
+        }
+
+        ConstraintWidget parent = mWidget.getParent();
+        boolean isInRtl = false;
+        if (parent instanceof ConstraintWidgetContainer) {
+            isInRtl = ((ConstraintWidgetContainer) parent).isRtl();
+        }
+        int distance = end.value - start.value;
+        int size = 0;
+        int numMatchConstraints = 0;
+        float weights = 0;
+        int numVisibleWidgets = 0;
+        final int count = mWidgets.size();
+        // let's find the first visible widget...
+        int firstVisibleWidget = -1;
+        for (int i = 0; i < count; i++) {
+            WidgetRun run = mWidgets.get(i);
+            if (run.mWidget.getVisibility() == GONE) {
+                continue;
+            }
+            firstVisibleWidget = i;
+            break;
+        }
+        // now the last visible widget...
+        int lastVisibleWidget = -1;
+        for (int i = count - 1; i >= 0; i--) {
+            WidgetRun run = mWidgets.get(i);
+            if (run.mWidget.getVisibility() == GONE) {
+                continue;
+            }
+            lastVisibleWidget = i;
+            break;
+        }
+        for (int j = 0; j < 2; j++) {
+            for (int i = 0; i < count; i++) {
+                WidgetRun run = mWidgets.get(i);
+                if (run.mWidget.getVisibility() == GONE) {
+                    continue;
+                }
+                numVisibleWidgets++;
+                if (i > 0 && i >= firstVisibleWidget) {
+                    size += run.start.mMargin;
+                }
+                int dimension = run.mDimension.value;
+                boolean treatAsFixed = run.mDimensionBehavior != MATCH_CONSTRAINT;
+                if (treatAsFixed) {
+                    if (orientation == HORIZONTAL
+                            && !run.mWidget.mHorizontalRun.mDimension.resolved) {
+                        return;
+                    }
+                    if (orientation == VERTICAL && !run.mWidget.mVerticalRun.mDimension.resolved) {
+                        return;
+                    }
+                } else if (run.matchConstraintsType == MATCH_CONSTRAINT_WRAP && j == 0) {
+                    treatAsFixed = true;
+                    dimension = run.mDimension.wrapValue;
+                    numMatchConstraints++;
+                } else if (run.mDimension.resolved) {
+                    treatAsFixed = true;
+                }
+                if (!treatAsFixed) { // only for the first pass
+                    numMatchConstraints++;
+                    float weight = run.mWidget.mWeight[orientation];
+                    if (weight >= 0) {
+                        weights += weight;
+                    }
+                } else {
+                    size += dimension;
+                }
+                if (i < count - 1 && i < lastVisibleWidget) {
+                    size += -run.end.mMargin;
+                }
+            }
+            if (size < distance || numMatchConstraints == 0) {
+                break; // we are good to go!
+            }
+            // otherwise, let's do another pass with using match_constraints
+            numVisibleWidgets = 0;
+            numMatchConstraints = 0;
+            size = 0;
+            weights = 0;
+        }
+
+        int position = start.value;
+        if (isInRtl) {
+            position = end.value;
+        }
+        if (size > distance) {
+            if (isInRtl) {
+                position += (int) (0.5f + (size - distance) / 2f);
+            } else {
+                position -= (int) (0.5f + (size - distance) / 2f);
+            }
+        }
+        int matchConstraintsDimension = 0;
+        if (numMatchConstraints > 0) {
+            matchConstraintsDimension =
+                    (int) (0.5f + (distance - size) / (float) numMatchConstraints);
+
+            int appliedLimits = 0;
+            for (int i = 0; i < count; i++) {
+                WidgetRun run = mWidgets.get(i);
+                if (run.mWidget.getVisibility() == GONE) {
+                    continue;
+                }
+                if (run.mDimensionBehavior == MATCH_CONSTRAINT && !run.mDimension.resolved) {
+                    int dimension = matchConstraintsDimension;
+                    if (weights > 0) {
+                        float weight = run.mWidget.mWeight[orientation];
+                        dimension = (int) (0.5f + weight * (distance - size) / weights);
+                    }
+                    int max;
+                    int min;
+                    int value = dimension;
+                    if (orientation == HORIZONTAL) {
+                        max = run.mWidget.mMatchConstraintMaxWidth;
+                        min = run.mWidget.mMatchConstraintMinWidth;
+                    } else {
+                        max = run.mWidget.mMatchConstraintMaxHeight;
+                        min = run.mWidget.mMatchConstraintMinHeight;
+                    }
+                    if (run.matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+                        value = Math.min(value, run.mDimension.wrapValue);
+                    }
+                    value = Math.max(min, value);
+                    if (max > 0) {
+                        value = Math.min(max, value);
+                    }
+                    if (value != dimension) {
+                        appliedLimits++;
+                        dimension = value;
+                    }
+                    run.mDimension.resolve(dimension);
+                }
+            }
+            if (appliedLimits > 0) {
+                numMatchConstraints -= appliedLimits;
+                // we have to recompute the sizes
+                size = 0;
+                for (int i = 0; i < count; i++) {
+                    WidgetRun run = mWidgets.get(i);
+                    if (run.mWidget.getVisibility() == GONE) {
+                        continue;
+                    }
+                    if (i > 0 && i >= firstVisibleWidget) {
+                        size += run.start.mMargin;
+                    }
+                    size += run.mDimension.value;
+                    if (i < count - 1 && i < lastVisibleWidget) {
+                        size += -run.end.mMargin;
+                    }
+                }
+            }
+            if (mChainStyle == ConstraintWidget.CHAIN_PACKED && appliedLimits == 0) {
+                mChainStyle = ConstraintWidget.CHAIN_SPREAD;
+            }
+        }
+
+        if (size > distance) {
+            mChainStyle = ConstraintWidget.CHAIN_PACKED;
+        }
+
+        if (numVisibleWidgets > 0 && numMatchConstraints == 0
+                && firstVisibleWidget == lastVisibleWidget) {
+            // only one widget of fixed size to display...
+            mChainStyle = ConstraintWidget.CHAIN_PACKED;
+        }
+
+        if (mChainStyle == ConstraintWidget.CHAIN_SPREAD_INSIDE) {
+            int gap = 0;
+            if (numVisibleWidgets > 1) {
+                gap = (distance - size) / (numVisibleWidgets - 1);
+            } else if (numVisibleWidgets == 1) {
+                gap = (distance - size) / 2;
+            }
+            if (numMatchConstraints > 0) {
+                gap = 0;
+            }
+            for (int i = 0; i < count; i++) {
+                int index = i;
+                if (isInRtl) {
+                    index = count - (i + 1);
+                }
+                WidgetRun run = mWidgets.get(index);
+                if (run.mWidget.getVisibility() == GONE) {
+                    run.start.resolve(position);
+                    run.end.resolve(position);
+                    continue;
+                }
+                if (i > 0) {
+                    if (isInRtl) {
+                        position -= gap;
+                    } else {
+                        position += gap;
+                    }
+                }
+                if (i > 0 && i >= firstVisibleWidget) {
+                    if (isInRtl) {
+                        position -= run.start.mMargin;
+                    } else {
+                        position += run.start.mMargin;
+                    }
+                }
+
+                if (isInRtl) {
+                    run.end.resolve(position);
+                } else {
+                    run.start.resolve(position);
+                }
+
+                int dimension = run.mDimension.value;
+                if (run.mDimensionBehavior == MATCH_CONSTRAINT
+                        && run.matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+                    dimension = run.mDimension.wrapValue;
+                }
+                if (isInRtl) {
+                    position -= dimension;
+                } else {
+                    position += dimension;
+                }
+
+                if (isInRtl) {
+                    run.start.resolve(position);
+                } else {
+                    run.end.resolve(position);
+                }
+                run.mResolved = true;
+                if (i < count - 1 && i < lastVisibleWidget) {
+                    if (isInRtl) {
+                        position -= -run.end.mMargin;
+                    } else {
+                        position += -run.end.mMargin;
+                    }
+                }
+            }
+        } else if (mChainStyle == ConstraintWidget.CHAIN_SPREAD) {
+            int gap = (distance - size) / (numVisibleWidgets + 1);
+            if (numMatchConstraints > 0) {
+                gap = 0;
+            }
+            for (int i = 0; i < count; i++) {
+                int index = i;
+                if (isInRtl) {
+                    index = count - (i + 1);
+                }
+                WidgetRun run = mWidgets.get(index);
+                if (run.mWidget.getVisibility() == GONE) {
+                    run.start.resolve(position);
+                    run.end.resolve(position);
+                    continue;
+                }
+                if (isInRtl) {
+                    position -= gap;
+                } else {
+                    position += gap;
+                }
+                if (i > 0 && i >= firstVisibleWidget) {
+                    if (isInRtl) {
+                        position -= run.start.mMargin;
+                    } else {
+                        position += run.start.mMargin;
+                    }
+                }
+
+                if (isInRtl) {
+                    run.end.resolve(position);
+                } else {
+                    run.start.resolve(position);
+                }
+
+                int dimension = run.mDimension.value;
+                if (run.mDimensionBehavior == MATCH_CONSTRAINT
+                        && run.matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+                    dimension = Math.min(dimension, run.mDimension.wrapValue);
+                }
+
+                if (isInRtl) {
+                    position -= dimension;
+                } else {
+                    position += dimension;
+                }
+
+                if (isInRtl) {
+                    run.start.resolve(position);
+                } else {
+                    run.end.resolve(position);
+                }
+                if (i < count - 1 && i < lastVisibleWidget) {
+                    if (isInRtl) {
+                        position -= -run.end.mMargin;
+                    } else {
+                        position += -run.end.mMargin;
+                    }
+                }
+            }
+        } else if (mChainStyle == ConstraintWidget.CHAIN_PACKED) {
+            float bias = (orientation == HORIZONTAL) ? mWidget.getHorizontalBiasPercent()
+                    : mWidget.getVerticalBiasPercent();
+            if (isInRtl) {
+                bias = 1 - bias;
+            }
+            int gap = (int) (0.5f + (distance - size) * bias);
+            if (gap < 0 || numMatchConstraints > 0) {
+                gap = 0;
+            }
+            if (isInRtl) {
+                position -= gap;
+            } else {
+                position += gap;
+            }
+            for (int i = 0; i < count; i++) {
+                int index = i;
+                if (isInRtl) {
+                    index = count - (i + 1);
+                }
+                WidgetRun run = mWidgets.get(index);
+                if (run.mWidget.getVisibility() == GONE) {
+                    run.start.resolve(position);
+                    run.end.resolve(position);
+                    continue;
+                }
+                if (i > 0 && i >= firstVisibleWidget) {
+                    if (isInRtl) {
+                        position -= run.start.mMargin;
+                    } else {
+                        position += run.start.mMargin;
+                    }
+                }
+                if (isInRtl) {
+                    run.end.resolve(position);
+                } else {
+                    run.start.resolve(position);
+                }
+
+                int dimension = run.mDimension.value;
+                if (run.mDimensionBehavior == MATCH_CONSTRAINT
+                        && run.matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+                    dimension = run.mDimension.wrapValue;
+                }
+                if (isInRtl) {
+                    position -= dimension;
+                } else {
+                    position += dimension;
+                }
+
+                if (isInRtl) {
+                    run.start.resolve(position);
+                } else {
+                    run.end.resolve(position);
+                }
+                if (i < count - 1 && i < lastVisibleWidget) {
+                    if (isInRtl) {
+                        position -= -run.end.mMargin;
+                    } else {
+                        position += -run.end.mMargin;
+                    }
+                }
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public void applyToWidget() {
+        for (int i = 0; i < mWidgets.size(); i++) {
+            WidgetRun run = mWidgets.get(i);
+            run.applyToWidget();
+        }
+    }
+
+    private ConstraintWidget getFirstVisibleWidget() {
+        for (int i = 0; i < mWidgets.size(); i++) {
+            WidgetRun run = mWidgets.get(i);
+            if (run.mWidget.getVisibility() != GONE) {
+                return run.mWidget;
+            }
+        }
+        return null;
+    }
+
+    private ConstraintWidget getLastVisibleWidget() {
+        for (int i = mWidgets.size() - 1; i >= 0; i--) {
+            WidgetRun run = mWidgets.get(i);
+            if (run.mWidget.getVisibility() != GONE) {
+                return run.mWidget;
+            }
+        }
+        return null;
+    }
+
+
+    @Override
+    void apply() {
+        for (WidgetRun run : mWidgets) {
+            run.apply();
+        }
+        int count = mWidgets.size();
+        if (count < 1) {
+            return;
+        }
+
+        // get the first and last element of the chain
+        ConstraintWidget firstWidget = mWidgets.get(0).mWidget;
+        ConstraintWidget lastWidget = mWidgets.get(count - 1).mWidget;
+
+        if (orientation == HORIZONTAL) {
+            ConstraintAnchor startAnchor = firstWidget.mLeft;
+            ConstraintAnchor endAnchor = lastWidget.mRight;
+            DependencyNode startTarget = getTarget(startAnchor, HORIZONTAL);
+            int startMargin = startAnchor.getMargin();
+            ConstraintWidget firstVisibleWidget = getFirstVisibleWidget();
+            if (firstVisibleWidget != null) {
+                startMargin = firstVisibleWidget.mLeft.getMargin();
+            }
+            if (startTarget != null) {
+                addTarget(start, startTarget, startMargin);
+            }
+            DependencyNode endTarget = getTarget(endAnchor, HORIZONTAL);
+            int endMargin = endAnchor.getMargin();
+            ConstraintWidget lastVisibleWidget = getLastVisibleWidget();
+            if (lastVisibleWidget != null) {
+                endMargin = lastVisibleWidget.mRight.getMargin();
+            }
+            if (endTarget != null) {
+                addTarget(end, endTarget, -endMargin);
+            }
+        } else {
+            ConstraintAnchor startAnchor = firstWidget.mTop;
+            ConstraintAnchor endAnchor = lastWidget.mBottom;
+            DependencyNode startTarget = getTarget(startAnchor, VERTICAL);
+            int startMargin = startAnchor.getMargin();
+            ConstraintWidget firstVisibleWidget = getFirstVisibleWidget();
+            if (firstVisibleWidget != null) {
+                startMargin = firstVisibleWidget.mTop.getMargin();
+            }
+            if (startTarget != null) {
+                addTarget(start, startTarget, startMargin);
+            }
+            DependencyNode endTarget = getTarget(endAnchor, VERTICAL);
+            int endMargin = endAnchor.getMargin();
+            ConstraintWidget lastVisibleWidget = getLastVisibleWidget();
+            if (lastVisibleWidget != null) {
+                endMargin = lastVisibleWidget.mBottom.getMargin();
+            }
+            if (endTarget != null) {
+                addTarget(end, endTarget, -endMargin);
+            }
+        }
+        start.updateDelegate = this;
+        end.updateDelegate = this;
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Dependency.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Dependency.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+public interface Dependency {
+    // @TODO: add description
+    void update(Dependency node);
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DependencyGraph.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DependencyGraph.java
@@ -1,0 +1,1060 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.FIXED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_PARENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.GONE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_RATIO;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.Guideline;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+public class DependencyGraph {
+    private static final boolean USE_GROUPS = true;
+    private ConstraintWidgetContainer mWidgetcontainer;
+    private boolean mNeedBuildGraph = true;
+    private boolean mNeedRedoMeasures = true;
+    private ConstraintWidgetContainer mContainer;
+    private ArrayList<WidgetRun> mRuns = new ArrayList<>();
+    private static final boolean DEBUG = false;
+
+    // TODO: Unused, should we delete?
+    @SuppressWarnings("unused") private ArrayList<RunGroup> mRunGroups = new ArrayList<>();
+
+    public DependencyGraph(ConstraintWidgetContainer container) {
+        this.mWidgetcontainer = container;
+        mContainer = container;
+    }
+
+    private BasicMeasure.Measurer mMeasurer = null;
+    private BasicMeasure.Measure mMeasure = new BasicMeasure.Measure();
+
+    public void setMeasurer(BasicMeasure.Measurer measurer) {
+        mMeasurer = measurer;
+    }
+
+    private int computeWrap(ConstraintWidgetContainer container, int orientation) {
+        final int count = mGroups.size();
+        long wrapSize = 0;
+        for (int i = 0; i < count; i++) {
+            RunGroup run = mGroups.get(i);
+            long size = run.computeWrapSize(container, orientation);
+            wrapSize = Math.max(wrapSize, size);
+        }
+        return (int) wrapSize;
+    }
+
+    /**
+     * Find and mark terminal widgets (trailing widgets) -- they are the only
+     * ones we need to care for wrap_content checks
+     */
+    public void defineTerminalWidgets(ConstraintWidget.DimensionBehaviour horizontalBehavior,
+            ConstraintWidget.DimensionBehaviour verticalBehavior) {
+        if (mNeedBuildGraph) {
+            buildGraph();
+
+            if (USE_GROUPS) {
+                boolean hasBarrier = false;
+                for (ConstraintWidget widget : mWidgetcontainer.mChildren) {
+                    widget.isTerminalWidget[HORIZONTAL] = true;
+                    widget.isTerminalWidget[VERTICAL] = true;
+                    if (widget instanceof Barrier) {
+                        hasBarrier = true;
+                    }
+                }
+                if (!hasBarrier) {
+                    for (RunGroup group : mGroups) {
+                        group.defineTerminalWidgets(horizontalBehavior == WRAP_CONTENT,
+                                verticalBehavior == WRAP_CONTENT);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Try to measure the layout by solving the graph of constraints directly
+     *
+     * @param optimizeWrap use the wrap_content optimizer
+     * @return true if all widgets have been resolved
+     */
+    public boolean directMeasure(boolean optimizeWrap) {
+        optimizeWrap &= USE_GROUPS;
+
+        if (mNeedBuildGraph || mNeedRedoMeasures) {
+            for (ConstraintWidget widget : mWidgetcontainer.mChildren) {
+                widget.ensureWidgetRuns();
+                widget.measured = false;
+                widget.mHorizontalRun.reset();
+                widget.mVerticalRun.reset();
+            }
+            mWidgetcontainer.ensureWidgetRuns();
+            mWidgetcontainer.measured = false;
+            mWidgetcontainer.mHorizontalRun.reset();
+            mWidgetcontainer.mVerticalRun.reset();
+            mNeedRedoMeasures = false;
+        }
+
+        boolean avoid = basicMeasureWidgets(mContainer);
+        if (avoid) {
+            return false;
+        }
+
+        mWidgetcontainer.setX(0);
+        mWidgetcontainer.setY(0);
+
+        ConstraintWidget.DimensionBehaviour originalHorizontalDimension =
+                mWidgetcontainer.getDimensionBehaviour(HORIZONTAL);
+        ConstraintWidget.DimensionBehaviour originalVerticalDimension =
+                mWidgetcontainer.getDimensionBehaviour(VERTICAL);
+
+        if (mNeedBuildGraph) {
+            buildGraph();
+        }
+
+        int x1 = mWidgetcontainer.getX();
+        int y1 = mWidgetcontainer.getY();
+
+        mWidgetcontainer.mHorizontalRun.start.resolve(x1);
+        mWidgetcontainer.mVerticalRun.start.resolve(y1);
+
+        // Let's do the easy steps first -- anything that can be immediately measured
+        // Whatever is left for the dimension will be match_constraints.
+        measureWidgets();
+
+        // If we have to support wrap, let's see if we can compute it directly
+        if (originalHorizontalDimension == WRAP_CONTENT
+                || originalVerticalDimension == WRAP_CONTENT) {
+            if (optimizeWrap) {
+                for (WidgetRun run : mRuns) {
+                    if (!run.supportsWrapComputation()) {
+                        optimizeWrap = false;
+                        break;
+                    }
+                }
+            }
+
+            if (optimizeWrap && originalHorizontalDimension == WRAP_CONTENT) {
+                mWidgetcontainer.setHorizontalDimensionBehaviour(FIXED);
+                mWidgetcontainer.setWidth(computeWrap(mWidgetcontainer, HORIZONTAL));
+                mWidgetcontainer.mHorizontalRun.mDimension.resolve(mWidgetcontainer.getWidth());
+            }
+            if (optimizeWrap && originalVerticalDimension == WRAP_CONTENT) {
+                mWidgetcontainer.setVerticalDimensionBehaviour(FIXED);
+                mWidgetcontainer.setHeight(computeWrap(mWidgetcontainer, VERTICAL));
+                mWidgetcontainer.mVerticalRun.mDimension.resolve(mWidgetcontainer.getHeight());
+            }
+        }
+
+        boolean checkRoot = false;
+
+        // Now, depending on our own dimension behavior, we may want to solve
+        // one dimension before the other
+
+        if (mWidgetcontainer.mListDimensionBehaviors[HORIZONTAL]
+                == ConstraintWidget.DimensionBehaviour.FIXED
+                || mWidgetcontainer.mListDimensionBehaviors[HORIZONTAL]
+                == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
+
+            // solve horizontal dimension
+            int x2 = x1 + mWidgetcontainer.getWidth();
+            mWidgetcontainer.mHorizontalRun.end.resolve(x2);
+            mWidgetcontainer.mHorizontalRun.mDimension.resolve(x2 - x1);
+            measureWidgets();
+            if (mWidgetcontainer.mListDimensionBehaviors[VERTICAL] == FIXED
+                    || mWidgetcontainer.mListDimensionBehaviors[VERTICAL] == MATCH_PARENT) {
+                int y2 = y1 + mWidgetcontainer.getHeight();
+                mWidgetcontainer.mVerticalRun.end.resolve(y2);
+                mWidgetcontainer.mVerticalRun.mDimension.resolve(y2 - y1);
+            }
+            measureWidgets();
+            checkRoot = true;
+        } else {
+            // we'll bail out to the solver...
+        }
+
+        // Let's apply what we did resolve
+        for (WidgetRun run : mRuns) {
+            if (run.mWidget == mWidgetcontainer && !run.mResolved) {
+                continue;
+            }
+            run.applyToWidget();
+        }
+
+        boolean allResolved = true;
+        for (WidgetRun run : mRuns) {
+            if (!checkRoot && run.mWidget == mWidgetcontainer) {
+                continue;
+            }
+            if (!run.start.resolved) {
+                allResolved = false;
+                break;
+            }
+            if (!run.end.resolved && !(run instanceof GuidelineReference)) {
+                allResolved = false;
+                break;
+            }
+            if (!run.mDimension.resolved
+                    && !(run instanceof ChainRun) && !(run instanceof GuidelineReference)) {
+                allResolved = false;
+                break;
+            }
+        }
+
+        mWidgetcontainer.setHorizontalDimensionBehaviour(originalHorizontalDimension);
+        mWidgetcontainer.setVerticalDimensionBehaviour(originalVerticalDimension);
+
+        return allResolved;
+    }
+
+    // @TODO: add description
+    public boolean directMeasureSetup(boolean optimizeWrap) {
+        if (mNeedBuildGraph) {
+            for (ConstraintWidget widget : mWidgetcontainer.mChildren) {
+                widget.ensureWidgetRuns();
+                widget.measured = false;
+                widget.mHorizontalRun.mDimension.resolved = false;
+                widget.mHorizontalRun.mResolved = false;
+                widget.mHorizontalRun.reset();
+                widget.mVerticalRun.mDimension.resolved = false;
+                widget.mVerticalRun.mResolved = false;
+                widget.mVerticalRun.reset();
+            }
+            mWidgetcontainer.ensureWidgetRuns();
+            mWidgetcontainer.measured = false;
+            mWidgetcontainer.mHorizontalRun.mDimension.resolved = false;
+            mWidgetcontainer.mHorizontalRun.mResolved = false;
+            mWidgetcontainer.mHorizontalRun.reset();
+            mWidgetcontainer.mVerticalRun.mDimension.resolved = false;
+            mWidgetcontainer.mVerticalRun.mResolved = false;
+            mWidgetcontainer.mVerticalRun.reset();
+            buildGraph();
+        }
+
+        boolean avoid = basicMeasureWidgets(mContainer);
+        if (avoid) {
+            return false;
+        }
+
+        mWidgetcontainer.setX(0);
+        mWidgetcontainer.setY(0);
+        mWidgetcontainer.mHorizontalRun.start.resolve(0);
+        mWidgetcontainer.mVerticalRun.start.resolve(0);
+        return true;
+    }
+
+    // @TODO: add description
+    public boolean directMeasureWithOrientation(boolean optimizeWrap, int orientation) {
+        optimizeWrap &= USE_GROUPS;
+
+        ConstraintWidget.DimensionBehaviour originalHorizontalDimension =
+                mWidgetcontainer.getDimensionBehaviour(HORIZONTAL);
+        ConstraintWidget.DimensionBehaviour originalVerticalDimension =
+                mWidgetcontainer.getDimensionBehaviour(VERTICAL);
+
+        int x1 = mWidgetcontainer.getX();
+        int y1 = mWidgetcontainer.getY();
+
+        // If we have to support wrap, let's see if we can compute it directly
+        if (optimizeWrap && (originalHorizontalDimension == WRAP_CONTENT
+                || originalVerticalDimension == WRAP_CONTENT)) {
+            for (WidgetRun run : mRuns) {
+                if (run.orientation == orientation
+                        && !run.supportsWrapComputation()) {
+                    optimizeWrap = false;
+                    break;
+                }
+            }
+
+            if (orientation == HORIZONTAL) {
+                if (optimizeWrap && originalHorizontalDimension == WRAP_CONTENT) {
+                    mWidgetcontainer.setHorizontalDimensionBehaviour(FIXED);
+                    mWidgetcontainer.setWidth(computeWrap(mWidgetcontainer, HORIZONTAL));
+                    mWidgetcontainer.mHorizontalRun.mDimension.resolve(mWidgetcontainer.getWidth());
+                }
+            } else {
+                if (optimizeWrap && originalVerticalDimension == WRAP_CONTENT) {
+                    mWidgetcontainer.setVerticalDimensionBehaviour(FIXED);
+                    mWidgetcontainer.setHeight(computeWrap(mWidgetcontainer, VERTICAL));
+                    mWidgetcontainer.mVerticalRun.mDimension.resolve(mWidgetcontainer.getHeight());
+                }
+            }
+        }
+
+        boolean checkRoot = false;
+
+        // Now, depending on our own dimension behavior, we may want to solve
+        // one dimension before the other
+
+        if (orientation == HORIZONTAL) {
+            if (mWidgetcontainer.mListDimensionBehaviors[HORIZONTAL] == FIXED
+                    || mWidgetcontainer.mListDimensionBehaviors[HORIZONTAL] == MATCH_PARENT) {
+                int x2 = x1 + mWidgetcontainer.getWidth();
+                mWidgetcontainer.mHorizontalRun.end.resolve(x2);
+                mWidgetcontainer.mHorizontalRun.mDimension.resolve(x2 - x1);
+                checkRoot = true;
+            }
+        } else {
+            if (mWidgetcontainer.mListDimensionBehaviors[VERTICAL] == FIXED
+                    || mWidgetcontainer.mListDimensionBehaviors[VERTICAL] == MATCH_PARENT) {
+                int y2 = y1 + mWidgetcontainer.getHeight();
+                mWidgetcontainer.mVerticalRun.end.resolve(y2);
+                mWidgetcontainer.mVerticalRun.mDimension.resolve(y2 - y1);
+                checkRoot = true;
+            }
+        }
+        measureWidgets();
+
+        // Let's apply what we did resolve
+        for (WidgetRun run : mRuns) {
+            if (run.orientation != orientation) {
+                continue;
+            }
+            if (run.mWidget == mWidgetcontainer && !run.mResolved) {
+                continue;
+            }
+            run.applyToWidget();
+        }
+
+        boolean allResolved = true;
+        for (WidgetRun run : mRuns) {
+            if (run.orientation != orientation) {
+                continue;
+            }
+            if (!checkRoot && run.mWidget == mWidgetcontainer) {
+                continue;
+            }
+            if (!run.start.resolved) {
+                allResolved = false;
+                break;
+            }
+            if (!run.end.resolved) {
+                allResolved = false;
+                break;
+            }
+            if (!(run instanceof ChainRun) && !run.mDimension.resolved) {
+                allResolved = false;
+                break;
+            }
+        }
+
+        mWidgetcontainer.setHorizontalDimensionBehaviour(originalHorizontalDimension);
+        mWidgetcontainer.setVerticalDimensionBehaviour(originalVerticalDimension);
+
+        return allResolved;
+    }
+
+    /**
+     * Convenience function to fill in the measure spec
+     *
+     * @param widget the widget to measure
+     */
+    private void measure(ConstraintWidget widget,
+            ConstraintWidget.DimensionBehaviour horizontalBehavior,
+            int horizontalDimension,
+            ConstraintWidget.DimensionBehaviour verticalBehavior,
+            int verticalDimension) {
+        mMeasure.horizontalBehavior = horizontalBehavior;
+        mMeasure.verticalBehavior = verticalBehavior;
+        mMeasure.horizontalDimension = horizontalDimension;
+        mMeasure.verticalDimension = verticalDimension;
+        mMeasurer.measure(widget, mMeasure);
+        widget.setWidth(mMeasure.measuredWidth);
+        widget.setHeight(mMeasure.measuredHeight);
+        widget.setHasBaseline(mMeasure.measuredHasBaseline);
+        widget.setBaselineDistance(mMeasure.measuredBaseline);
+    }
+
+    private boolean basicMeasureWidgets(ConstraintWidgetContainer constraintWidgetContainer) {
+        for (ConstraintWidget widget : constraintWidgetContainer.mChildren) {
+            ConstraintWidget.DimensionBehaviour horizontal =
+                    widget.mListDimensionBehaviors[HORIZONTAL];
+            ConstraintWidget.DimensionBehaviour vertical = widget.mListDimensionBehaviors[VERTICAL];
+
+            if (widget.getVisibility() == GONE) {
+                widget.measured = true;
+                continue;
+            }
+
+            // Basic validation
+            // TODO: might move this earlier in the process
+            if (widget.mMatchConstraintPercentWidth < 1 && horizontal == MATCH_CONSTRAINT) {
+                widget.mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_PERCENT;
+            }
+            if (widget.mMatchConstraintPercentHeight < 1 && vertical == MATCH_CONSTRAINT) {
+                widget.mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_PERCENT;
+            }
+            if (widget.getDimensionRatio() > 0) {
+                if (horizontal == MATCH_CONSTRAINT
+                        && (vertical == WRAP_CONTENT || vertical == FIXED)) {
+                    widget.mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_RATIO;
+                } else if (vertical == MATCH_CONSTRAINT
+                        && (horizontal == WRAP_CONTENT || horizontal == FIXED)) {
+                    widget.mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_RATIO;
+                } else if (horizontal == MATCH_CONSTRAINT && vertical == MATCH_CONSTRAINT) {
+                    if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                        widget.mMatchConstraintDefaultWidth = MATCH_CONSTRAINT_RATIO;
+                    }
+                    if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                        widget.mMatchConstraintDefaultHeight = MATCH_CONSTRAINT_RATIO;
+                    }
+                }
+            }
+
+            if (horizontal == MATCH_CONSTRAINT
+                    && widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP) {
+                if (widget.mLeft.mTarget == null || widget.mRight.mTarget == null) {
+                    horizontal = WRAP_CONTENT;
+                }
+            }
+            if (vertical == MATCH_CONSTRAINT
+                    && widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP) {
+                if (widget.mTop.mTarget == null || widget.mBottom.mTarget == null) {
+                    vertical = WRAP_CONTENT;
+                }
+            }
+
+            widget.mHorizontalRun.mDimensionBehavior = horizontal;
+            widget.mHorizontalRun.matchConstraintsType = widget.mMatchConstraintDefaultWidth;
+            widget.mVerticalRun.mDimensionBehavior = vertical;
+            widget.mVerticalRun.matchConstraintsType = widget.mMatchConstraintDefaultHeight;
+
+            if ((horizontal == MATCH_PARENT || horizontal == FIXED || horizontal == WRAP_CONTENT)
+                    && (vertical == MATCH_PARENT
+                    || vertical == FIXED || vertical == WRAP_CONTENT)) {
+                int width = widget.getWidth();
+                if (horizontal == MATCH_PARENT) {
+                    width = constraintWidgetContainer.getWidth()
+                            - widget.mLeft.mMargin - widget.mRight.mMargin;
+                    horizontal = FIXED;
+                }
+                int height = widget.getHeight();
+                if (vertical == MATCH_PARENT) {
+                    height = constraintWidgetContainer.getHeight()
+                            - widget.mTop.mMargin - widget.mBottom.mMargin;
+                    vertical = FIXED;
+                }
+                measure(widget, horizontal, width, vertical, height);
+                widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                widget.measured = true;
+                continue;
+            }
+
+            if (horizontal == MATCH_CONSTRAINT && (vertical == WRAP_CONTENT || vertical == FIXED)) {
+                if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_RATIO) {
+                    if (vertical == WRAP_CONTENT) {
+                        measure(widget, WRAP_CONTENT, 0, WRAP_CONTENT, 0);
+                    }
+                    int height = widget.getHeight();
+                    int width = (int) (height * widget.mDimensionRatio + 0.5f);
+                    measure(widget, FIXED, width, FIXED, height);
+                    widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                    widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                    widget.measured = true;
+                    continue;
+                } else if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP) {
+                    measure(widget, WRAP_CONTENT, 0, vertical, 0);
+                    widget.mHorizontalRun.mDimension.wrapValue = widget.getWidth();
+                    continue;
+                } else if (widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT) {
+                    if (constraintWidgetContainer.mListDimensionBehaviors[HORIZONTAL] == FIXED
+                            || constraintWidgetContainer.mListDimensionBehaviors[HORIZONTAL]
+                            == MATCH_PARENT) {
+                        float percent = widget.mMatchConstraintPercentWidth;
+                        int width = (int) (0.5f + percent * constraintWidgetContainer.getWidth());
+                        int height = widget.getHeight();
+                        measure(widget, FIXED, width, vertical, height);
+                        widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                        widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                        widget.measured = true;
+                        continue;
+                    }
+                } else {
+                    // let's verify we have both constraints
+                    if (widget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].mTarget == null
+                            || widget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].mTarget == null) {
+                        measure(widget, WRAP_CONTENT, 0, vertical, 0);
+                        widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                        widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                        widget.measured = true;
+                        continue;
+                    }
+                }
+            }
+            if (vertical == MATCH_CONSTRAINT
+                    && (horizontal == WRAP_CONTENT || horizontal == FIXED)) {
+                if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_RATIO) {
+                    if (horizontal == WRAP_CONTENT) {
+                        measure(widget, WRAP_CONTENT, 0, WRAP_CONTENT, 0);
+                    }
+                    int width = widget.getWidth();
+                    float ratio = widget.mDimensionRatio;
+                    if (widget.getDimensionRatioSide() == UNKNOWN) {
+                        ratio = 1f / ratio;
+                    }
+                    int height = (int) (width * ratio + 0.5f);
+
+                    measure(widget, FIXED, width, FIXED, height);
+                    widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                    widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                    widget.measured = true;
+                    continue;
+                } else if (widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP) {
+                    measure(widget, horizontal, 0, WRAP_CONTENT, 0);
+                    widget.mVerticalRun.mDimension.wrapValue = widget.getHeight();
+                    continue;
+                } else if (widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT) {
+                    if (constraintWidgetContainer.mListDimensionBehaviors[VERTICAL] == FIXED
+                            || constraintWidgetContainer.mListDimensionBehaviors[VERTICAL]
+                            == MATCH_PARENT) {
+                        float percent = widget.mMatchConstraintPercentHeight;
+                        int width = widget.getWidth();
+                        int height = (int) (0.5f + percent * constraintWidgetContainer.getHeight());
+                        measure(widget, horizontal, width, FIXED, height);
+                        widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                        widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                        widget.measured = true;
+                        continue;
+                    }
+                } else {
+                    // let's verify we have both constraints
+                    if (widget.mListAnchors[ConstraintWidget.ANCHOR_TOP].mTarget == null
+                            || widget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].mTarget
+                            == null) {
+                        measure(widget, WRAP_CONTENT, 0, vertical, 0);
+                        widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                        widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                        widget.measured = true;
+                        continue;
+                    }
+                }
+            }
+            if (horizontal == MATCH_CONSTRAINT && vertical == MATCH_CONSTRAINT) {
+                if (widget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP
+                        || widget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP) {
+                    measure(widget, WRAP_CONTENT, 0, WRAP_CONTENT, 0);
+                    widget.mHorizontalRun.mDimension.wrapValue = widget.getWidth();
+                    widget.mVerticalRun.mDimension.wrapValue = widget.getHeight();
+                } else if (widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT
+                        && widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT
+                        && constraintWidgetContainer.mListDimensionBehaviors[HORIZONTAL] == FIXED
+                        && constraintWidgetContainer.mListDimensionBehaviors[VERTICAL] == FIXED) {
+                    float horizPercent = widget.mMatchConstraintPercentWidth;
+                    float vertPercent = widget.mMatchConstraintPercentHeight;
+                    int width = (int) (0.5f + horizPercent * constraintWidgetContainer.getWidth());
+                    int height = (int) (0.5f + vertPercent * constraintWidgetContainer.getHeight());
+                    measure(widget, FIXED, width, FIXED, height);
+                    widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                    widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                    widget.measured = true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    public void measureWidgets() {
+        for (ConstraintWidget widget : mWidgetcontainer.mChildren) {
+            if (widget.measured) {
+                continue;
+            }
+            ConstraintWidget.DimensionBehaviour horiz = widget.mListDimensionBehaviors[HORIZONTAL];
+            ConstraintWidget.DimensionBehaviour vert = widget.mListDimensionBehaviors[VERTICAL];
+            int horizMatchConstraintsType = widget.mMatchConstraintDefaultWidth;
+            int vertMatchConstraintsType = widget.mMatchConstraintDefaultHeight;
+
+            boolean horizWrap = horiz == WRAP_CONTENT
+                    || (horiz == MATCH_CONSTRAINT
+                    && horizMatchConstraintsType == MATCH_CONSTRAINT_WRAP);
+
+            boolean vertWrap = vert == WRAP_CONTENT
+                    || (vert == MATCH_CONSTRAINT
+                    && vertMatchConstraintsType == MATCH_CONSTRAINT_WRAP);
+
+            boolean horizResolved = widget.mHorizontalRun.mDimension.resolved;
+            boolean vertResolved = widget.mVerticalRun.mDimension.resolved;
+
+            if (horizResolved && vertResolved) {
+                measure(widget, FIXED, widget.mHorizontalRun.mDimension.value,
+                        FIXED, widget.mVerticalRun.mDimension.value);
+                widget.measured = true;
+            } else if (horizResolved && vertWrap) {
+                measure(widget, FIXED, widget.mHorizontalRun.mDimension.value,
+                        WRAP_CONTENT, widget.mVerticalRun.mDimension.value);
+                if (vert == MATCH_CONSTRAINT) {
+                    widget.mVerticalRun.mDimension.wrapValue = widget.getHeight();
+                } else {
+                    widget.mVerticalRun.mDimension.resolve(widget.getHeight());
+                    widget.measured = true;
+                }
+            } else if (vertResolved && horizWrap) {
+                measure(widget, WRAP_CONTENT, widget.mHorizontalRun.mDimension.value,
+                        FIXED, widget.mVerticalRun.mDimension.value);
+                if (horiz == MATCH_CONSTRAINT) {
+                    widget.mHorizontalRun.mDimension.wrapValue = widget.getWidth();
+                } else {
+                    widget.mHorizontalRun.mDimension.resolve(widget.getWidth());
+                    widget.measured = true;
+                }
+            }
+            if (widget.measured && widget.mVerticalRun.mBaselineDimension != null) {
+                widget.mVerticalRun.mBaselineDimension.resolve(widget.getBaselineDistance());
+            }
+        }
+    }
+
+    /**
+     * Invalidate the graph of constraints
+     */
+    public void invalidateGraph() {
+        mNeedBuildGraph = true;
+    }
+
+    /**
+     * Mark the widgets as needing to be remeasured
+     */
+    public void invalidateMeasures() {
+        mNeedRedoMeasures = true;
+    }
+
+    ArrayList<RunGroup> mGroups = new ArrayList<>();
+
+    // @TODO: add description
+    public void buildGraph() {
+        // First, let's identify the overall dependency graph
+        buildGraph(mRuns);
+
+        if (USE_GROUPS) {
+            mGroups.clear();
+            // Then get the horizontal and vertical groups
+            RunGroup.index = 0;
+            findGroup(mWidgetcontainer.mHorizontalRun, HORIZONTAL, mGroups);
+            findGroup(mWidgetcontainer.mVerticalRun, VERTICAL, mGroups);
+        }
+        mNeedBuildGraph = false;
+    }
+
+    // @TODO: add description
+    public void buildGraph(ArrayList<WidgetRun> runs) {
+        runs.clear();
+        mContainer.mHorizontalRun.clear();
+        mContainer.mVerticalRun.clear();
+        runs.add(mContainer.mHorizontalRun);
+        runs.add(mContainer.mVerticalRun);
+        HashSet<ChainRun> chainRuns = null;
+        for (ConstraintWidget widget : mContainer.mChildren) {
+            if (widget instanceof Guideline) {
+                runs.add(new GuidelineReference(widget));
+                continue;
+            }
+            if (widget.isInHorizontalChain()) {
+                if (widget.horizontalChainRun == null) {
+                    // build the horizontal chain
+                    widget.horizontalChainRun = new ChainRun(widget, HORIZONTAL);
+                }
+                if (chainRuns == null) {
+                    chainRuns = new HashSet<>();
+                }
+                chainRuns.add(widget.horizontalChainRun);
+            } else {
+                runs.add(widget.mHorizontalRun);
+            }
+            if (widget.isInVerticalChain()) {
+                if (widget.verticalChainRun == null) {
+                    // build the vertical chain
+                    widget.verticalChainRun = new ChainRun(widget, VERTICAL);
+                }
+                if (chainRuns == null) {
+                    chainRuns = new HashSet<>();
+                }
+                chainRuns.add(widget.verticalChainRun);
+            } else {
+                runs.add(widget.mVerticalRun);
+            }
+            if (widget instanceof HelperWidget) {
+                runs.add(new HelperReferences(widget));
+            }
+        }
+        if (chainRuns != null) {
+            runs.addAll(chainRuns);
+        }
+        for (WidgetRun run : runs) {
+            run.clear();
+        }
+        for (WidgetRun run : runs) {
+            if (run.mWidget == mContainer) {
+                continue;
+            }
+            run.apply();
+        }
+        if (DEBUG) {
+            displayGraph();
+        }
+    }
+
+
+    private void displayGraph() {
+        String content = "digraph {\n";
+        for (WidgetRun run : mRuns) {
+            content = generateDisplayGraph(run, content);
+        }
+        content += "\n}\n";
+        System.out.println("content:<<\n" + content + "\n>>");
+    }
+
+    private void applyGroup(DependencyNode node,
+            int orientation,
+            int direction,
+            DependencyNode end,
+            ArrayList<RunGroup> groups,
+            RunGroup group) {
+        WidgetRun run = node.mRun;
+        if (run.mRunGroup != null
+                || run == mWidgetcontainer.mHorizontalRun || run == mWidgetcontainer.mVerticalRun) {
+            return;
+        }
+
+        if (group == null) {
+            group = new RunGroup(run, direction);
+            groups.add(group);
+        }
+
+        run.mRunGroup = group;
+        group.add(run);
+        for (Dependency dependent : run.start.mDependencies) {
+            if (dependent instanceof DependencyNode) {
+                applyGroup((DependencyNode) dependent,
+                        orientation, RunGroup.START, end, groups, group);
+            }
+        }
+        for (Dependency dependent : run.end.mDependencies) {
+            if (dependent instanceof DependencyNode) {
+                applyGroup((DependencyNode) dependent,
+                        orientation, RunGroup.END, end, groups, group);
+            }
+        }
+        if (orientation == VERTICAL && run instanceof VerticalWidgetRun) {
+            for (Dependency dependent : ((VerticalWidgetRun) run).baseline.mDependencies) {
+                if (dependent instanceof DependencyNode) {
+                    applyGroup((DependencyNode) dependent,
+                            orientation, RunGroup.BASELINE, end, groups, group);
+                }
+            }
+        }
+        for (DependencyNode target : run.start.mTargets) {
+            if (target == end) {
+                group.dual = true;
+            }
+            applyGroup(target, orientation, RunGroup.START, end, groups, group);
+        }
+        for (DependencyNode target : run.end.mTargets) {
+            if (target == end) {
+                group.dual = true;
+            }
+            applyGroup(target, orientation, RunGroup.END, end, groups, group);
+        }
+        if (orientation == VERTICAL && run instanceof VerticalWidgetRun) {
+            for (DependencyNode target : ((VerticalWidgetRun) run).baseline.mTargets) {
+                applyGroup(target, orientation, RunGroup.BASELINE, end, groups, group);
+            }
+        }
+    }
+
+    private void findGroup(WidgetRun run, int orientation, ArrayList<RunGroup> groups) {
+        for (Dependency dependent : run.start.mDependencies) {
+            if (dependent instanceof DependencyNode) {
+                DependencyNode node = (DependencyNode) dependent;
+                applyGroup(node, orientation, RunGroup.START, run.end, groups, null);
+            } else if (dependent instanceof WidgetRun) {
+                WidgetRun dependentRun = (WidgetRun) dependent;
+                applyGroup(dependentRun.start, orientation, RunGroup.START, run.end, groups, null);
+            }
+        }
+        for (Dependency dependent : run.end.mDependencies) {
+            if (dependent instanceof DependencyNode) {
+                DependencyNode node = (DependencyNode) dependent;
+                applyGroup(node, orientation, RunGroup.END, run.start, groups, null);
+            } else if (dependent instanceof WidgetRun) {
+                WidgetRun dependentRun = (WidgetRun) dependent;
+                applyGroup(dependentRun.end, orientation, RunGroup.END, run.start, groups, null);
+            }
+        }
+        if (orientation == VERTICAL) {
+            for (Dependency dependent : ((VerticalWidgetRun) run).baseline.mDependencies) {
+                if (dependent instanceof DependencyNode) {
+                    DependencyNode node = (DependencyNode) dependent;
+                    applyGroup(node, orientation, RunGroup.BASELINE, null, groups, null);
+                }
+            }
+        }
+    }
+
+
+    private String generateDisplayNode(DependencyNode node,
+            boolean centeredConnection,
+            String content) {
+        StringBuilder contentBuilder = new StringBuilder(content);
+        for (DependencyNode target : node.mTargets) {
+            String constraint = "\n" + node.name();
+            constraint += " -> " + target.name();
+            if (node.mMargin > 0 || centeredConnection || node.mRun instanceof HelperReferences) {
+                constraint += "[";
+                if (node.mMargin > 0) {
+                    constraint += "label=\"" + node.mMargin + "\"";
+                    if (centeredConnection) {
+                        constraint += ",";
+                    }
+                }
+                if (centeredConnection) {
+                    constraint += " style=dashed ";
+                }
+                if (node.mRun instanceof HelperReferences) {
+                    constraint += " style=bold,color=gray ";
+                }
+                constraint += "]";
+            }
+            constraint += "\n";
+            contentBuilder.append(constraint);
+        }
+        content = contentBuilder.toString();
+//        for (DependencyNode dependency : node.dependencies) {
+//            content = generateDisplayNode(dependency, content);
+//        }
+        return content;
+    }
+
+    private String nodeDefinition(WidgetRun run) {
+        int orientation = run instanceof VerticalWidgetRun ? VERTICAL : HORIZONTAL;
+        String name = run.mWidget.getDebugName();
+        StringBuilder definition = new StringBuilder(name);
+        ConstraintWidget.DimensionBehaviour behaviour =
+                orientation == HORIZONTAL ? run.mWidget.getHorizontalDimensionBehaviour()
+                        : run.mWidget.getVerticalDimensionBehaviour();
+        RunGroup runGroup = run.mRunGroup;
+
+        if (orientation == HORIZONTAL) {
+            definition.append("_HORIZONTAL");
+        } else {
+            definition.append("_VERTICAL");
+        }
+        definition.append(" [shape=none, label=<");
+        definition.append("<TABLE BORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"2\">");
+        definition.append("  <TR>");
+        if (orientation == HORIZONTAL) {
+            definition.append("    <TD ");
+            if (run.start.resolved) {
+                definition.append(" BGCOLOR=\"green\"");
+            }
+            definition.append(" PORT=\"LEFT\" BORDER=\"1\">L</TD>");
+        } else {
+            definition.append("    <TD ");
+            if (run.start.resolved) {
+                definition.append(" BGCOLOR=\"green\"");
+            }
+            definition.append(" PORT=\"TOP\" BORDER=\"1\">T</TD>");
+        }
+        definition.append("    <TD BORDER=\"1\" ");
+        if (run.mDimension.resolved && !run.mWidget.measured) {
+            definition.append(" BGCOLOR=\"green\" ");
+        } else if (run.mDimension.resolved) {
+            definition.append(" BGCOLOR=\"lightgray\" ");
+        } else if (run.mWidget.measured) {
+            definition.append(" BGCOLOR=\"yellow\" ");
+        }
+        if (behaviour == MATCH_CONSTRAINT) {
+            definition.append("style=\"dashed\"");
+        }
+        definition.append(">");
+        definition.append(name);
+        if (runGroup != null) {
+            definition.append(" [");
+            definition.append(runGroup.mGroupIndex + 1);
+            definition.append("/");
+            definition.append(RunGroup.index);
+            definition.append("]");
+        }
+        definition.append(" </TD>");
+        if (orientation == HORIZONTAL) {
+            definition.append("    <TD ");
+            if (run.end.resolved) {
+                definition.append(" BGCOLOR=\"green\"");
+            }
+            definition.append(" PORT=\"RIGHT\" BORDER=\"1\">R</TD>");
+        } else {
+            definition.append("    <TD ");
+            if (((VerticalWidgetRun) run).baseline.resolved) {
+                definition.append(" BGCOLOR=\"green\"");
+            }
+            definition.append(" PORT=\"BASELINE\" BORDER=\"1\">b</TD>");
+            definition.append("    <TD ");
+            if (run.end.resolved) {
+                definition.append(" BGCOLOR=\"green\"");
+            }
+            definition.append(" PORT=\"BOTTOM\" BORDER=\"1\">B</TD>");
+        }
+        definition.append("  </TR></TABLE>");
+        definition.append(">];\n");
+        return definition.toString();
+    }
+
+    private String generateChainDisplayGraph(ChainRun chain, String content) {
+        int orientation = chain.orientation;
+        StringBuilder subgroup = new StringBuilder("subgraph ");
+        subgroup.append("cluster_");
+        subgroup.append(chain.mWidget.getDebugName());
+        if (orientation == HORIZONTAL) {
+            subgroup.append("_h");
+        } else {
+            subgroup.append("_v");
+        }
+        subgroup.append(" {\n");
+        String definitions = "";
+        for (WidgetRun run : chain.mWidgets) {
+            subgroup.append(run.mWidget.getDebugName());
+            if (orientation == HORIZONTAL) {
+                subgroup.append("_HORIZONTAL");
+            } else {
+                subgroup.append("_VERTICAL");
+            }
+            subgroup.append(";\n");
+            definitions = generateDisplayGraph(run, definitions);
+        }
+        subgroup.append("}\n");
+        return content + definitions + subgroup;
+    }
+
+    private boolean isCenteredConnection(DependencyNode start, DependencyNode end) {
+        int startTargets = 0;
+        int endTargets = 0;
+        for (DependencyNode s : start.mTargets) {
+            if (s != end) {
+                startTargets++;
+            }
+        }
+        for (DependencyNode e : end.mTargets) {
+            if (e != start) {
+                endTargets++;
+            }
+        }
+        return startTargets > 0 && endTargets > 0;
+    }
+
+    private String generateDisplayGraph(WidgetRun root, String content) {
+        DependencyNode start = root.start;
+        DependencyNode end = root.end;
+        StringBuilder sb = new StringBuilder(content);
+
+        if (!(root instanceof HelperReferences) && start.mDependencies.isEmpty()
+                && end.mDependencies.isEmpty() && start.mTargets.isEmpty()
+                && end.mTargets.isEmpty()) {
+            return content;
+        }
+        sb.append(nodeDefinition(root));
+
+        boolean centeredConnection = isCenteredConnection(start, end);
+        content = generateDisplayNode(start, centeredConnection, content);
+        content = generateDisplayNode(end, centeredConnection, content);
+        if (root instanceof VerticalWidgetRun) {
+            DependencyNode baseline = ((VerticalWidgetRun) root).baseline;
+            content = generateDisplayNode(baseline, centeredConnection, content);
+        }
+
+        if (root instanceof HorizontalWidgetRun
+                || (root instanceof ChainRun && ((ChainRun) root).orientation == HORIZONTAL)) {
+            ConstraintWidget.DimensionBehaviour behaviour =
+                    root.mWidget.getHorizontalDimensionBehaviour();
+            if (behaviour == ConstraintWidget.DimensionBehaviour.FIXED
+                    || behaviour == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                if (!start.mTargets.isEmpty() && end.mTargets.isEmpty()) {
+                    sb.append("\n");
+                    sb.append(end.name());
+                    sb.append(" -> ");
+                    sb.append(start.name());
+                    sb.append("\n");
+                } else if (start.mTargets.isEmpty() && !end.mTargets.isEmpty()) {
+                    sb.append("\n");
+                    sb.append(start.name());
+                    sb.append(" -> ");
+                    sb.append(end.name());
+                    sb.append("\n");
+                }
+            } else {
+                if (behaviour == MATCH_CONSTRAINT && root.mWidget.getDimensionRatio() > 0) {
+                    sb.append("\n");
+                    sb.append(root.mWidget.getDebugName());
+                    sb.append("_HORIZONTAL -> ");
+                    sb.append(root.mWidget.getDebugName());
+                    sb.append("_VERTICAL;\n");
+                }
+            }
+        } else if (root instanceof VerticalWidgetRun
+                || (root instanceof ChainRun && ((ChainRun) root).orientation == VERTICAL)) {
+            ConstraintWidget.DimensionBehaviour behaviour =
+                    root.mWidget.getVerticalDimensionBehaviour();
+            if (behaviour == ConstraintWidget.DimensionBehaviour.FIXED
+                    || behaviour == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                if (!start.mTargets.isEmpty() && end.mTargets.isEmpty()) {
+                    sb.append("\n");
+                    sb.append(end.name());
+                    sb.append(" -> ");
+                    sb.append(start.name());
+                    sb.append("\n");
+                } else if (start.mTargets.isEmpty() && !end.mTargets.isEmpty()) {
+                    sb.append("\n");
+                    sb.append(start.name());
+                    sb.append(" -> ");
+                    sb.append(end.name());
+                    sb.append("\n");
+                }
+            } else {
+                if (behaviour == MATCH_CONSTRAINT && root.mWidget.getDimensionRatio() > 0) {
+                    sb.append("\n");
+                    sb.append(root.mWidget.getDebugName());
+                    sb.append("_VERTICAL -> ");
+                    sb.append(root.mWidget.getDebugName());
+                    sb.append("_HORIZONTAL;\n");
+                }
+            }
+        }
+        if (root instanceof ChainRun) {
+            return generateChainDisplayGraph((ChainRun) root, content);
+        }
+        return sb.toString();
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DependencyNode.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DependencyNode.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DependencyNode implements Dependency {
+    public Dependency updateDelegate = null;
+    public boolean delegateToWidgetRun = false;
+    public boolean readyToSolve = false;
+
+    enum Type {
+        UNKNOWN, HORIZONTAL_DIMENSION, VERTICAL_DIMENSION,
+        LEFT, RIGHT, TOP, BOTTOM, BASELINE
+    }
+
+    WidgetRun mRun;
+    Type mType = Type.UNKNOWN;
+    int mMargin;
+    public int value;
+    int mMarginFactor = 1;
+    DimensionDependency mMarginDependency = null;
+    public boolean resolved = false;
+
+    public DependencyNode(WidgetRun run) {
+        this.mRun = run;
+    }
+
+    List<Dependency> mDependencies = new ArrayList<>();
+    List<DependencyNode> mTargets = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return mRun.mWidget.getDebugName() + ":" + mType + "("
+                + (resolved ? value : "unresolved") + ") <t="
+                + mTargets.size() + ":d=" + mDependencies.size() + ">";
+    }
+
+    // @TODO: add description
+    public void resolve(int value) {
+        if (resolved) {
+            return;
+        }
+
+        this.resolved = true;
+        this.value = value;
+        for (Dependency node : mDependencies) {
+            node.update(node);
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public void update(Dependency node) {
+        for (DependencyNode target : mTargets) {
+            if (!target.resolved) {
+                return;
+            }
+        }
+        readyToSolve = true;
+        if (updateDelegate != null) {
+            updateDelegate.update(this);
+        }
+        if (delegateToWidgetRun) {
+            mRun.update(this);
+            return;
+        }
+        DependencyNode target = null;
+        int numTargets = 0;
+        for (DependencyNode t : mTargets) {
+            if (t instanceof DimensionDependency) {
+                continue;
+            }
+            target = t;
+            numTargets++;
+        }
+        if (target != null && numTargets == 1 && target.resolved) {
+            if (mMarginDependency != null) {
+                if (mMarginDependency.resolved) {
+                    mMargin = mMarginFactor * mMarginDependency.value;
+                } else {
+                    return;
+                }
+            }
+            resolve(target.value + mMargin);
+        }
+        if (updateDelegate != null) {
+            updateDelegate.update(this);
+        }
+    }
+
+    // @TODO: add description
+    public void addDependency(Dependency dependency) {
+        mDependencies.add(dependency);
+        if (resolved) {
+            dependency.update(dependency);
+        }
+    }
+
+    // @TODO: add description
+    public String name() {
+        String definition = mRun.mWidget.getDebugName();
+        if (mType == Type.LEFT
+                || mType == Type.RIGHT) {
+            definition += "_HORIZONTAL";
+        } else {
+            definition += "_VERTICAL";
+        }
+        definition += ":" + mType.name();
+        return definition;
+    }
+
+    // @TODO: add description
+    public void clear() {
+        mTargets.clear();
+        mDependencies.clear();
+        resolved = false;
+        value = 0;
+        readyToSolve = false;
+        delegateToWidgetRun = false;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DimensionDependency.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/DimensionDependency.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+class DimensionDependency extends DependencyNode {
+
+    public int wrapValue;
+
+    DimensionDependency(WidgetRun run) {
+        super(run);
+        if (run instanceof HorizontalWidgetRun) {
+            mType = Type.HORIZONTAL_DIMENSION;
+        } else {
+            mType = Type.VERTICAL_DIMENSION;
+        }
+    }
+
+    @Override
+    public void resolve(int value) {
+        if (resolved) {
+            return;
+        }
+        this.resolved = true;
+        this.value = value;
+        for (Dependency node : mDependencies) {
+            node.update(node);
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
@@ -1,0 +1,1092 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.GONE;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.ChainHead;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.Guideline;
+
+import java.util.ArrayList;
+
+/**
+ * Direct resolution engine
+ *
+ * This walks through the graph of dependencies and infer final position. This allows
+ * us to skip the linear solver in many situations, as well as skipping intermediate measure passes.
+ *
+ * Widgets are solved independently in horizontal and vertical. Any widgets not fully resolved
+ * will be computed later on by the linear solver.
+ */
+public class Direct {
+
+    private static final boolean DEBUG = LinearSystem.FULL_DEBUG;
+    private static final boolean APPLY_MATCH_PARENT = false;
+    private static BasicMeasure.Measure sMeasure = new BasicMeasure.Measure();
+    private static final boolean EARLY_TERMINATION = true; // feature flag -- remove after release.
+
+    private static int sHcount = 0;
+    private static int sVcount = 0;
+
+    /**
+     * Walk the dependency graph and solves it.
+     *
+     * @param layout   the container we want to optimize
+     * @param measurer the measurer used to measure the widget
+     */
+    public static void solvingPass(ConstraintWidgetContainer layout,
+            BasicMeasure.Measurer measurer) {
+        ConstraintWidget.DimensionBehaviour horizontal = layout.getHorizontalDimensionBehaviour();
+        ConstraintWidget.DimensionBehaviour vertical = layout.getVerticalDimensionBehaviour();
+        sHcount = 0;
+        sVcount = 0;
+        long time = 0;
+        if (DEBUG) {
+            time = System.nanoTime();
+            System.out.println("#### SOLVING PASS (horiz " + horizontal
+                    + ", vert " + vertical + ") ####");
+        }
+        layout.resetFinalResolution();
+        ArrayList<ConstraintWidget> children = layout.getChildren();
+        final int count = children.size();
+        if (DEBUG) {
+            System.out.println("#### SOLVING PASS on " + count + " widgeets ####");
+        }
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            child.resetFinalResolution();
+        }
+
+        boolean isRtl = layout.isRtl();
+
+        // First, let's solve the horizontal dependencies, as it's a lot more common to have
+        // a container with a fixed horizontal dimension (e.g. match_parent) than the opposite.
+
+        // If we know our size, we can fully set the entire dimension, but if not we can
+        // still solve what we can starting from the left.
+        if (horizontal == ConstraintWidget.DimensionBehaviour.FIXED) {
+            layout.setFinalHorizontal(0, layout.getWidth());
+        } else {
+            layout.setFinalLeft(0);
+        }
+
+        if (DEBUG) {
+            System.out.println("\n### Let's solve horizontal dependencies ###\n");
+        }
+
+        // Then let's first try to solve horizontal guidelines,
+        // as they only depends on the container
+        boolean hasGuideline = false;
+        boolean hasBarrier = false;
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (child instanceof Guideline) {
+                Guideline guideline = (Guideline) child;
+                if (guideline.getOrientation() == Guideline.VERTICAL) {
+                    if (guideline.getRelativeBegin() != -1) {
+                        guideline.setFinalValue(guideline.getRelativeBegin());
+                    } else if (guideline.getRelativeEnd() != -1
+                            && layout.isResolvedHorizontally()) {
+                        guideline.setFinalValue(layout.getWidth() - guideline.getRelativeEnd());
+                    } else if (layout.isResolvedHorizontally()) {
+                        int position =
+                                (int) (0.5f + guideline.getRelativePercent() * layout.getWidth());
+                        guideline.setFinalValue(position);
+                    }
+                    hasGuideline = true;
+                }
+            } else if (child instanceof Barrier) {
+                Barrier barrier = (Barrier) child;
+                if (barrier.getOrientation() == HORIZONTAL) {
+                    hasBarrier = true;
+                }
+            }
+        }
+        if (hasGuideline) {
+            if (DEBUG) {
+                System.out.println("\n#### VERTICAL GUIDELINES CHECKS ####");
+            }
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget child = children.get(i);
+                if (child instanceof Guideline) {
+                    Guideline guideline = (Guideline) child;
+                    if (guideline.getOrientation() == Guideline.VERTICAL) {
+                        horizontalSolvingPass(0, guideline, measurer, isRtl);
+                    }
+                }
+            }
+            if (DEBUG) {
+                System.out.println("### Done solving guidelines.");
+            }
+        }
+
+        if (DEBUG) {
+            System.out.println("\n#### HORIZONTAL SOLVING PASS ####");
+        }
+
+        // Now let's resolve what we can in the dependencies of the container
+        horizontalSolvingPass(0, layout, measurer, isRtl);
+
+        // Finally, let's go through barriers, as they depends on widgets that may have been solved.
+        if (hasBarrier) {
+            if (DEBUG) {
+                System.out.println("\n#### HORIZONTAL BARRIER CHECKS ####");
+            }
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget child = children.get(i);
+                if (child instanceof Barrier) {
+                    Barrier barrier = (Barrier) child;
+                    if (barrier.getOrientation() == HORIZONTAL) {
+                        solveBarrier(0, barrier, measurer, HORIZONTAL, isRtl);
+                    }
+                }
+            }
+            if (DEBUG) {
+                System.out.println("#### DONE HORIZONTAL BARRIER CHECKS ####");
+            }
+        }
+
+        if (DEBUG) {
+            System.out.println("\n### Let's solve vertical dependencies now ###\n");
+        }
+
+        // Now we are done with the horizontal axis, let's see what we can do vertically
+        if (vertical == ConstraintWidget.DimensionBehaviour.FIXED) {
+            layout.setFinalVertical(0, layout.getHeight());
+        } else {
+            layout.setFinalTop(0);
+        }
+
+        // Same thing as above -- let's start with guidelines...
+        hasGuideline = false;
+        hasBarrier = false;
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (child instanceof Guideline) {
+                Guideline guideline = (Guideline) child;
+                if (guideline.getOrientation() == Guideline.HORIZONTAL) {
+                    if (guideline.getRelativeBegin() != -1) {
+                        guideline.setFinalValue(guideline.getRelativeBegin());
+                    } else if (guideline.getRelativeEnd() != -1 && layout.isResolvedVertically()) {
+                        guideline.setFinalValue(layout.getHeight() - guideline.getRelativeEnd());
+                    } else if (layout.isResolvedVertically()) {
+                        int position =
+                                (int) (0.5f + guideline.getRelativePercent() * layout.getHeight());
+                        guideline.setFinalValue(position);
+                    }
+                    hasGuideline = true;
+                }
+            } else if (child instanceof Barrier) {
+                Barrier barrier = (Barrier) child;
+                if (barrier.getOrientation() == ConstraintWidget.VERTICAL) {
+                    hasBarrier = true;
+                }
+            }
+        }
+        if (hasGuideline) {
+            if (DEBUG) {
+                System.out.println("\n#### HORIZONTAL GUIDELINES CHECKS ####");
+            }
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget child = children.get(i);
+                if (child instanceof Guideline) {
+                    Guideline guideline = (Guideline) child;
+                    if (guideline.getOrientation() == Guideline.HORIZONTAL) {
+                        verticalSolvingPass(1, guideline, measurer);
+                    }
+                }
+            }
+            if (DEBUG) {
+                System.out.println("\n### Done solving guidelines.");
+            }
+        }
+
+        if (DEBUG) {
+            System.out.println("\n#### VERTICAL SOLVING PASS ####");
+        }
+
+        // ...then solve the vertical dependencies...
+        verticalSolvingPass(0, layout, measurer);
+
+        // ...then deal with any barriers left.
+        if (hasBarrier) {
+            if (DEBUG) {
+                System.out.println("#### VERTICAL BARRIER CHECKS ####");
+            }
+            for (int i = 0; i < count; i++) {
+                ConstraintWidget child = children.get(i);
+                if (child instanceof Barrier) {
+                    Barrier barrier = (Barrier) child;
+                    if (barrier.getOrientation() == ConstraintWidget.VERTICAL) {
+                        solveBarrier(0, barrier, measurer, VERTICAL, isRtl);
+                    }
+                }
+            }
+        }
+
+        if (DEBUG) {
+            System.out.println("\n#### LAST PASS ####");
+        }
+        // We can do a last pass to see any widget that could still be measured
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (child.isMeasureRequested() && canMeasure(0, child)) {
+                ConstraintWidgetContainer.measure(0, child,
+                        measurer, sMeasure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                if (child instanceof Guideline) {
+                    if (((Guideline) child).getOrientation() == Guideline.HORIZONTAL) {
+                        verticalSolvingPass(0, child, measurer);
+                    } else {
+                        horizontalSolvingPass(0, child, measurer, isRtl);
+                    }
+                } else {
+                    horizontalSolvingPass(0, child, measurer, isRtl);
+                    verticalSolvingPass(0, child, measurer);
+                }
+            }
+        }
+
+        if (DEBUG) {
+            time = System.nanoTime() - time;
+            System.out.println("\n*** THROUGH WITH DIRECT PASS in " + time + " ns ***\n");
+            System.out.println("hcount: " + sHcount + " vcount: " + sVcount);
+        }
+    }
+
+    /**
+     * Ask the barrier if it's resolved, and if so do a solving pass
+     */
+    private static void solveBarrier(int level,
+            Barrier barrier,
+            BasicMeasure.Measurer measurer,
+            int orientation,
+            boolean isRtl) {
+        if (barrier.allSolved()) {
+            if (orientation == HORIZONTAL) {
+                horizontalSolvingPass(level + 1, barrier, measurer, isRtl);
+            } else {
+                verticalSolvingPass(level + 1, barrier, measurer);
+            }
+        }
+    }
+
+    /**
+     * Small utility function to indent logs depending on the level
+     *
+     * @return a formatted string for the indentation
+     */
+    public static String ls(int level) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            builder.append("  ");
+        }
+        builder.append("+-(" + level + ") ");
+        return builder.toString();
+    }
+
+    /**
+     * Does an horizontal solving pass for the given widget. This will walk through the widget's
+     * horizontal dependencies and if they can be resolved directly, do so.
+     *
+     * @param layout   the widget we want to solve the dependencies
+     * @param measurer the measurer object to measure the widgets.
+     */
+    private static void horizontalSolvingPass(int level,
+            ConstraintWidget layout,
+            BasicMeasure.Measurer measurer,
+            boolean isRtl) {
+        if (EARLY_TERMINATION && layout.isHorizontalSolvingPassDone()) {
+            if (DEBUG) {
+                System.out.println(ls(level) + "HORIZONTAL SOLVING PASS ON "
+                        + layout.getDebugName() + " ALREADY CALLED");
+            }
+            return;
+        }
+        sHcount++;
+        if (DEBUG) {
+            System.out.println(ls(level) + "HORIZONTAL SOLVING PASS ON " + layout.getDebugName());
+        }
+
+        if (!(layout instanceof ConstraintWidgetContainer) && layout.isMeasureRequested()
+                && canMeasure(level + 1, layout)) {
+            BasicMeasure.Measure measure = new BasicMeasure.Measure();
+            ConstraintWidgetContainer.measure(level + 1, layout,
+                    measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+        }
+
+        ConstraintAnchor left = layout.getAnchor(ConstraintAnchor.Type.LEFT);
+        ConstraintAnchor right = layout.getAnchor(ConstraintAnchor.Type.RIGHT);
+        int l = left.getFinalValue();
+        int r = right.getFinalValue();
+
+        if (left.getDependents() != null && left.hasFinalValue()) {
+            for (ConstraintAnchor first : left.getDependents()) {
+                ConstraintWidget widget = first.mOwner;
+                int x1 = 0;
+                int x2 = 0;
+                boolean canMeasure = canMeasure(level + 1, widget);
+                if (widget.isMeasureRequested() && canMeasure) {
+                    BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                    ConstraintWidgetContainer.measure(level + 1, widget,
+                            measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                }
+
+                boolean bothConnected = (first == widget.mLeft && widget.mRight.mTarget != null
+                        && widget.mRight.mTarget.hasFinalValue())
+                        || (first == widget.mRight && widget.mLeft.mTarget != null
+                        && widget.mLeft.mTarget.hasFinalValue());
+                if (widget.getHorizontalDimensionBehaviour()
+                        != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT || canMeasure) {
+                    if (widget.isMeasureRequested()) {
+                        // Widget needs to be measured
+                        if (DEBUG) {
+                            System.out.println(ls(level + 1) + "(L) We didn't measure "
+                                    + widget.getDebugName() + ", let's bail");
+                        }
+                        continue;
+                    }
+                    if (first == widget.mLeft && widget.mRight.mTarget == null) {
+                        x1 = l + widget.mLeft.getMargin();
+                        x2 = x1 + widget.getWidth();
+                        widget.setFinalHorizontal(x1, x2);
+                        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+                    } else if (first == widget.mRight && widget.mLeft.mTarget == null) {
+                        x2 = l - widget.mRight.getMargin();
+                        x1 = x2 - widget.getWidth();
+                        widget.setFinalHorizontal(x1, x2);
+                        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+                    } else if (bothConnected && !widget.isInHorizontalChain()) {
+                        solveHorizontalCenterConstraints(level + 1, measurer, widget, isRtl);
+                    } else if (APPLY_MATCH_PARENT && widget.getHorizontalDimensionBehaviour()
+                            == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
+                        widget.setFinalHorizontal(0, widget.getWidth());
+                        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+                    }
+                } else if (widget.getHorizontalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && widget.mMatchConstraintMaxWidth >= 0
+                        && widget.mMatchConstraintMinWidth >= 0
+                        && (widget.getVisibility() == ConstraintWidget.GONE
+                        || ((widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD)
+                        && widget.getDimensionRatio() == 0))
+                        && !widget.isInHorizontalChain() && !widget.isInVirtualLayout()) {
+                    if (bothConnected && !widget.isInHorizontalChain()) {
+                        solveHorizontalMatchConstraint(level + 1, layout, measurer, widget, isRtl);
+                    }
+                }
+            }
+        }
+        if (layout instanceof Guideline) {
+            return;
+        }
+        if (right.getDependents() != null && right.hasFinalValue()) {
+            for (ConstraintAnchor first : right.getDependents()) {
+                ConstraintWidget widget = first.mOwner;
+                boolean canMeasure = canMeasure(level + 1, widget);
+                if (widget.isMeasureRequested() && canMeasure) {
+                    BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                    ConstraintWidgetContainer.measure(level + 1, widget,
+                            measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                }
+
+                int x1 = 0;
+                int x2 = 0;
+                boolean bothConnected = (first == widget.mLeft && widget.mRight.mTarget != null
+                        && widget.mRight.mTarget.hasFinalValue())
+                        || (first == widget.mRight && widget.mLeft.mTarget != null
+                        && widget.mLeft.mTarget.hasFinalValue());
+                if (widget.getHorizontalDimensionBehaviour()
+                        != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT || canMeasure) {
+                    if (widget.isMeasureRequested()) {
+                        // Widget needs to be measured
+                        if (DEBUG) {
+                            System.out.println(ls(level + 1) + "(R) We didn't measure "
+                                    + widget.getDebugName() + ", le'ts bail");
+                        }
+                        continue;
+                    }
+                    if (first == widget.mLeft && widget.mRight.mTarget == null) {
+                        x1 = r + widget.mLeft.getMargin();
+                        x2 = x1 + widget.getWidth();
+                        widget.setFinalHorizontal(x1, x2);
+                        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+                    } else if (first == widget.mRight && widget.mLeft.mTarget == null) {
+                        x2 = r - widget.mRight.getMargin();
+                        x1 = x2 - widget.getWidth();
+                        widget.setFinalHorizontal(x1, x2);
+                        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+                    } else if (bothConnected && !widget.isInHorizontalChain()) {
+                        solveHorizontalCenterConstraints(level + 1, measurer, widget, isRtl);
+                    }
+                } else if (widget.getHorizontalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && widget.mMatchConstraintMaxWidth >= 0
+                        && widget.mMatchConstraintMinWidth >= 0
+                        && (widget.getVisibility() == ConstraintWidget.GONE
+                        || ((widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD)
+                        && widget.getDimensionRatio() == 0))
+                        && !widget.isInHorizontalChain() && !widget.isInVirtualLayout()) {
+                    if (bothConnected && !widget.isInHorizontalChain()) {
+                        solveHorizontalMatchConstraint(level + 1, layout, measurer, widget, isRtl);
+                    }
+                }
+            }
+        }
+        layout.markHorizontalSolvingPassDone();
+    }
+
+    /**
+     * Does an vertical solving pass for the given widget. This will walk through the widget's
+     * vertical dependencies and if they can be resolved directly, do so.
+     *
+     * @param layout   the widget we want to solve the dependencies
+     * @param measurer the measurer object to measure the widgets.
+     */
+    private static void verticalSolvingPass(int level,
+            ConstraintWidget layout,
+            BasicMeasure.Measurer measurer) {
+        if (EARLY_TERMINATION && layout.isVerticalSolvingPassDone()) {
+            if (DEBUG) {
+                System.out.println(ls(level) + "VERTICAL SOLVING PASS ON "
+                        + layout.getDebugName() + " ALREADY CALLED");
+            }
+            return;
+        }
+        sVcount++;
+        if (DEBUG) {
+            System.out.println(ls(level) + "VERTICAL SOLVING PASS ON " + layout.getDebugName());
+        }
+
+        if (!(layout instanceof ConstraintWidgetContainer)
+                && layout.isMeasureRequested() && canMeasure(level + 1, layout)) {
+            BasicMeasure.Measure measure = new BasicMeasure.Measure();
+            ConstraintWidgetContainer.measure(level + 1, layout,
+                    measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+        }
+
+        ConstraintAnchor top = layout.getAnchor(ConstraintAnchor.Type.TOP);
+        ConstraintAnchor bottom = layout.getAnchor(ConstraintAnchor.Type.BOTTOM);
+        int t = top.getFinalValue();
+        int b = bottom.getFinalValue();
+
+        if (top.getDependents() != null && top.hasFinalValue()) {
+            for (ConstraintAnchor first : top.getDependents()) {
+                ConstraintWidget widget = first.mOwner;
+                int y1 = 0;
+                int y2 = 0;
+                boolean canMeasure = canMeasure(level + 1, widget);
+                if (widget.isMeasureRequested() && canMeasure) {
+                    BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                    ConstraintWidgetContainer.measure(level + 1, widget,
+                            measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                }
+
+                boolean bothConnected = (first == widget.mTop && widget.mBottom.mTarget != null
+                        && widget.mBottom.mTarget.hasFinalValue())
+                        || (first == widget.mBottom && widget.mTop.mTarget != null
+                        && widget.mTop.mTarget.hasFinalValue());
+                if (widget.getVerticalDimensionBehaviour()
+                        != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        || canMeasure) {
+                    if (widget.isMeasureRequested()) {
+                        // Widget needs to be measured
+                        if (DEBUG) {
+                            System.out.println(ls(level + 1) + "(T) We didn't measure "
+                                    + widget.getDebugName() + ", le'ts bail");
+                        }
+                        continue;
+                    }
+                    if (first == widget.mTop && widget.mBottom.mTarget == null) {
+                        y1 = t + widget.mTop.getMargin();
+                        y2 = y1 + widget.getHeight();
+                        widget.setFinalVertical(y1, y2);
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    } else if (first == widget.mBottom && widget.mTop.mTarget == null) {
+                        y2 = t - widget.mBottom.getMargin();
+                        y1 = y2 - widget.getHeight();
+                        widget.setFinalVertical(y1, y2);
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    } else if (bothConnected && !widget.isInVerticalChain()) {
+                        solveVerticalCenterConstraints(level + 1, measurer, widget);
+                    } else if (APPLY_MATCH_PARENT && widget.getVerticalDimensionBehaviour()
+                            == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
+                        widget.setFinalVertical(0, widget.getHeight());
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    }
+                } else if (widget.getVerticalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && widget.mMatchConstraintMaxHeight >= 0
+                        && widget.mMatchConstraintMinHeight >= 0
+                        && (widget.getVisibility() == ConstraintWidget.GONE
+                        || ((widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD)
+                        && widget.getDimensionRatio() == 0))
+                        && !widget.isInVerticalChain() && !widget.isInVirtualLayout()) {
+                    if (bothConnected && !widget.isInVerticalChain()) {
+                        solveVerticalMatchConstraint(level + 1, layout, measurer, widget);
+                    }
+                }
+            }
+        }
+        if (layout instanceof Guideline) {
+            return;
+        }
+        if (bottom.getDependents() != null && bottom.hasFinalValue()) {
+            for (ConstraintAnchor first : bottom.getDependents()) {
+                ConstraintWidget widget = first.mOwner;
+                boolean canMeasure = canMeasure(level + 1, widget);
+                if (widget.isMeasureRequested() && canMeasure) {
+                    BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                    ConstraintWidgetContainer.measure(level + 1, widget,
+                            measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                }
+
+                int y1 = 0;
+                int y2 = 0;
+                boolean bothConnected = (first == widget.mTop && widget.mBottom.mTarget != null
+                        && widget.mBottom.mTarget.hasFinalValue())
+                        || (first == widget.mBottom && widget.mTop.mTarget != null
+                        && widget.mTop.mTarget.hasFinalValue());
+                if (widget.getVerticalDimensionBehaviour()
+                        != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT || canMeasure) {
+                    if (widget.isMeasureRequested()) {
+                        // Widget needs to be measured
+                        if (DEBUG) {
+                            System.out.println(ls(level + 1) + "(B) We didn't measure "
+                                    + widget.getDebugName() + ", le'ts bail");
+                        }
+                        continue;
+                    }
+                    if (first == widget.mTop && widget.mBottom.mTarget == null) {
+                        y1 = b + widget.mTop.getMargin();
+                        y2 = y1 + widget.getHeight();
+                        widget.setFinalVertical(y1, y2);
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    } else if (first == widget.mBottom && widget.mTop.mTarget == null) {
+                        y2 = b - widget.mBottom.getMargin();
+                        y1 = y2 - widget.getHeight();
+                        widget.setFinalVertical(y1, y2);
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    } else if (bothConnected && !widget.isInVerticalChain()) {
+                        solveVerticalCenterConstraints(level + 1, measurer, widget);
+                    }
+                } else if (widget.getVerticalDimensionBehaviour()
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && widget.mMatchConstraintMaxHeight >= 0
+                        && widget.mMatchConstraintMinHeight >= 0
+                        && (widget.getVisibility() == ConstraintWidget.GONE
+                        || ((widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD)
+                        && widget.getDimensionRatio() == 0))
+                        && !widget.isInVerticalChain() && !widget.isInVirtualLayout()) {
+                    if (bothConnected && !widget.isInVerticalChain()) {
+                        solveVerticalMatchConstraint(level + 1, layout, measurer, widget);
+                    }
+                }
+            }
+        }
+
+        ConstraintAnchor baseline = layout.getAnchor(ConstraintAnchor.Type.BASELINE);
+        if (baseline.getDependents() != null && baseline.hasFinalValue()) {
+            int baselineValue = baseline.getFinalValue();
+            for (ConstraintAnchor first : baseline.getDependents()) {
+                ConstraintWidget widget = first.mOwner;
+                boolean canMeasure = canMeasure(level + 1, widget);
+                if (widget.isMeasureRequested() && canMeasure) {
+                    BasicMeasure.Measure measure = new BasicMeasure.Measure();
+                    ConstraintWidgetContainer.measure(level + 1, widget,
+                            measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+                }
+                if (widget.getVerticalDimensionBehaviour()
+                        != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT || canMeasure) {
+                    if (widget.isMeasureRequested()) {
+                        // Widget needs to be measured
+                        if (DEBUG) {
+                            System.out.println(ls(level + 1) + "(B) We didn't measure "
+                                    + widget.getDebugName() + ", le'ts bail");
+                        }
+                        continue;
+                    }
+                    if (first == widget.mBaseline) {
+                        widget.setFinalBaseline(baselineValue + first.getMargin());
+                        verticalSolvingPass(level + 1, widget, measurer);
+                    }
+                }
+            }
+        }
+        layout.markVerticalSolvingPassDone();
+    }
+
+    /**
+     * Solve horizontal centering constraints
+     */
+    private static void solveHorizontalCenterConstraints(int level,
+            BasicMeasure.Measurer measurer,
+            ConstraintWidget widget,
+            boolean isRtl) {
+        // TODO: Handle match constraints here or before calling this
+        int x1;
+        int x2;
+        float bias = widget.getHorizontalBiasPercent();
+        int start = widget.mLeft.mTarget.getFinalValue();
+        int end = widget.mRight.mTarget.getFinalValue();
+        int s1 = start + widget.mLeft.getMargin();
+        int s2 = end - widget.mRight.getMargin();
+        if (start == end) {
+            bias = 0.5f;
+            s1 = start;
+            s2 = end;
+        }
+        int width = widget.getWidth();
+        int distance = s2 - s1 - width;
+        if (s1 > s2) {
+            distance = s1 - s2 - width;
+        }
+        int d1;
+        if (distance > 0) {
+            d1 = (int) (0.5f + bias * distance);
+        } else {
+            d1 = (int) (bias * distance);
+        }
+        x1 = s1 + d1;
+        x2 = x1 + width;
+        if (s1 > s2) {
+            x1 = s1 + d1;
+            x2 = x1 - width;
+        }
+        widget.setFinalHorizontal(x1, x2);
+        horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+    }
+
+    /**
+     * Solve vertical centering constraints
+     */
+    private static void solveVerticalCenterConstraints(int level,
+            BasicMeasure.Measurer measurer,
+            ConstraintWidget widget) {
+        // TODO: Handle match constraints here or before calling this
+        int y1;
+        int y2;
+        float bias = widget.getVerticalBiasPercent();
+        int start = widget.mTop.mTarget.getFinalValue();
+        int end = widget.mBottom.mTarget.getFinalValue();
+        int s1 = start + widget.mTop.getMargin();
+        int s2 = end - widget.mBottom.getMargin();
+        if (start == end) {
+            bias = 0.5f;
+            s1 = start;
+            s2 = end;
+        }
+        int height = widget.getHeight();
+        int distance = s2 - s1 - height;
+        if (s1 > s2) {
+            distance = s1 - s2 - height;
+        }
+        int d1;
+        if (distance > 0) {
+            d1 = (int) (0.5f + bias * distance);
+        } else {
+            d1 = (int) (bias * distance);
+        }
+        y1 = s1 + d1;
+        y2 = y1 + height;
+        if (s1 > s2) {
+            y1 = s1 - d1;
+            y2 = y1 - height;
+        }
+        widget.setFinalVertical(y1, y2);
+        verticalSolvingPass(level + 1, widget, measurer);
+    }
+
+    /**
+     * Solve horizontal match constraints
+     */
+    private static void solveHorizontalMatchConstraint(int level,
+            ConstraintWidget layout,
+            BasicMeasure.Measurer measurer,
+            ConstraintWidget widget,
+            boolean isRtl) {
+        int x1;
+        int x2;
+        float bias = widget.getHorizontalBiasPercent();
+        int s1 = widget.mLeft.mTarget.getFinalValue() + widget.mLeft.getMargin();
+        int s2 = widget.mRight.mTarget.getFinalValue() - widget.mRight.getMargin();
+        if (s2 >= s1) {
+            int width = widget.getWidth();
+            if (widget.getVisibility() != ConstraintWidget.GONE) {
+                if (widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT) {
+                    int parentWidth = 0;
+                    if (layout instanceof ConstraintWidgetContainer) {
+                        parentWidth = layout.getWidth();
+                    } else {
+                        parentWidth = layout.getParent().getWidth();
+                    }
+                    width = (int) (0.5f * widget.getHorizontalBiasPercent() * parentWidth);
+                } else if (widget.mMatchConstraintDefaultWidth
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD) {
+                    width = s2 - s1;
+                }
+                width = Math.max(widget.mMatchConstraintMinWidth, width);
+                if (widget.mMatchConstraintMaxWidth > 0) {
+                    width = Math.min(widget.mMatchConstraintMaxWidth, width);
+                }
+            }
+            int distance = s2 - s1 - width;
+            int d1 = (int) (0.5f + bias * distance);
+            x1 = s1 + d1;
+            x2 = x1 + width;
+            widget.setFinalHorizontal(x1, x2);
+            horizontalSolvingPass(level + 1, widget, measurer, isRtl);
+        }
+    }
+
+    /**
+     * Solve vertical match constraints
+     */
+    private static void solveVerticalMatchConstraint(int level,
+            ConstraintWidget layout,
+            BasicMeasure.Measurer measurer,
+            ConstraintWidget widget) {
+        int y1;
+        int y2;
+        float bias = widget.getVerticalBiasPercent();
+        int s1 = widget.mTop.mTarget.getFinalValue() + widget.mTop.getMargin();
+        int s2 = widget.mBottom.mTarget.getFinalValue() - widget.mBottom.getMargin();
+        if (s2 >= s1) {
+            int height = widget.getHeight();
+            if (widget.getVisibility() != ConstraintWidget.GONE) {
+                if (widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_PERCENT) {
+                    int parentHeight = 0;
+                    if (layout instanceof ConstraintWidgetContainer) {
+                        parentHeight = layout.getHeight();
+                    } else {
+                        parentHeight = layout.getParent().getHeight();
+                    }
+                    height = (int) (0.5f * bias * parentHeight);
+                } else if (widget.mMatchConstraintDefaultHeight
+                        == ConstraintWidget.MATCH_CONSTRAINT_SPREAD) {
+                    height = s2 - s1;
+                }
+                height = Math.max(widget.mMatchConstraintMinHeight, height);
+                if (widget.mMatchConstraintMaxHeight > 0) {
+                    height = Math.min(widget.mMatchConstraintMaxHeight, height);
+                }
+            }
+            int distance = s2 - s1 - height;
+            int d1 = (int) (0.5f + bias * distance);
+            y1 = s1 + d1;
+            y2 = y1 + height;
+            widget.setFinalVertical(y1, y2);
+            verticalSolvingPass(level + 1, widget, measurer);
+        }
+    }
+
+    /**
+     * Returns true if the dimensions of the given widget are computable directly
+     *
+     * @param layout the widget to check
+     * @return true if both dimensions are knowable by a single measure pass
+     */
+    private static boolean canMeasure(int level, ConstraintWidget layout) {
+        ConstraintWidget.DimensionBehaviour horizontalBehaviour =
+                layout.getHorizontalDimensionBehaviour();
+        ConstraintWidget.DimensionBehaviour verticalBehaviour =
+                layout.getVerticalDimensionBehaviour();
+        ConstraintWidgetContainer parent = layout.getParent() != null
+                ? (ConstraintWidgetContainer) layout.getParent() : null;
+        boolean isParentHorizontalFixed = parent != null && parent.getHorizontalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.FIXED;
+        boolean isParentVerticalFixed = parent != null && parent.getVerticalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.FIXED;
+        boolean isHorizontalFixed = horizontalBehaviour == ConstraintWidget.DimensionBehaviour.FIXED
+                || layout.isResolvedHorizontally()
+                || (APPLY_MATCH_PARENT && horizontalBehaviour
+                == ConstraintWidget.DimensionBehaviour.MATCH_PARENT && isParentHorizontalFixed)
+                || horizontalBehaviour == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+                || (horizontalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && layout.mMatchConstraintDefaultWidth
+                == ConstraintWidget.MATCH_CONSTRAINT_SPREAD
+                && layout.mDimensionRatio == 0
+                && layout.hasDanglingDimension(HORIZONTAL))
+                || (horizontalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && layout.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_WRAP
+                && layout.hasResolvedTargets(HORIZONTAL, layout.getWidth()));
+        boolean isVerticalFixed = verticalBehaviour == ConstraintWidget.DimensionBehaviour.FIXED
+                || layout.isResolvedVertically()
+                || (APPLY_MATCH_PARENT && verticalBehaviour
+                == ConstraintWidget.DimensionBehaviour.MATCH_PARENT && isParentVerticalFixed)
+                || verticalBehaviour == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+                || (verticalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && layout.mMatchConstraintDefaultHeight
+                == ConstraintWidget.MATCH_CONSTRAINT_SPREAD
+                && layout.mDimensionRatio == 0
+                && layout.hasDanglingDimension(ConstraintWidget.VERTICAL))
+                || (verticalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && layout.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP
+                && layout.hasResolvedTargets(VERTICAL, layout.getHeight()));
+        if (layout.mDimensionRatio > 0 && (isHorizontalFixed || isVerticalFixed)) {
+            return true;
+        }
+        if (DEBUG) {
+            System.out.println(ls(level) + "can measure " + layout.getDebugName() + " ? "
+                    + (isHorizontalFixed && isVerticalFixed) + "  [ "
+                    + isHorizontalFixed + " (horiz " + horizontalBehaviour + ") & "
+                    + isVerticalFixed + " (vert " + verticalBehaviour + ") ]");
+        }
+        return isHorizontalFixed && isVerticalFixed;
+    }
+
+    /**
+     * Try to directly resolve the chain
+     *
+     * @return true if fully resolved
+     */
+    public static boolean solveChain(ConstraintWidgetContainer container, LinearSystem system,
+            int orientation, int offset, ChainHead chainHead,
+            boolean isChainSpread, boolean isChainSpreadInside,
+            boolean isChainPacked) {
+        if (LinearSystem.FULL_DEBUG) {
+            System.out.println("\n### SOLVE CHAIN ###");
+        }
+        if (isChainPacked) {
+            return false;
+        }
+        if (orientation == HORIZONTAL) {
+            if (!container.isResolvedHorizontally()) {
+                return false;
+            }
+        } else {
+            if (!container.isResolvedVertically()) {
+                return false;
+            }
+        }
+        int level = 0; // nested level (used for debugging)
+        boolean isRtl = container.isRtl();
+
+        ConstraintWidget first = chainHead.getFirst();
+        ConstraintWidget last = chainHead.getLast();
+        ConstraintWidget firstVisibleWidget = chainHead.getFirstVisibleWidget();
+        ConstraintWidget lastVisibleWidget = chainHead.getLastVisibleWidget();
+        ConstraintWidget head = chainHead.getHead();
+
+        ConstraintWidget widget = first;
+        ConstraintWidget next;
+        boolean done = false;
+
+        ConstraintAnchor begin = first.mListAnchors[offset];
+        ConstraintAnchor end = last.mListAnchors[offset + 1];
+        if (begin.mTarget == null || end.mTarget == null) {
+            return false;
+        }
+        if (!begin.mTarget.hasFinalValue() || !end.mTarget.hasFinalValue()) {
+            return false;
+        }
+
+        if (firstVisibleWidget == null || lastVisibleWidget == null) {
+            return false;
+        }
+
+        int startPoint = begin.mTarget.getFinalValue()
+                + firstVisibleWidget.mListAnchors[offset].getMargin();
+        int endPoint = end.mTarget.getFinalValue()
+                - lastVisibleWidget.mListAnchors[offset + 1].getMargin();
+
+        int distance = endPoint - startPoint;
+        if (distance <= 0) {
+            return false;
+        }
+        int totalSize = 0;
+        BasicMeasure.Measure measure = new BasicMeasure.Measure();
+
+        int numWidgets = 0;
+        int numVisibleWidgets = 0;
+
+        while (!done) {
+            boolean canMeasure = canMeasure(level + 1, widget);
+            if (!canMeasure) {
+                return false;
+            }
+            if (widget.mListDimensionBehaviors[orientation]
+                    == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+                return false;
+            }
+
+            if (widget.isMeasureRequested()) {
+                ConstraintWidgetContainer.measure(level + 1, widget,
+                        container.getMeasurer(), measure, BasicMeasure.Measure.SELF_DIMENSIONS);
+            }
+
+            totalSize += widget.mListAnchors[offset].getMargin();
+            if (orientation == HORIZONTAL) {
+                totalSize += +widget.getWidth();
+            } else {
+                totalSize += widget.getHeight();
+            }
+            totalSize += widget.mListAnchors[offset + 1].getMargin();
+
+            numWidgets++;
+            if (widget.getVisibility() != ConstraintWidget.GONE) {
+                numVisibleWidgets++;
+            }
+
+
+            // go to the next widget
+            ConstraintAnchor nextAnchor = widget.mListAnchors[offset + 1].mTarget;
+            if (nextAnchor != null) {
+                next = nextAnchor.mOwner;
+                if (next.mListAnchors[offset].mTarget == null
+                        || next.mListAnchors[offset].mTarget.mOwner != widget) {
+                    next = null;
+                }
+            } else {
+                next = null;
+            }
+            if (next != null) {
+                widget = next;
+            } else {
+                done = true;
+            }
+        }
+
+        if (numVisibleWidgets == 0) {
+            return false;
+        }
+
+        if (numVisibleWidgets != numWidgets) {
+            return false;
+        }
+
+        if (distance < totalSize) {
+            return false;
+        }
+
+        int gap = distance - totalSize;
+        if (isChainSpread) {
+            gap = gap / (numVisibleWidgets + 1);
+        } else if (isChainSpreadInside) {
+            if (numVisibleWidgets > 2) {
+                gap = gap / numVisibleWidgets - 1;
+            }
+        }
+
+        if (numVisibleWidgets == 1) {
+            float bias;
+            if (orientation == ConstraintWidget.HORIZONTAL) {
+                bias = head.getHorizontalBiasPercent();
+            } else {
+                bias = head.getVerticalBiasPercent();
+            }
+            int p1 = (int) (0.5f + startPoint + gap * bias);
+            if (orientation == HORIZONTAL) {
+                firstVisibleWidget.setFinalHorizontal(p1, p1 + firstVisibleWidget.getWidth());
+            } else {
+                firstVisibleWidget.setFinalVertical(p1, p1 + firstVisibleWidget.getHeight());
+            }
+            Direct.horizontalSolvingPass(level + 1,
+                    firstVisibleWidget, container.getMeasurer(), isRtl);
+            return true;
+        }
+
+        if (isChainSpread) {
+            done = false;
+
+            int current = startPoint + gap;
+            widget = first;
+            while (!done) {
+                if (widget.getVisibility() == GONE) {
+                    if (orientation == HORIZONTAL) {
+                        widget.setFinalHorizontal(current, current);
+                        Direct.horizontalSolvingPass(level + 1,
+                                widget, container.getMeasurer(), isRtl);
+                    } else {
+                        widget.setFinalVertical(current, current);
+                        Direct.verticalSolvingPass(level + 1, widget, container.getMeasurer());
+                    }
+                } else {
+                    current += widget.mListAnchors[offset].getMargin();
+                    if (orientation == HORIZONTAL) {
+                        widget.setFinalHorizontal(current, current + widget.getWidth());
+                        Direct.horizontalSolvingPass(level + 1,
+                                widget, container.getMeasurer(), isRtl);
+                        current += widget.getWidth();
+                    } else {
+                        widget.setFinalVertical(current, current + widget.getHeight());
+                        Direct.verticalSolvingPass(level + 1, widget, container.getMeasurer());
+                        current += widget.getHeight();
+                    }
+                    current += widget.mListAnchors[offset + 1].getMargin();
+                    current += gap;
+                }
+
+                widget.addToSolver(system, false);
+
+                // go to the next widget
+                ConstraintAnchor nextAnchor = widget.mListAnchors[offset + 1].mTarget;
+                if (nextAnchor != null) {
+                    next = nextAnchor.mOwner;
+                    if (next.mListAnchors[offset].mTarget == null
+                            || next.mListAnchors[offset].mTarget.mOwner != widget) {
+                        next = null;
+                    }
+                } else {
+                    next = null;
+                }
+                if (next != null) {
+                    widget = next;
+                } else {
+                    done = true;
+                }
+            }
+        } else if (isChainSpreadInside) {
+            if (numVisibleWidgets == 2) {
+                if (orientation == HORIZONTAL) {
+                    firstVisibleWidget.setFinalHorizontal(startPoint,
+                            startPoint + firstVisibleWidget.getWidth());
+                    lastVisibleWidget.setFinalHorizontal(endPoint - lastVisibleWidget.getWidth(),
+                            endPoint);
+                    Direct.horizontalSolvingPass(level + 1,
+                            firstVisibleWidget, container.getMeasurer(), isRtl);
+                    Direct.horizontalSolvingPass(level + 1,
+                            lastVisibleWidget, container.getMeasurer(), isRtl);
+                } else {
+                    firstVisibleWidget.setFinalVertical(startPoint,
+                            startPoint + firstVisibleWidget.getHeight());
+                    lastVisibleWidget.setFinalVertical(endPoint - lastVisibleWidget.getHeight(),
+                            endPoint);
+                    Direct.verticalSolvingPass(level + 1,
+                            firstVisibleWidget, container.getMeasurer());
+                    Direct.verticalSolvingPass(level + 1,
+                            lastVisibleWidget, container.getMeasurer());
+                }
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Grouping.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/Grouping.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.BOTH;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.FIXED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_PARENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.WRAP_CONTENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.Flow;
+import androidx.constraintlayout.core.widgets.Guideline;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import java.util.ArrayList;
+
+/**
+ * Implements a simple grouping mechanism, to group interdependent widgets together.
+ *
+ * TODO: we should move towards a more leaner implementation
+ *          -- this is more expensive as it could be.
+ */
+public class Grouping {
+
+    private static final boolean DEBUG = false;
+    private static final boolean DEBUG_GROUPING = false;
+    private static final boolean FORCE_USE = true;
+
+    // @TODO: add description
+    public static boolean validInGroup(ConstraintWidget.DimensionBehaviour layoutHorizontal,
+            ConstraintWidget.DimensionBehaviour layoutVertical,
+            ConstraintWidget.DimensionBehaviour widgetHorizontal,
+            ConstraintWidget.DimensionBehaviour widgetVertical) {
+        boolean fixedHorizontal = widgetHorizontal == FIXED || widgetHorizontal == WRAP_CONTENT
+                || (widgetHorizontal == MATCH_PARENT && layoutHorizontal != WRAP_CONTENT);
+        boolean fixedVertical = widgetVertical == FIXED || widgetVertical == WRAP_CONTENT
+                || (widgetVertical == MATCH_PARENT && layoutVertical != WRAP_CONTENT);
+        if (fixedHorizontal || fixedVertical) {
+            return true;
+        }
+        return false;
+    }
+
+    // @TODO: add description
+    public static boolean simpleSolvingPass(ConstraintWidgetContainer layout,
+            BasicMeasure.Measurer measurer) {
+
+        if (DEBUG) {
+            System.out.println("*** GROUP SOLVING ***");
+        }
+        ArrayList<ConstraintWidget> children = layout.getChildren();
+
+        final int count = children.size();
+
+        ArrayList<Guideline> verticalGuidelines = null;
+        ArrayList<Guideline> horizontalGuidelines = null;
+        ArrayList<HelperWidget> horizontalBarriers = null;
+        ArrayList<HelperWidget> verticalBarriers = null;
+        ArrayList<ConstraintWidget> isolatedHorizontalChildren = null;
+        ArrayList<ConstraintWidget> isolatedVerticalChildren = null;
+
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (!validInGroup(layout.getHorizontalDimensionBehaviour(),
+                    layout.getVerticalDimensionBehaviour(),
+                    child.getHorizontalDimensionBehaviour(),
+                    child.getVerticalDimensionBehaviour())) {
+                if (DEBUG) {
+                    System.out.println("*** NO GROUP SOLVING ***");
+                }
+                return false;
+            }
+            if (child instanceof Flow) {
+                return false;
+            }
+        }
+        if (layout.mMetrics != null) {
+            layout.mMetrics.grouping++;
+        }
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (!validInGroup(layout.getHorizontalDimensionBehaviour(),
+                    layout.getVerticalDimensionBehaviour(),
+                    child.getHorizontalDimensionBehaviour(),
+                    child.getVerticalDimensionBehaviour())) {
+                ConstraintWidgetContainer.measure(0, child, measurer,
+                        layout.mMeasure, BasicMeasure.Measure.SELF_DIMENSIONS);
+            }
+            if (child instanceof Guideline) {
+                Guideline guideline = (Guideline) child;
+                if (guideline.getOrientation() == HORIZONTAL) {
+                    if (horizontalGuidelines == null) {
+                        horizontalGuidelines = new ArrayList<>();
+                    }
+                    horizontalGuidelines.add(guideline);
+                }
+                if (guideline.getOrientation() == VERTICAL) {
+                    if (verticalGuidelines == null) {
+                        verticalGuidelines = new ArrayList<>();
+                    }
+                    verticalGuidelines.add(guideline);
+                }
+            }
+            if (child instanceof HelperWidget) {
+                if (child instanceof Barrier) {
+                    Barrier barrier = (Barrier) child;
+                    if (barrier.getOrientation() == HORIZONTAL) {
+                        if (horizontalBarriers == null) {
+                            horizontalBarriers = new ArrayList<>();
+                        }
+                        horizontalBarriers.add(barrier);
+                    }
+                    if (barrier.getOrientation() == VERTICAL) {
+                        if (verticalBarriers == null) {
+                            verticalBarriers = new ArrayList<>();
+                        }
+                        verticalBarriers.add(barrier);
+                    }
+                } else {
+                    HelperWidget helper = (HelperWidget) child;
+                    if (horizontalBarriers == null) {
+                        horizontalBarriers = new ArrayList<>();
+                    }
+                    horizontalBarriers.add(helper);
+                    if (verticalBarriers == null) {
+                        verticalBarriers = new ArrayList<>();
+                    }
+                    verticalBarriers.add(helper);
+                }
+            }
+            if (child.mLeft.mTarget == null && child.mRight.mTarget == null
+                    && !(child instanceof Guideline) && !(child instanceof Barrier)) {
+                if (isolatedHorizontalChildren == null) {
+                    isolatedHorizontalChildren = new ArrayList<>();
+                }
+                isolatedHorizontalChildren.add(child);
+            }
+            if (child.mTop.mTarget == null && child.mBottom.mTarget == null
+                    && child.mBaseline.mTarget == null
+                    && !(child instanceof Guideline) && !(child instanceof Barrier)) {
+                if (isolatedVerticalChildren == null) {
+                    isolatedVerticalChildren = new ArrayList<>();
+                }
+                isolatedVerticalChildren.add(child);
+            }
+        }
+        ArrayList<WidgetGroup> allDependencyLists = new ArrayList<>();
+
+        if (FORCE_USE || layout.getHorizontalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+            //horizontalDependencyLists; //new ArrayList<>();
+            ArrayList<WidgetGroup> dependencyLists = allDependencyLists;
+
+            if (verticalGuidelines != null) {
+                for (Guideline guideline : verticalGuidelines) {
+                    findDependents(guideline, HORIZONTAL, dependencyLists, null);
+                }
+            }
+            if (horizontalBarriers != null) {
+                for (HelperWidget barrier : horizontalBarriers) {
+                    WidgetGroup group = findDependents(barrier, HORIZONTAL, dependencyLists, null);
+                    barrier.addDependents(dependencyLists, HORIZONTAL, group);
+                    group.cleanup(dependencyLists);
+                }
+            }
+
+            ConstraintAnchor left = layout.getAnchor(ConstraintAnchor.Type.LEFT);
+            if (left.getDependents() != null) {
+                for (ConstraintAnchor first : left.getDependents()) {
+                    findDependents(first.mOwner, ConstraintWidget.HORIZONTAL,
+                            dependencyLists, null);
+                }
+            }
+
+            ConstraintAnchor right = layout.getAnchor(ConstraintAnchor.Type.RIGHT);
+            if (right.getDependents() != null) {
+                for (ConstraintAnchor first : right.getDependents()) {
+                    findDependents(first.mOwner, ConstraintWidget.HORIZONTAL,
+                            dependencyLists, null);
+                }
+            }
+
+            ConstraintAnchor center = layout.getAnchor(ConstraintAnchor.Type.CENTER);
+            if (center.getDependents() != null) {
+                for (ConstraintAnchor first : center.getDependents()) {
+                    findDependents(first.mOwner, ConstraintWidget.HORIZONTAL,
+                            dependencyLists, null);
+                }
+            }
+
+            if (isolatedHorizontalChildren != null) {
+                for (ConstraintWidget widget : isolatedHorizontalChildren) {
+                    findDependents(widget, HORIZONTAL, dependencyLists, null);
+                }
+            }
+        }
+
+        if (FORCE_USE || layout.getVerticalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+            //verticalDependencyLists; //new ArrayList<>();
+            ArrayList<WidgetGroup> dependencyLists = allDependencyLists;
+
+            if (horizontalGuidelines != null) {
+                for (Guideline guideline : horizontalGuidelines) {
+                    findDependents(guideline, VERTICAL, dependencyLists, null);
+                }
+            }
+            if (verticalBarriers != null) {
+                for (HelperWidget barrier : verticalBarriers) {
+                    WidgetGroup group = findDependents(barrier, VERTICAL, dependencyLists, null);
+                    barrier.addDependents(dependencyLists, VERTICAL, group);
+                    group.cleanup(dependencyLists);
+                }
+            }
+
+            ConstraintAnchor top = layout.getAnchor(ConstraintAnchor.Type.TOP);
+            if (top.getDependents() != null) {
+                for (ConstraintAnchor first : top.getDependents()) {
+                    findDependents(first.mOwner, VERTICAL, dependencyLists, null);
+                }
+            }
+
+            ConstraintAnchor baseline = layout.getAnchor(ConstraintAnchor.Type.BASELINE);
+            if (baseline.getDependents() != null) {
+                for (ConstraintAnchor first : baseline.getDependents()) {
+                    findDependents(first.mOwner, VERTICAL, dependencyLists, null);
+                }
+            }
+
+            ConstraintAnchor bottom = layout.getAnchor(ConstraintAnchor.Type.BOTTOM);
+            if (bottom.getDependents() != null) {
+                for (ConstraintAnchor first : bottom.getDependents()) {
+                    findDependents(first.mOwner, VERTICAL, dependencyLists, null);
+                }
+            }
+
+            ConstraintAnchor center = layout.getAnchor(ConstraintAnchor.Type.CENTER);
+            if (center.getDependents() != null) {
+                for (ConstraintAnchor first : center.getDependents()) {
+                    findDependents(first.mOwner, VERTICAL, dependencyLists, null);
+                }
+            }
+
+            if (isolatedVerticalChildren != null) {
+                for (ConstraintWidget widget : isolatedVerticalChildren) {
+                    findDependents(widget, VERTICAL, dependencyLists, null);
+                }
+            }
+        }
+        // Now we may have to merge horizontal/vertical dependencies
+        for (int i = 0; i < count; i++) {
+            ConstraintWidget child = children.get(i);
+            if (child.oppositeDimensionsTied()) {
+                WidgetGroup horizontalGroup = findGroup(allDependencyLists, child.horizontalGroup);
+                WidgetGroup verticalGroup = findGroup(allDependencyLists, child.verticalGroup);
+                if (horizontalGroup != null && verticalGroup != null) {
+                    if (DEBUG_GROUPING) {
+                        System.out.println("Merging " + horizontalGroup
+                                + " to " + verticalGroup + " for " + child);
+                    }
+                    horizontalGroup.moveTo(HORIZONTAL, verticalGroup);
+                    verticalGroup.setOrientation(BOTH);
+                    allDependencyLists.remove(horizontalGroup);
+                }
+            }
+            if (DEBUG_GROUPING) {
+                System.out.println("Widget " + child + " => "
+                        + child.horizontalGroup + " : " + child.verticalGroup);
+            }
+        }
+
+        if (allDependencyLists.size() <= 1) {
+            return false;
+        }
+
+        if (DEBUG) {
+            System.out.println("----------------------------------");
+            System.out.println("-- Horizontal dependency lists:");
+            System.out.println("----------------------------------");
+            for (WidgetGroup list : allDependencyLists) {
+                if (list.getOrientation() != VERTICAL) {
+                    System.out.println("list: " + list);
+                }
+            }
+            System.out.println("----------------------------------");
+            System.out.println("-- Vertical dependency lists:");
+            System.out.println("----------------------------------");
+            for (WidgetGroup list : allDependencyLists) {
+                if (list.getOrientation() != HORIZONTAL) {
+                    System.out.println("list: " + list);
+                }
+            }
+            System.out.println("----------------------------------");
+        }
+
+        WidgetGroup horizontalPick = null;
+        WidgetGroup verticalPick = null;
+
+        if (layout.getHorizontalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+            int maxWrap = 0;
+            WidgetGroup picked = null;
+            for (WidgetGroup list : allDependencyLists) {
+                if (list.getOrientation() == VERTICAL) {
+                    continue;
+                }
+                list.setAuthoritative(false);
+                int wrap = list.measureWrap(layout.getSystem(), HORIZONTAL);
+                if (wrap > maxWrap) {
+                    picked = list;
+                    maxWrap = wrap;
+                }
+                if (DEBUG) {
+                    System.out.println("list: " + list + " => " + wrap);
+                }
+            }
+            if (picked != null) {
+                if (DEBUG) {
+                    System.out.println("Horizontal MaxWrap : " + maxWrap + " with group " + picked);
+                }
+                layout.setHorizontalDimensionBehaviour(ConstraintWidget.DimensionBehaviour.FIXED);
+                layout.setWidth(maxWrap);
+                picked.setAuthoritative(true);
+                horizontalPick = picked;
+            }
+        }
+
+        if (layout.getVerticalDimensionBehaviour()
+                == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+            int maxWrap = 0;
+            WidgetGroup picked = null;
+            for (WidgetGroup list : allDependencyLists) {
+                if (list.getOrientation() == HORIZONTAL) {
+                    continue;
+                }
+                list.setAuthoritative(false);
+                int wrap = list.measureWrap(layout.getSystem(), VERTICAL);
+                if (wrap > maxWrap) {
+                    picked = list;
+                    maxWrap = wrap;
+                }
+                if (DEBUG) {
+                    System.out.println("      " + list + " => " + wrap);
+                }
+            }
+            if (picked != null) {
+                if (DEBUG) {
+                    System.out.println("Vertical MaxWrap : " + maxWrap + " with group " + picked);
+                }
+                layout.setVerticalDimensionBehaviour(ConstraintWidget.DimensionBehaviour.FIXED);
+                layout.setHeight(maxWrap);
+                picked.setAuthoritative(true);
+                verticalPick = picked;
+            }
+        }
+        return horizontalPick != null || verticalPick != null;
+    }
+
+    private static WidgetGroup findGroup(ArrayList<WidgetGroup> horizontalDependencyLists,
+            int groupId) {
+        final int count = horizontalDependencyLists.size();
+        for (int i = 0; i < count; i++) {
+            WidgetGroup group = horizontalDependencyLists.get(i);
+            if (groupId == group.getId()) {
+                return group;
+            }
+        }
+        return null;
+    }
+
+    // @TODO: add description
+    public static WidgetGroup findDependents(ConstraintWidget constraintWidget,
+            int orientation,
+            ArrayList<WidgetGroup> list,
+            WidgetGroup group) {
+        int groupId = -1;
+        if (orientation == ConstraintWidget.HORIZONTAL) {
+            groupId = constraintWidget.horizontalGroup;
+        } else {
+            groupId = constraintWidget.verticalGroup;
+        }
+        if (DEBUG_GROUPING) {
+            System.out.println("--- find " + (orientation == HORIZONTAL ? "Horiz" : "Vert")
+                    + " dependents of " + constraintWidget.getDebugName()
+                    + " group " + group + " widget group id " + groupId);
+        }
+        if (groupId != -1 && (group == null || (groupId != group.getId()))) {
+            // already in a group!
+            if (DEBUG_GROUPING) {
+                System.out.println("widget " + constraintWidget.getDebugName()
+                        + " already in group " + groupId + " group: " + group);
+            }
+            for (int i = 0; i < list.size(); i++) {
+                WidgetGroup widgetGroup = list.get(i);
+                if (widgetGroup.getId() == groupId) {
+                    if (group != null) {
+                        if (DEBUG_GROUPING) {
+                            System.out.println("Move group " + group + " to " + widgetGroup);
+                        }
+                        group.moveTo(orientation, widgetGroup);
+                        list.remove(group);
+                    }
+                    group = widgetGroup;
+                    break;
+                }
+            }
+        } else if (groupId != -1) {
+            return group;
+        }
+        if (group == null) {
+            if (constraintWidget instanceof HelperWidget) {
+                HelperWidget helper = (HelperWidget) constraintWidget;
+                groupId = helper.findGroupInDependents(orientation);
+                if (groupId != -1) {
+                    for (int i = 0; i < list.size(); i++) {
+                        WidgetGroup widgetGroup = list.get(i);
+                        if (widgetGroup.getId() == groupId) {
+                            group = widgetGroup;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (group == null) {
+                group = new WidgetGroup(orientation);
+            }
+            if (DEBUG_GROUPING) {
+                System.out.println("Create group " + group
+                        + " for widget " + constraintWidget.getDebugName());
+            }
+            list.add(group);
+        }
+        if (group.add(constraintWidget)) {
+            if (constraintWidget instanceof Guideline) {
+                Guideline guideline = (Guideline) constraintWidget;
+                guideline.getAnchor().findDependents(guideline.getOrientation()
+                        == Guideline.HORIZONTAL ? VERTICAL : HORIZONTAL, list, group);
+            }
+            if (orientation == ConstraintWidget.HORIZONTAL) {
+                constraintWidget.horizontalGroup = group.getId();
+                if (DEBUG_GROUPING) {
+                    System.out.println("Widget " + constraintWidget.getDebugName()
+                            + " H group is " + constraintWidget.horizontalGroup);
+                }
+                constraintWidget.mLeft.findDependents(orientation, list, group);
+                constraintWidget.mRight.findDependents(orientation, list, group);
+            } else {
+                constraintWidget.verticalGroup = group.getId();
+                if (DEBUG_GROUPING) {
+                    System.out.println("Widget " + constraintWidget.getDebugName()
+                            + " V group is " + constraintWidget.verticalGroup);
+                }
+                constraintWidget.mTop.findDependents(orientation, list, group);
+                constraintWidget.mBaseline.findDependents(orientation, list, group);
+                constraintWidget.mBottom.findDependents(orientation, list, group);
+            }
+            constraintWidget.mCenter.findDependents(orientation, list, group);
+        }
+        return group;
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/GuidelineReference.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/GuidelineReference.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.Guideline;
+
+class GuidelineReference extends WidgetRun {
+
+    GuidelineReference(ConstraintWidget widget) {
+        super(widget);
+        widget.mHorizontalRun.clear();
+        widget.mVerticalRun.clear();
+        this.orientation = ((Guideline) widget).getOrientation();
+    }
+
+    @Override
+    void clear() {
+        start.clear();
+    }
+
+    @Override
+    void reset() {
+        start.resolved = false;
+        end.resolved = false;
+    }
+
+    @Override
+    boolean supportsWrapComputation() {
+        return false;
+    }
+
+    private void addDependency(
+            androidx.constraintlayout.core.widgets.analyzer.DependencyNode node) {
+        start.mDependencies.add(node);
+        node.mTargets.add(start);
+    }
+
+    @Override
+    public void update(Dependency dependency) {
+        if (!start.readyToSolve) {
+            return;
+        }
+        if (start.resolved) {
+            return;
+        }
+        // ready to solve, centering.
+        androidx.constraintlayout.core.widgets.analyzer.DependencyNode startTarget =
+                start.mTargets.get(0);
+        Guideline guideline = (Guideline) mWidget;
+        int startPos = (int) (0.5f + startTarget.value * guideline.getRelativePercent());
+        start.resolve(startPos);
+    }
+
+    @Override
+    void apply() {
+        Guideline guideline = (Guideline) mWidget;
+        int relativeBegin = guideline.getRelativeBegin();
+        int relativeEnd = guideline.getRelativeEnd();
+        @SuppressWarnings("unused") float percent = guideline.getRelativePercent();
+        if (guideline.getOrientation() == ConstraintWidget.VERTICAL) {
+            if (relativeBegin != -1) {
+                start.mTargets.add(mWidget.mParent.mHorizontalRun.start);
+                mWidget.mParent.mHorizontalRun.start.mDependencies.add(start);
+                start.mMargin = relativeBegin;
+            } else if (relativeEnd != -1) {
+                start.mTargets.add(mWidget.mParent.mHorizontalRun.end);
+                mWidget.mParent.mHorizontalRun.end.mDependencies.add(start);
+                start.mMargin = -relativeEnd;
+            } else {
+                start.delegateToWidgetRun = true;
+                start.mTargets.add(mWidget.mParent.mHorizontalRun.end);
+                mWidget.mParent.mHorizontalRun.end.mDependencies.add(start);
+            }
+            // FIXME -- if we move the DependencyNode directly
+            //              in the ConstraintAnchor we'll be good.
+            addDependency(mWidget.mHorizontalRun.start);
+            addDependency(mWidget.mHorizontalRun.end);
+        } else {
+            if (relativeBegin != -1) {
+                start.mTargets.add(mWidget.mParent.mVerticalRun.start);
+                mWidget.mParent.mVerticalRun.start.mDependencies.add(start);
+                start.mMargin = relativeBegin;
+            } else if (relativeEnd != -1) {
+                start.mTargets.add(mWidget.mParent.mVerticalRun.end);
+                mWidget.mParent.mVerticalRun.end.mDependencies.add(start);
+                start.mMargin = -relativeEnd;
+            } else {
+                start.delegateToWidgetRun = true;
+                start.mTargets.add(mWidget.mParent.mVerticalRun.end);
+                mWidget.mParent.mVerticalRun.end.mDependencies.add(start);
+            }
+            // FIXME -- if we move the DependencyNode directly
+            //              in the ConstraintAnchor we'll be good.
+            addDependency(mWidget.mVerticalRun.start);
+            addDependency(mWidget.mVerticalRun.end);
+        }
+    }
+
+    @Override
+    public void applyToWidget() {
+        Guideline guideline = (Guideline) mWidget;
+        if (guideline.getOrientation() == ConstraintWidget.VERTICAL) {
+            mWidget.setX(start.value);
+        } else {
+            mWidget.setY(start.value);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/HelperReferences.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/HelperReferences.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import androidx.constraintlayout.core.widgets.Barrier;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+class HelperReferences extends WidgetRun {
+    HelperReferences(ConstraintWidget widget) {
+        super(widget);
+    }
+
+    @Override
+    void clear() {
+        mRunGroup = null;
+        start.clear();
+    }
+
+    @Override
+    void reset() {
+        start.resolved = false;
+    }
+
+    @Override
+    boolean supportsWrapComputation() {
+        return false;
+    }
+
+    private void addDependency(DependencyNode node) {
+        start.mDependencies.add(node);
+        node.mTargets.add(start);
+    }
+
+    @Override
+    void apply() {
+        if (mWidget instanceof Barrier) {
+            start.delegateToWidgetRun = true;
+            Barrier barrier = (Barrier) mWidget;
+            int type = barrier.getBarrierType();
+            boolean allowsGoneWidget = barrier.getAllowsGoneWidget();
+            switch (type) {
+                case Barrier.LEFT: {
+                    start.mType = DependencyNode.Type.LEFT;
+                    for (int i = 0; i < barrier.mWidgetsCount; i++) {
+                        ConstraintWidget refWidget = barrier.mWidgets[i];
+                        if (!allowsGoneWidget
+                                && refWidget.getVisibility() == ConstraintWidget.GONE) {
+                            continue;
+                        }
+                        DependencyNode target = refWidget.mHorizontalRun.start;
+                        target.mDependencies.add(start);
+                        start.mTargets.add(target);
+                        // FIXME -- if we move the DependencyNode directly
+                        //          in the ConstraintAnchor we'll be good.
+                    }
+                    addDependency(mWidget.mHorizontalRun.start);
+                    addDependency(mWidget.mHorizontalRun.end);
+                }
+                break;
+                case Barrier.RIGHT: {
+                    start.mType = DependencyNode.Type.RIGHT;
+                    for (int i = 0; i < barrier.mWidgetsCount; i++) {
+                        ConstraintWidget refWidget = barrier.mWidgets[i];
+                        if (!allowsGoneWidget
+                                && refWidget.getVisibility() == ConstraintWidget.GONE) {
+                            continue;
+                        }
+                        DependencyNode target = refWidget.mHorizontalRun.end;
+                        target.mDependencies.add(start);
+                        start.mTargets.add(target);
+                        // FIXME -- if we move the DependencyNode directly
+                        //              in the ConstraintAnchor we'll be good.
+                    }
+                    addDependency(mWidget.mHorizontalRun.start);
+                    addDependency(mWidget.mHorizontalRun.end);
+                }
+                break;
+                case Barrier.TOP: {
+                    start.mType = DependencyNode.Type.TOP;
+                    for (int i = 0; i < barrier.mWidgetsCount; i++) {
+                        ConstraintWidget refwidget = barrier.mWidgets[i];
+                        if (!allowsGoneWidget
+                                && refwidget.getVisibility() == ConstraintWidget.GONE) {
+                            continue;
+                        }
+                        DependencyNode target = refwidget.mVerticalRun.start;
+                        target.mDependencies.add(start);
+                        start.mTargets.add(target);
+                        // FIXME -- if we move the DependencyNode directly
+                        //              in the ConstraintAnchor we'll be good.
+                    }
+                    addDependency(mWidget.mVerticalRun.start);
+                    addDependency(mWidget.mVerticalRun.end);
+                }
+                break;
+                case Barrier.BOTTOM: {
+                    start.mType = DependencyNode.Type.BOTTOM;
+                    for (int i = 0; i < barrier.mWidgetsCount; i++) {
+                        ConstraintWidget refwidget = barrier.mWidgets[i];
+                        if (!allowsGoneWidget
+                                && refwidget.getVisibility() == ConstraintWidget.GONE) {
+                            continue;
+                        }
+                        DependencyNode target = refwidget.mVerticalRun.end;
+                        target.mDependencies.add(start);
+                        start.mTargets.add(target);
+                        // FIXME -- if we move the DependencyNode directly
+                        //              in the ConstraintAnchor we'll be good.
+                    }
+                    addDependency(mWidget.mVerticalRun.start);
+                    addDependency(mWidget.mVerticalRun.end);
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void update(Dependency dependency) {
+        Barrier barrier = (Barrier) mWidget;
+        int type = barrier.getBarrierType();
+
+        int min = -1;
+        int max = 0;
+        for (DependencyNode node : start.mTargets) {
+            int value = node.value;
+            if (min == -1 || value < min) {
+                min = value;
+            }
+            if (max < value) {
+                max = value;
+            }
+        }
+        if (type == Barrier.LEFT || type == Barrier.TOP) {
+            start.resolve(min + barrier.getMargin());
+        } else {
+            start.resolve(max + barrier.getMargin());
+        }
+    }
+
+    @Override
+    public void applyToWidget() {
+        if (mWidget instanceof Barrier) {
+            Barrier barrier = (Barrier) mWidget;
+            int type = barrier.getBarrierType();
+            if (type == Barrier.LEFT
+                    || type == Barrier.RIGHT) {
+                mWidget.setX(start.value);
+            } else {
+                mWidget.setY(start.value);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/HorizontalWidgetRun.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/HorizontalWidgetRun.java
@@ -1,0 +1,617 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.FIXED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_PARENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_RATIO;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+import static androidx.constraintlayout.core.widgets.analyzer.WidgetRun.RunType.CENTER;
+
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.Helper;
+
+public class HorizontalWidgetRun extends WidgetRun {
+
+    private static int[] sTempDimensions = new int[2];
+
+    public HorizontalWidgetRun(ConstraintWidget widget) {
+        super(widget);
+        start.mType = DependencyNode.Type.LEFT;
+        end.mType = DependencyNode.Type.RIGHT;
+        this.orientation = HORIZONTAL;
+    }
+
+    @Override
+    public String toString() {
+        return "HorizontalRun " + mWidget.getDebugName();
+    }
+
+    @Override
+    void clear() {
+        mRunGroup = null;
+        start.clear();
+        end.clear();
+        mDimension.clear();
+        mResolved = false;
+    }
+
+    @Override
+    void reset() {
+        mResolved = false;
+        start.clear();
+        start.resolved = false;
+        end.clear();
+        end.resolved = false;
+        mDimension.resolved = false;
+    }
+
+    @Override
+    boolean supportsWrapComputation() {
+        if (super.mDimensionBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+            if (super.mWidget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    void apply() {
+        if (mWidget.measured) {
+            mDimension.resolve(mWidget.getWidth());
+        }
+        if (!mDimension.resolved) {
+            super.mDimensionBehavior = mWidget.getHorizontalDimensionBehaviour();
+            if (super.mDimensionBehavior != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+                if (mDimensionBehavior == MATCH_PARENT) {
+                    ConstraintWidget parent = mWidget.getParent();
+                    if (parent != null
+                            && (parent.getHorizontalDimensionBehaviour() == FIXED
+                            || parent.getHorizontalDimensionBehaviour() == MATCH_PARENT)) {
+                        int resolvedDimension = parent.getWidth()
+                                - mWidget.mLeft.getMargin() - mWidget.mRight.getMargin();
+                        addTarget(start, parent.mHorizontalRun.start, mWidget.mLeft.getMargin());
+                        addTarget(end, parent.mHorizontalRun.end, -mWidget.mRight.getMargin());
+                        mDimension.resolve(resolvedDimension);
+                        return;
+                    }
+                }
+                if (mDimensionBehavior == FIXED) {
+                    mDimension.resolve(mWidget.getWidth());
+                }
+            }
+        } else {
+            if (mDimensionBehavior == MATCH_PARENT) {
+                ConstraintWidget parent = mWidget.getParent();
+                if (parent != null
+                        && (parent.getHorizontalDimensionBehaviour() == FIXED
+                        || parent.getHorizontalDimensionBehaviour() == MATCH_PARENT)) {
+                    addTarget(start, parent.mHorizontalRun.start, mWidget.mLeft.getMargin());
+                    addTarget(end, parent.mHorizontalRun.end, -mWidget.mRight.getMargin());
+                    return;
+                }
+            }
+        }
+
+        // three basic possibilities:
+        // <-s-e->
+        // <-s-e
+        //   s-e->
+        // and a variation if the dimension is not yet known:
+        // <-s-d-e->
+        // <-s<-d<-e
+        //   s->d->e->
+
+        if (mDimension.resolved && mWidget.measured) {
+            if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].mTarget != null
+                    && mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].mTarget
+                    != null) { // <-s-e->
+                if (mWidget.isInHorizontalChain()) {
+                    start.mMargin = mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin();
+                    end.mMargin = -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].getMargin();
+                } else {
+                    DependencyNode startTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT]);
+                    if (startTarget != null) {
+                        addTarget(start, startTarget,
+                                mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin());
+                    }
+                    DependencyNode endTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT]);
+                    if (endTarget != null) {
+                        addTarget(end, endTarget,
+                                -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].getMargin());
+                    }
+                    start.delegateToWidgetRun = true;
+                    end.delegateToWidgetRun = true;
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].mTarget
+                    != null) { // <-s-e
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT]);
+                if (target != null) {
+                    addTarget(start, target,
+                            mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin());
+                    addTarget(end, start, mDimension.value);
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].mTarget
+                    != null) {   //   s-e->
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT]);
+                if (target != null) {
+                    addTarget(end, target,
+                            -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].getMargin());
+                    addTarget(start, end, -mDimension.value);
+                }
+            } else {
+                // no connections, nothing to do.
+                if (!(mWidget instanceof Helper) && mWidget.getParent() != null
+                        && mWidget.getAnchor(ConstraintAnchor.Type.CENTER).mTarget == null) {
+                    DependencyNode left = mWidget.getParent().mHorizontalRun.start;
+                    addTarget(start, left, mWidget.getX());
+                    addTarget(end, start, mDimension.value);
+                }
+            }
+        } else {
+            if (mDimensionBehavior == MATCH_CONSTRAINT) {
+                switch (mWidget.mMatchConstraintDefaultWidth) {
+                    case MATCH_CONSTRAINT_RATIO: {
+                        if (mWidget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_RATIO
+                        ) {
+                            // need to look into both side
+                            start.updateDelegate = this;
+                            end.updateDelegate = this;
+                            mWidget.mVerticalRun.start.updateDelegate = this;
+                            mWidget.mVerticalRun.end.updateDelegate = this;
+                            mDimension.updateDelegate = this;
+
+                            if (mWidget.isInVerticalChain()) {
+                                mDimension.mTargets.add(mWidget.mVerticalRun.mDimension);
+                                mWidget.mVerticalRun.mDimension.mDependencies.add(mDimension);
+                                mWidget.mVerticalRun.mDimension.updateDelegate = this;
+                                mDimension.mTargets.add(mWidget.mVerticalRun.start);
+                                mDimension.mTargets.add(mWidget.mVerticalRun.end);
+                                mWidget.mVerticalRun.start.mDependencies.add(mDimension);
+                                mWidget.mVerticalRun.end.mDependencies.add(mDimension);
+                            } else if (mWidget.isInHorizontalChain()) {
+                                mWidget.mVerticalRun.mDimension.mTargets.add(mDimension);
+                                mDimension.mDependencies.add(mWidget.mVerticalRun.mDimension);
+                            } else {
+                                mWidget.mVerticalRun.mDimension.mTargets.add(mDimension);
+                            }
+                            break;
+                        }
+                        // we have a ratio, but we depend on the other side computation
+                        DependencyNode targetDimension = mWidget.mVerticalRun.mDimension;
+                        mDimension.mTargets.add(targetDimension);
+                        targetDimension.mDependencies.add(mDimension);
+                        mWidget.mVerticalRun.start.mDependencies.add(mDimension);
+                        mWidget.mVerticalRun.end.mDependencies.add(mDimension);
+                        mDimension.delegateToWidgetRun = true;
+                        mDimension.mDependencies.add(start);
+                        mDimension.mDependencies.add(end);
+                        start.mTargets.add(mDimension);
+                        end.mTargets.add(mDimension);
+                    }
+                    break;
+                    case MATCH_CONSTRAINT_PERCENT: {
+                        // we need to look up the parent dimension
+                        ConstraintWidget parent = mWidget.getParent();
+                        if (parent == null) {
+                            break;
+                        }
+                        DependencyNode targetDimension = parent.mVerticalRun.mDimension;
+                        mDimension.mTargets.add(targetDimension);
+                        targetDimension.mDependencies.add(mDimension);
+                        mDimension.delegateToWidgetRun = true;
+                        mDimension.mDependencies.add(start);
+                        mDimension.mDependencies.add(end);
+                    }
+                    break;
+                    case MATCH_CONSTRAINT_SPREAD: {
+                        // the work is done in the update()
+                    }
+                    break;
+                    default:
+                        break;
+                }
+            }
+            if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].mTarget != null
+                    && mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].mTarget
+                    != null) { // <-s-d-e->
+
+                if (mWidget.isInHorizontalChain()) {
+                    start.mMargin = mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin();
+                    end.mMargin = -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].getMargin();
+                } else {
+                    DependencyNode startTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT]);
+                    DependencyNode endTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT]);
+                    if (false) {
+                        if (startTarget != null) {
+                            addTarget(start, startTarget,
+                                    mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin());
+                        }
+                        if (endTarget != null) {
+                            addTarget(end, endTarget,
+                                    -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT]
+                                            .getMargin());
+                        }
+                    } else {
+                        if (startTarget != null) {
+                            startTarget.addDependency(this);
+                        }
+                        if (endTarget != null) {
+                            endTarget.addDependency(this);
+                        }
+                    }
+                    mRunType = CENTER;
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].mTarget
+                    != null) { // <-s<-d<-e
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT]);
+                if (target != null) {
+                    addTarget(start, target,
+                            mWidget.mListAnchors[ConstraintWidget.ANCHOR_LEFT].getMargin());
+                    addTarget(end, start, 1, mDimension);
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].mTarget
+                    != null) {   //   s->d->e->
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT]);
+                if (target != null) {
+                    addTarget(end, target,
+                            -mWidget.mListAnchors[ConstraintWidget.ANCHOR_RIGHT].getMargin());
+                    addTarget(start, end, -1, mDimension);
+                }
+            } else {
+                // no connections, nothing to do.
+                if (!(mWidget instanceof Helper) && mWidget.getParent() != null) {
+                    DependencyNode left = mWidget.getParent().mHorizontalRun.start;
+                    addTarget(start, left, mWidget.getX());
+                    addTarget(end, start, 1, mDimension);
+                }
+            }
+        }
+    }
+
+    private void computeInsetRatio(int[] dimensions,
+            int x1,
+            int x2,
+            int y1,
+            int y2,
+            float ratio,
+            int side) {
+        int dx = x2 - x1;
+        int dy = y2 - y1;
+        switch (side) {
+            case UNKNOWN: {
+                int candidateX1 = (int) (0.5f + dy * ratio);
+                int candidateY1 = dy;
+                int candidateX2 = dx;
+                int candidateY2 = (int) (0.5f + dx / ratio);
+                if (candidateX1 <= dx && candidateY1 <= dy) {
+                    dimensions[HORIZONTAL] = candidateX1;
+                    dimensions[VERTICAL] = candidateY1;
+                } else if (candidateX2 <= dx && candidateY2 <= dy) {
+                    dimensions[HORIZONTAL] = candidateX2;
+                    dimensions[VERTICAL] = candidateY2;
+                }
+            }
+            break;
+            case HORIZONTAL: {
+                int horizontalSide = (int) (0.5f + dy * ratio);
+                dimensions[HORIZONTAL] = horizontalSide;
+                dimensions[VERTICAL] = dy;
+            }
+            break;
+            case VERTICAL: {
+                int verticalSide = (int) (0.5f + dx * ratio);
+                dimensions[HORIZONTAL] = dx;
+                dimensions[VERTICAL] = verticalSide;
+            }
+            break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void update(Dependency dependency) {
+        switch (mRunType) {
+            case START: {
+                updateRunStart(dependency);
+            }
+            break;
+            case END: {
+                updateRunEnd(dependency);
+            }
+            break;
+            case CENTER: {
+                updateRunCenter(dependency, mWidget.mLeft, mWidget.mRight, HORIZONTAL);
+                return;
+            }
+            default:
+                break;
+        }
+
+        if (!mDimension.resolved) {
+            if (mDimensionBehavior == MATCH_CONSTRAINT) {
+                switch (mWidget.mMatchConstraintDefaultWidth) {
+                    case MATCH_CONSTRAINT_RATIO: {
+                        if (mWidget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD
+                                || mWidget.mMatchConstraintDefaultHeight
+                                == MATCH_CONSTRAINT_RATIO) {
+                            DependencyNode secondStart = mWidget.mVerticalRun.start;
+                            DependencyNode secondEnd = mWidget.mVerticalRun.end;
+                            boolean s1 = mWidget.mLeft.mTarget != null;
+                            boolean s2 = mWidget.mTop.mTarget != null;
+                            boolean e1 = mWidget.mRight.mTarget != null;
+                            boolean e2 = mWidget.mBottom.mTarget != null;
+
+                            int definedSide = mWidget.getDimensionRatioSide();
+
+                            if (s1 && s2 && e1 && e2) {
+                                float ratio = mWidget.getDimensionRatio();
+                                if (secondStart.resolved && secondEnd.resolved) {
+                                    if (!(start.readyToSolve && end.readyToSolve)) {
+                                        return;
+                                    }
+                                    int x1 = start.mTargets.get(0).value + start.mMargin;
+                                    int x2 = end.mTargets.get(0).value - end.mMargin;
+                                    int y1 = secondStart.value + secondStart.mMargin;
+                                    int y2 = secondEnd.value - secondEnd.mMargin;
+                                    computeInsetRatio(sTempDimensions,
+                                            x1, x2, y1, y2, ratio, definedSide);
+                                    mDimension.resolve(sTempDimensions[HORIZONTAL]);
+                                    mWidget.mVerticalRun.mDimension
+                                            .resolve(sTempDimensions[VERTICAL]);
+                                    return;
+                                }
+                                if (start.resolved && end.resolved) {
+                                    if (!(secondStart.readyToSolve && secondEnd.readyToSolve)) {
+                                        return;
+                                    }
+                                    int x1 = start.value + start.mMargin;
+                                    int x2 = end.value - end.mMargin;
+                                    int y1 = secondStart.mTargets.get(0).value
+                                            + secondStart.mMargin;
+                                    int y2 = secondEnd.mTargets.get(0).value - secondEnd.mMargin;
+                                    computeInsetRatio(sTempDimensions,
+                                            x1, x2, y1, y2, ratio, definedSide);
+                                    mDimension.resolve(sTempDimensions[HORIZONTAL]);
+                                    mWidget.mVerticalRun.mDimension
+                                            .resolve(sTempDimensions[VERTICAL]);
+                                }
+                                if (!(start.readyToSolve && end.readyToSolve
+                                        && secondStart.readyToSolve
+                                        && secondEnd.readyToSolve)) {
+                                    return;
+                                }
+                                int x1 = start.mTargets.get(0).value + start.mMargin;
+                                int x2 = end.mTargets.get(0).value - end.mMargin;
+                                int y1 = secondStart.mTargets.get(0).value + secondStart.mMargin;
+                                int y2 = secondEnd.mTargets.get(0).value - secondEnd.mMargin;
+                                computeInsetRatio(sTempDimensions,
+                                        x1, x2, y1, y2, ratio, definedSide);
+                                mDimension.resolve(sTempDimensions[HORIZONTAL]);
+                                mWidget.mVerticalRun.mDimension.resolve(sTempDimensions[VERTICAL]);
+                            } else if (s1 && e1) {
+                                if (!(start.readyToSolve && end.readyToSolve)) {
+                                    return;
+                                }
+                                float ratio = mWidget.getDimensionRatio();
+                                int x1 = start.mTargets.get(0).value + start.mMargin;
+                                int x2 = end.mTargets.get(0).value - end.mMargin;
+
+                                switch (definedSide) {
+                                    case UNKNOWN:
+                                    case HORIZONTAL: {
+                                        int dx = x2 - x1;
+                                        int ldx = getLimitedDimension(dx, HORIZONTAL);
+                                        int dy = (int) (0.5f + ldx * ratio);
+                                        int ldy = getLimitedDimension(dy, VERTICAL);
+                                        if (dy != ldy) {
+                                            ldx = (int) (0.5f + ldy / ratio);
+                                        }
+                                        mDimension.resolve(ldx);
+                                        mWidget.mVerticalRun.mDimension.resolve(ldy);
+                                    }
+                                    break;
+                                    case VERTICAL: {
+                                        int dx = x2 - x1;
+                                        int ldx = getLimitedDimension(dx, HORIZONTAL);
+                                        int dy = (int) (0.5f + ldx / ratio);
+                                        int ldy = getLimitedDimension(dy, VERTICAL);
+                                        if (dy != ldy) {
+                                            ldx = (int) (0.5f + ldy * ratio);
+                                        }
+                                        mDimension.resolve(ldx);
+                                        mWidget.mVerticalRun.mDimension.resolve(ldy);
+                                    }
+                                    break;
+                                    default:
+                                        break;
+                                }
+                            } else if (s2 && e2) {
+                                if (!(secondStart.readyToSolve && secondEnd.readyToSolve)) {
+                                    return;
+                                }
+                                float ratio = mWidget.getDimensionRatio();
+                                int y1 = secondStart.mTargets.get(0).value + secondStart.mMargin;
+                                int y2 = secondEnd.mTargets.get(0).value - secondEnd.mMargin;
+
+                                switch (definedSide) {
+                                    case UNKNOWN:
+                                    case VERTICAL: {
+                                        int dy = y2 - y1;
+                                        int ldy = getLimitedDimension(dy, VERTICAL);
+                                        int dx = (int) (0.5f + ldy / ratio);
+                                        int ldx = getLimitedDimension(dx, HORIZONTAL);
+                                        if (dx != ldx) {
+                                            ldy = (int) (0.5f + ldx * ratio);
+                                        }
+                                        mDimension.resolve(ldx);
+                                        mWidget.mVerticalRun.mDimension.resolve(ldy);
+                                    }
+                                    break;
+                                    case HORIZONTAL: {
+                                        int dy = y2 - y1;
+                                        int ldy = getLimitedDimension(dy, VERTICAL);
+                                        int dx = (int) (0.5f + ldy * ratio);
+                                        int ldx = getLimitedDimension(dx, HORIZONTAL);
+                                        if (dx != ldx) {
+                                            ldy = (int) (0.5f + ldx / ratio);
+                                        }
+                                        mDimension.resolve(ldx);
+                                        mWidget.mVerticalRun.mDimension.resolve(ldy);
+                                    }
+                                    break;
+                                    default:
+                                        break;
+                                }
+                            }
+                        } else {
+                            int size = 0;
+                            int ratioSide = mWidget.getDimensionRatioSide();
+                            switch (ratioSide) {
+                                case HORIZONTAL: {
+                                    size = (int) (0.5f + mWidget.mVerticalRun.mDimension.value
+                                            / mWidget.getDimensionRatio());
+                                }
+                                break;
+                                case ConstraintWidget.VERTICAL: {
+                                    size = (int) (0.5f + mWidget.mVerticalRun.mDimension.value
+                                            * mWidget.getDimensionRatio());
+                                }
+                                break;
+                                case ConstraintWidget.UNKNOWN: {
+                                    size = (int) (0.5f + mWidget.mVerticalRun.mDimension.value
+                                            * mWidget.getDimensionRatio());
+                                }
+                                break;
+                                default:
+                                    break;
+                            }
+                            mDimension.resolve(size);
+                        }
+                    }
+                    break;
+                    case MATCH_CONSTRAINT_PERCENT: {
+                        ConstraintWidget parent = mWidget.getParent();
+                        if (parent != null) {
+                            if (parent.mHorizontalRun.mDimension.resolved) {
+                                float percent = mWidget.mMatchConstraintPercentWidth;
+                                int targetDimensionValue = parent.mHorizontalRun.mDimension.value;
+                                int size = (int) (0.5f + targetDimensionValue * percent);
+                                mDimension.resolve(size);
+                            }
+                        }
+                    }
+                    break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        if (!(start.readyToSolve && end.readyToSolve)) {
+            return;
+        }
+
+        if (start.resolved && end.resolved && mDimension.resolved) {
+            return;
+        }
+
+        if (!mDimension.resolved
+                && mDimensionBehavior == MATCH_CONSTRAINT
+                && mWidget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD
+                && !mWidget.isInHorizontalChain()) {
+
+            DependencyNode startTarget = start.mTargets.get(0);
+            DependencyNode endTarget = end.mTargets.get(0);
+            int startPos = startTarget.value + start.mMargin;
+            int endPos = endTarget.value + end.mMargin;
+
+            int distance = endPos - startPos;
+            start.resolve(startPos);
+            end.resolve(endPos);
+            mDimension.resolve(distance);
+            return;
+        }
+
+        if (!mDimension.resolved
+                && mDimensionBehavior == MATCH_CONSTRAINT
+                && matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+            if (start.mTargets.size() > 0 && end.mTargets.size() > 0) {
+                DependencyNode startTarget = start.mTargets.get(0);
+                DependencyNode endTarget = end.mTargets.get(0);
+                int startPos = startTarget.value + start.mMargin;
+                int endPos = endTarget.value + end.mMargin;
+                int availableSpace = endPos - startPos;
+                int value = Math.min(availableSpace, mDimension.wrapValue);
+                int max = mWidget.mMatchConstraintMaxWidth;
+                int min = mWidget.mMatchConstraintMinWidth;
+                value = Math.max(min, value);
+                if (max > 0) {
+                    value = Math.min(max, value);
+                }
+                mDimension.resolve(value);
+            }
+        }
+
+        if (!mDimension.resolved) {
+            return;
+        }
+        // ready to solve, centering.
+        DependencyNode startTarget = start.mTargets.get(0);
+        DependencyNode endTarget = end.mTargets.get(0);
+        int startPos = startTarget.value + start.mMargin;
+        int endPos = endTarget.value + end.mMargin;
+        float bias = mWidget.getHorizontalBiasPercent();
+        if (startTarget == endTarget) {
+            startPos = startTarget.value;
+            endPos = endTarget.value;
+            // TODO: this might be a nice feature to support, but I guess for now let's stay
+            // compatible with 1.1
+            bias = 0.5f;
+        }
+        int distance = (endPos - startPos - mDimension.value);
+        start.resolve((int) (0.5f + startPos + distance * bias));
+        end.resolve(start.value + mDimension.value);
+    }
+
+    // @TODO: add description
+    @Override
+    public void applyToWidget() {
+        if (start.resolved) {
+            mWidget.setX(start.value);
+        }
+    }
+
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/RunGroup.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/RunGroup.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+
+import java.util.ArrayList;
+
+class RunGroup {
+    public static final int START = 0;
+    public static final int END = 1;
+    public static final int BASELINE = 2;
+
+    public static int index;
+
+    public int position = 0;
+    public boolean dual = false;
+
+    WidgetRun mFirstRun = null;
+    WidgetRun mLastRun = null;
+    ArrayList<WidgetRun> mRuns = new ArrayList<>();
+
+    int mGroupIndex = 0;
+    int mDirection;
+
+    RunGroup(WidgetRun run, int dir) {
+        mGroupIndex = index;
+        index++;
+        mFirstRun = run;
+        mLastRun = run;
+        mDirection = dir;
+    }
+
+    public void add(WidgetRun run) {
+        mRuns.add(run);
+        mLastRun = run;
+    }
+
+    private long traverseStart(DependencyNode node, long startPosition) {
+        WidgetRun run = node.mRun;
+        if (run instanceof HelperReferences) {
+            return startPosition;
+        }
+        long position = startPosition;
+
+        // first, compute stuff dependent on this node.
+
+        final int count = node.mDependencies.size();
+        for (int i = 0; i < count; i++) {
+            Dependency dependency = node.mDependencies.get(i);
+            if (dependency instanceof DependencyNode) {
+                DependencyNode nextNode = (DependencyNode) dependency;
+                if (nextNode.mRun == run) {
+                    // skip our own sibling node
+                    continue;
+                }
+                position = Math.max(position,
+                        traverseStart(nextNode, startPosition + nextNode.mMargin));
+            }
+        }
+
+        if (node == run.start) {
+            // let's go for our sibling
+            long dimension = run.getWrapDimension();
+            position = Math.max(position, traverseStart(run.end, startPosition + dimension));
+            position = Math.max(position, startPosition + dimension - run.end.mMargin);
+        }
+
+        return position;
+    }
+
+    private long traverseEnd(DependencyNode node, long startPosition) {
+        WidgetRun run = node.mRun;
+        if (run instanceof HelperReferences) {
+            return startPosition;
+        }
+        long position = startPosition;
+
+        // first, compute stuff dependent on this node.
+
+        final int count = node.mDependencies.size();
+        for (int i = 0; i < count; i++) {
+            Dependency dependency = node.mDependencies.get(i);
+            if (dependency instanceof DependencyNode) {
+                DependencyNode nextNode = (DependencyNode) dependency;
+                if (nextNode.mRun == run) {
+                    // skip our own sibling node
+                    continue;
+                }
+                position = Math.min(position,
+                        traverseEnd(nextNode, startPosition + nextNode.mMargin));
+            }
+        }
+
+        if (node == run.end) {
+            // let's go for our sibling
+            long dimension = run.getWrapDimension();
+            position = Math.min(position, traverseEnd(run.start, startPosition - dimension));
+            position = Math.min(position, startPosition - dimension - run.start.mMargin);
+        }
+
+        return position;
+    }
+
+    public long computeWrapSize(ConstraintWidgetContainer container, int orientation) {
+        if (mFirstRun instanceof ChainRun) {
+            ChainRun chainRun = (ChainRun) mFirstRun;
+            if (chainRun.orientation != orientation) {
+                return 0;
+            }
+        } else {
+            if (orientation == HORIZONTAL) {
+                if (!(mFirstRun instanceof HorizontalWidgetRun)) {
+                    return 0;
+                }
+            } else {
+                if (!(mFirstRun instanceof VerticalWidgetRun)) {
+                    return 0;
+                }
+            }
+        }
+        DependencyNode containerStart = orientation == HORIZONTAL
+                ? container.mHorizontalRun.start : container.mVerticalRun.start;
+        DependencyNode containerEnd = orientation == HORIZONTAL
+                ? container.mHorizontalRun.end : container.mVerticalRun.end;
+
+        boolean runWithStartTarget = mFirstRun.start.mTargets.contains(containerStart);
+        boolean runWithEndTarget = mFirstRun.end.mTargets.contains(containerEnd);
+
+        long dimension = mFirstRun.getWrapDimension();
+
+        if (runWithStartTarget && runWithEndTarget) {
+            long maxPosition = traverseStart(mFirstRun.start, 0);
+            long minPosition = traverseEnd(mFirstRun.end, 0);
+
+            // to compute the gaps, we subtract the margins
+            long endGap = maxPosition - dimension;
+            if (endGap >= -mFirstRun.end.mMargin) {
+                endGap += mFirstRun.end.mMargin;
+            }
+            long startGap = -minPosition - dimension - mFirstRun.start.mMargin;
+            if (startGap >= mFirstRun.start.mMargin) {
+                startGap -= mFirstRun.start.mMargin;
+            }
+            float bias = mFirstRun.mWidget.getBiasPercent(orientation);
+            long gap = 0;
+            if (bias > 0) {
+                gap = (long) ((startGap / bias) + (endGap / (1f - bias)));
+            }
+
+            startGap = (long) (0.5f + (gap * bias));
+            endGap = (long) (0.5f + (gap * (1f - bias)));
+
+            long runDimension = startGap + dimension + endGap;
+            dimension = mFirstRun.start.mMargin + runDimension - mFirstRun.end.mMargin;
+
+        } else if (runWithStartTarget) {
+            long maxPosition = traverseStart(mFirstRun.start, mFirstRun.start.mMargin);
+            long runDimension = mFirstRun.start.mMargin + dimension;
+            dimension = Math.max(maxPosition, runDimension);
+        } else if (runWithEndTarget) {
+            long minPosition = traverseEnd(mFirstRun.end, mFirstRun.end.mMargin);
+            long runDimension = -mFirstRun.end.mMargin + dimension;
+            dimension = Math.max(-minPosition, runDimension);
+        } else {
+            dimension = mFirstRun.start.mMargin
+                    + mFirstRun.getWrapDimension() - mFirstRun.end.mMargin;
+        }
+
+        return dimension;
+    }
+
+    private boolean defineTerminalWidget(WidgetRun run, int orientation) {
+        if (!run.mWidget.isTerminalWidget[orientation]) {
+            return false;
+        }
+        for (Dependency dependency : run.start.mDependencies) {
+            if (dependency instanceof DependencyNode) {
+                DependencyNode node = (DependencyNode) dependency;
+                if (node.mRun == run) {
+                    continue;
+                }
+                if (node == node.mRun.start) {
+                    if (run instanceof ChainRun) {
+                        ChainRun chainRun = (ChainRun) run;
+                        for (WidgetRun widgetChainRun : chainRun.mWidgets) {
+                            defineTerminalWidget(widgetChainRun, orientation);
+                        }
+                    } else {
+                        if (!(run instanceof HelperReferences)) {
+                            run.mWidget.isTerminalWidget[orientation] = false;
+                        }
+                    }
+                    defineTerminalWidget(node.mRun, orientation);
+                }
+            }
+        }
+        for (Dependency dependency : run.end.mDependencies) {
+            if (dependency instanceof DependencyNode) {
+                DependencyNode node = (DependencyNode) dependency;
+                if (node.mRun == run) {
+                    continue;
+                }
+                if (node == node.mRun.start) {
+                    if (run instanceof ChainRun) {
+                        ChainRun chainRun = (ChainRun) run;
+                        for (WidgetRun widgetChainRun : chainRun.mWidgets) {
+                            defineTerminalWidget(widgetChainRun, orientation);
+                        }
+                    } else {
+                        if (!(run instanceof HelperReferences)) {
+                            run.mWidget.isTerminalWidget[orientation] = false;
+                        }
+                    }
+                    defineTerminalWidget(node.mRun, orientation);
+                }
+            }
+        }
+        return false;
+    }
+
+
+    public void defineTerminalWidgets(boolean horizontalCheck, boolean verticalCheck) {
+        if (horizontalCheck && mFirstRun instanceof HorizontalWidgetRun) {
+            defineTerminalWidget(mFirstRun, HORIZONTAL);
+        }
+        if (verticalCheck && mFirstRun instanceof VerticalWidgetRun) {
+            defineTerminalWidget(mFirstRun, VERTICAL);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/VerticalWidgetRun.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/VerticalWidgetRun.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.FIXED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_PARENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_RATIO;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+import static androidx.constraintlayout.core.widgets.analyzer.WidgetRun.RunType.CENTER;
+
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.Helper;
+
+public class VerticalWidgetRun extends WidgetRun {
+    private static final boolean FORCE_USE = true;
+    public DependencyNode baseline = new DependencyNode(this);
+    androidx.constraintlayout.core.widgets.analyzer.DimensionDependency mBaselineDimension = null;
+
+    public VerticalWidgetRun(ConstraintWidget widget) {
+        super(widget);
+        start.mType = DependencyNode.Type.TOP;
+        end.mType = DependencyNode.Type.BOTTOM;
+        baseline.mType = DependencyNode.Type.BASELINE;
+        this.orientation = VERTICAL;
+    }
+
+    @Override
+    public String toString() {
+        return "VerticalRun " + mWidget.getDebugName();
+    }
+
+    @Override
+    void clear() {
+        mRunGroup = null;
+        start.clear();
+        end.clear();
+        baseline.clear();
+        mDimension.clear();
+        mResolved = false;
+    }
+
+    @Override
+    void reset() {
+        mResolved = false;
+        start.clear();
+        start.resolved = false;
+        end.clear();
+        end.resolved = false;
+        baseline.clear();
+        baseline.resolved = false;
+        mDimension.resolved = false;
+    }
+
+    @Override
+    boolean supportsWrapComputation() {
+        if (super.mDimensionBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+            if (super.mWidget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void update(Dependency dependency) {
+        switch (mRunType) {
+            case START: {
+                updateRunStart(dependency);
+            }
+            break;
+            case END: {
+                updateRunEnd(dependency);
+            }
+            break;
+            case CENTER: {
+                updateRunCenter(dependency, mWidget.mTop, mWidget.mBottom, VERTICAL);
+                return;
+            }
+            default:
+                break;
+        }
+        if (FORCE_USE || dependency == mDimension) {
+            if (mDimension.readyToSolve && !mDimension.resolved) {
+                if (mDimensionBehavior == MATCH_CONSTRAINT) {
+                    switch (mWidget.mMatchConstraintDefaultHeight) {
+                        case MATCH_CONSTRAINT_RATIO: {
+                            if (mWidget.mHorizontalRun.mDimension.resolved) {
+                                int size = 0;
+                                int ratioSide = mWidget.getDimensionRatioSide();
+                                switch (ratioSide) {
+                                    case ConstraintWidget.HORIZONTAL: {
+                                        size = (int) (0.5f + mWidget.mHorizontalRun.mDimension.value
+                                                * mWidget.getDimensionRatio());
+                                    }
+                                    break;
+                                    case ConstraintWidget.VERTICAL: {
+                                        size = (int) (0.5f + mWidget.mHorizontalRun.mDimension.value
+                                                / mWidget.getDimensionRatio());
+                                    }
+                                    break;
+                                    case ConstraintWidget.UNKNOWN: {
+                                        size = (int) (0.5f + mWidget.mHorizontalRun.mDimension.value
+                                                / mWidget.getDimensionRatio());
+                                    }
+                                    break;
+                                    default:
+                                        break;
+                                }
+                                mDimension.resolve(size);
+                            }
+                        }
+                        break;
+                        case MATCH_CONSTRAINT_PERCENT: {
+                            ConstraintWidget parent = mWidget.getParent();
+                            if (parent != null) {
+                                if (parent.mVerticalRun.mDimension.resolved) {
+                                    float percent = mWidget.mMatchConstraintPercentHeight;
+                                    int targetDimensionValue = parent.mVerticalRun.mDimension.value;
+                                    int size = (int) (0.5f + targetDimensionValue * percent);
+                                    mDimension.resolve(size);
+                                }
+                            }
+                        }
+                        break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+        if (!(start.readyToSolve && end.readyToSolve)) {
+            return;
+        }
+        if (start.resolved && end.resolved && mDimension.resolved) {
+            return;
+        }
+
+        if (!mDimension.resolved
+                && mDimensionBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                && mWidget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD
+                && !mWidget.isInVerticalChain()) {
+
+            DependencyNode startTarget = start.mTargets.get(0);
+            DependencyNode endTarget = end.mTargets.get(0);
+            int startPos = startTarget.value + start.mMargin;
+            int endPos = endTarget.value + end.mMargin;
+
+            int distance = endPos - startPos;
+            start.resolve(startPos);
+            end.resolve(endPos);
+            mDimension.resolve(distance);
+            return;
+        }
+
+        if (!mDimension.resolved
+                && mDimensionBehavior == MATCH_CONSTRAINT
+                && matchConstraintsType == MATCH_CONSTRAINT_WRAP) {
+            if (start.mTargets.size() > 0 && end.mTargets.size() > 0) {
+                DependencyNode startTarget = start.mTargets.get(0);
+                DependencyNode endTarget = end.mTargets.get(0);
+                int startPos = startTarget.value + start.mMargin;
+                int endPos = endTarget.value + end.mMargin;
+                int availableSpace = endPos - startPos;
+                if (availableSpace < mDimension.wrapValue) {
+                    mDimension.resolve(availableSpace);
+                } else {
+                    mDimension.resolve(mDimension.wrapValue);
+                }
+            }
+        }
+
+        if (!mDimension.resolved) {
+            return;
+        }
+        // ready to solve, centering.
+        if (start.mTargets.size() > 0 && end.mTargets.size() > 0) {
+            DependencyNode startTarget = start.mTargets.get(0);
+            DependencyNode endTarget = end.mTargets.get(0);
+            int startPos = startTarget.value + start.mMargin;
+            int endPos = endTarget.value + end.mMargin;
+            float bias = mWidget.getVerticalBiasPercent();
+            if (startTarget == endTarget) {
+                startPos = startTarget.value;
+                endPos = endTarget.value;
+                // TODO: this might be a nice feature to support, but I guess for now let's stay
+                // compatible with 1.1
+                bias = 0.5f;
+            }
+            int distance = (endPos - startPos - mDimension.value);
+            start.resolve((int) (0.5f + startPos + distance * bias));
+            end.resolve(start.value + mDimension.value);
+        }
+    }
+
+    @Override
+    void apply() {
+        if (mWidget.measured) {
+            mDimension.resolve(mWidget.getHeight());
+        }
+        if (!mDimension.resolved) {
+            super.mDimensionBehavior = mWidget.getVerticalDimensionBehaviour();
+            if (mWidget.hasBaseline()) {
+                mBaselineDimension = new BaselineDimensionDependency(this);
+            }
+            if (super.mDimensionBehavior != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+                if (mDimensionBehavior == MATCH_PARENT) {
+                    ConstraintWidget parent = mWidget.getParent();
+                    if (parent != null && parent.getVerticalDimensionBehaviour() == FIXED) {
+                        int resolvedDimension = parent.getHeight()
+                                - mWidget.mTop.getMargin() - mWidget.mBottom.getMargin();
+                        addTarget(start, parent.mVerticalRun.start, mWidget.mTop.getMargin());
+                        addTarget(end, parent.mVerticalRun.end, -mWidget.mBottom.getMargin());
+                        mDimension.resolve(resolvedDimension);
+                        return;
+                    }
+                }
+                if (mDimensionBehavior == FIXED) {
+                    mDimension.resolve(mWidget.getHeight());
+                }
+            }
+        } else {
+            if (mDimensionBehavior == MATCH_PARENT) {
+                ConstraintWidget parent = mWidget.getParent();
+                if (parent != null && parent.getVerticalDimensionBehaviour() == FIXED) {
+                    addTarget(start, parent.mVerticalRun.start, mWidget.mTop.getMargin());
+                    addTarget(end, parent.mVerticalRun.end, -mWidget.mBottom.getMargin());
+                    return;
+                }
+            }
+        }
+        // three basic possibilities:
+        // <-s-e->
+        // <-s-e
+        //   s-e->
+        // and a variation if the dimension is not yet known:
+        // <-s-d-e->
+        // <-s<-d<-e
+        //   s->d->e->
+
+        if (mDimension.resolved && mWidget.measured) {
+            if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].mTarget != null
+                    && mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].mTarget
+                    != null) { // <-s-e->
+                if (mWidget.isInVerticalChain()) {
+                    start.mMargin = mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin();
+                    end.mMargin = -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].getMargin();
+                } else {
+                    DependencyNode startTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP]);
+                    if (startTarget != null) {
+                        addTarget(start, startTarget,
+                                mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin());
+                    }
+                    DependencyNode endTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM]);
+                    if (endTarget != null) {
+                        addTarget(end, endTarget,
+                                -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].getMargin());
+                    }
+                    start.delegateToWidgetRun = true;
+                    end.delegateToWidgetRun = true;
+                }
+                if (mWidget.hasBaseline()) {
+                    addTarget(baseline, start, mWidget.getBaselineDistance());
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].mTarget != null) { // <-s-e
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP]);
+                if (target != null) {
+                    addTarget(start, target,
+                            mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin());
+                    addTarget(end, start, mDimension.value);
+                    if (mWidget.hasBaseline()) {
+                        addTarget(baseline, start, mWidget.getBaselineDistance());
+                    }
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].mTarget
+                    != null) {   //   s-e->
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM]);
+                if (target != null) {
+                    addTarget(end, target,
+                            -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].getMargin());
+                    addTarget(start, end, -mDimension.value);
+                }
+                if (mWidget.hasBaseline()) {
+                    addTarget(baseline, start, mWidget.getBaselineDistance());
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_BASELINE].mTarget
+                    != null) {
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BASELINE]);
+                if (target != null) {
+                    addTarget(baseline, target, 0);
+                    addTarget(start, baseline, -mWidget.getBaselineDistance());
+                    addTarget(end, start, mDimension.value);
+                }
+            } else {
+                // no connections, nothing to do.
+                if (!(mWidget instanceof Helper) && mWidget.getParent() != null
+                        && mWidget.getAnchor(ConstraintAnchor.Type.CENTER).mTarget == null) {
+                    DependencyNode top = mWidget.getParent().mVerticalRun.start;
+                    addTarget(start, top, mWidget.getY());
+                    addTarget(end, start, mDimension.value);
+                    if (mWidget.hasBaseline()) {
+                        addTarget(baseline, start, mWidget.getBaselineDistance());
+                    }
+                }
+            }
+        } else {
+            if (!mDimension.resolved && mDimensionBehavior == MATCH_CONSTRAINT) {
+                switch (mWidget.mMatchConstraintDefaultHeight) {
+                    case MATCH_CONSTRAINT_RATIO: {
+                        if (!mWidget.isInVerticalChain()) {
+                            if (mWidget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_RATIO) {
+                                // need to look into both side
+                                // do nothing here --
+                                //    let the HorizontalWidgetRun::update() deal with it.
+                                break;
+                            }
+                            // we have a ratio, but we depend on the other side computation
+                            DependencyNode targetDimension = mWidget.mHorizontalRun.mDimension;
+                            mDimension.mTargets.add(targetDimension);
+                            targetDimension.mDependencies.add(mDimension);
+                            mDimension.delegateToWidgetRun = true;
+                            mDimension.mDependencies.add(start);
+                            mDimension.mDependencies.add(end);
+                        }
+                    }
+                    break;
+                    case MATCH_CONSTRAINT_PERCENT: {
+                        // we need to look up the parent dimension
+                        ConstraintWidget parent = mWidget.getParent();
+                        if (parent == null) {
+                            break;
+                        }
+                        DependencyNode targetDimension = parent.mVerticalRun.mDimension;
+                        mDimension.mTargets.add(targetDimension);
+                        targetDimension.mDependencies.add(mDimension);
+                        mDimension.delegateToWidgetRun = true;
+                        mDimension.mDependencies.add(start);
+                        mDimension.mDependencies.add(end);
+                    }
+                    break;
+                    case MATCH_CONSTRAINT_SPREAD: {
+                        // the work is done in the update()
+                    }
+                    break;
+                    default:
+                        break;
+                }
+            } else {
+                mDimension.addDependency(this);
+            }
+            if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].mTarget != null
+                    && mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].mTarget
+                    != null) { // <-s-d-e->
+                if (mWidget.isInVerticalChain()) {
+                    start.mMargin = mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin();
+                    end.mMargin = -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].getMargin();
+                } else {
+                    DependencyNode startTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP]);
+                    DependencyNode endTarget =
+                            getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM]);
+                    if (false) {
+                        if (startTarget != null) {
+                            addTarget(start, startTarget,
+                                    mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin());
+                        }
+                        if (endTarget != null) {
+                            addTarget(end, endTarget,
+                                    -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM]
+                                            .getMargin());
+                        }
+                    } else {
+                        if (startTarget != null) {
+                            startTarget.addDependency(this);
+                        }
+                        if (endTarget != null) {
+                            endTarget.addDependency(this);
+                        }
+                    }
+                    mRunType = CENTER;
+                }
+                if (mWidget.hasBaseline()) {
+                    addTarget(baseline, start, 1, mBaselineDimension);
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].mTarget
+                    != null) { // <-s<-d<-e
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP]);
+                if (target != null) {
+                    addTarget(start, target,
+                            mWidget.mListAnchors[ConstraintWidget.ANCHOR_TOP].getMargin());
+                    addTarget(end, start, 1, mDimension);
+                    if (mWidget.hasBaseline()) {
+                        addTarget(baseline, start, 1, mBaselineDimension);
+                    }
+                    if (mDimensionBehavior == MATCH_CONSTRAINT) {
+                        if (mWidget.getDimensionRatio() > 0) {
+                            if (mWidget.mHorizontalRun.mDimensionBehavior == MATCH_CONSTRAINT) {
+                                mWidget.mHorizontalRun.mDimension.mDependencies.add(mDimension);
+                                mDimension.mTargets.add(mWidget.mHorizontalRun.mDimension);
+                                mDimension.updateDelegate = this;
+                            }
+                        }
+                    }
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].mTarget
+                    != null) {   //   s->d->e->
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM]);
+                if (target != null) {
+                    addTarget(end, target,
+                            -mWidget.mListAnchors[ConstraintWidget.ANCHOR_BOTTOM].getMargin());
+                    addTarget(start, end, -1, mDimension);
+                    if (mWidget.hasBaseline()) {
+                        addTarget(baseline, start, 1, mBaselineDimension);
+                    }
+                }
+            } else if (mWidget.mListAnchors[ConstraintWidget.ANCHOR_BASELINE].mTarget != null) {
+                DependencyNode target =
+                        getTarget(mWidget.mListAnchors[ConstraintWidget.ANCHOR_BASELINE]);
+                if (target != null) {
+                    addTarget(baseline, target, 0);
+                    addTarget(start, baseline, -1, mBaselineDimension);
+                    addTarget(end, start, 1, mDimension);
+                }
+            } else {
+                // no connections, nothing to do.
+                if (!(mWidget instanceof Helper) && mWidget.getParent() != null) {
+                    DependencyNode top = mWidget.getParent().mVerticalRun.start;
+                    addTarget(start, top, mWidget.getY());
+                    addTarget(end, start, 1, mDimension);
+                    if (mWidget.hasBaseline()) {
+                        addTarget(baseline, start, 1, mBaselineDimension);
+                    }
+                    if (mDimensionBehavior == MATCH_CONSTRAINT) {
+                        if (mWidget.getDimensionRatio() > 0) {
+                            if (mWidget.mHorizontalRun.mDimensionBehavior == MATCH_CONSTRAINT) {
+                                mWidget.mHorizontalRun.mDimension.mDependencies.add(mDimension);
+                                mDimension.mTargets.add(mWidget.mHorizontalRun.mDimension);
+                                mDimension.updateDelegate = this;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // if dimension has no dependency, mark it as ready to solve
+            if (mDimension.mTargets.size() == 0) {
+                mDimension.readyToSolve = true;
+            }
+        }
+    }
+
+    // @TODO: add description
+    @Override
+    public void applyToWidget() {
+        if (start.resolved) {
+            mWidget.setY(start.value);
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/WidgetGroup.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/WidgetGroup.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.BOTH;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.widgets.Chain;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Represents a group of widget for the grouping mechanism.
+ */
+public class WidgetGroup {
+    private static final boolean DEBUG = false;
+    ArrayList<ConstraintWidget> mWidgets = new ArrayList<>();
+    static int sCount = 0;
+    int mId = -1;
+    boolean mAuthoritative = false;
+    int mOrientation = HORIZONTAL;
+    ArrayList<MeasureResult> mResults = null;
+    private int mMoveTo = -1;
+
+    public WidgetGroup(int orientation) {
+        mId = sCount++;
+        this.mOrientation = orientation;
+    }
+
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    public int getId() {
+        return mId;
+    }
+
+    // @TODO: add description
+    public boolean add(ConstraintWidget widget) {
+        if (mWidgets.contains(widget)) {
+            return false;
+        }
+        mWidgets.add(widget);
+        return true;
+    }
+
+    public void setAuthoritative(boolean isAuthoritative) {
+        mAuthoritative = isAuthoritative;
+    }
+
+    public boolean isAuthoritative() {
+        return mAuthoritative;
+    }
+
+    private String getOrientationString() {
+        if (mOrientation == HORIZONTAL) {
+            return "Horizontal";
+        } else if (mOrientation == VERTICAL) {
+            return "Vertical";
+        } else if (mOrientation == BOTH) {
+            return "Both";
+        }
+        return "Unknown";
+    }
+
+    @Override
+    public String toString() {
+        String ret = getOrientationString() + " [" + mId + "] <";
+        for (ConstraintWidget widget : mWidgets) {
+            ret += " " + widget.getDebugName();
+        }
+        ret += " >";
+        return ret;
+    }
+
+    // @TODO: add description
+    public void moveTo(int orientation, WidgetGroup widgetGroup) {
+        if (DEBUG) {
+            System.out.println("Move all widgets (" + this + ") from "
+                    + mId + " to " + widgetGroup.getId() + "(" + widgetGroup + ")");
+            System.out.println("" +
+                    "do not call  "+ measureWrap(  orientation, new ConstraintWidget()));
+        }
+        for (ConstraintWidget widget : mWidgets) {
+            widgetGroup.add(widget);
+            if (orientation == HORIZONTAL) {
+                widget.horizontalGroup = widgetGroup.getId();
+            } else {
+                widget.verticalGroup = widgetGroup.getId();
+            }
+        }
+        mMoveTo = widgetGroup.mId;
+    }
+
+    // @TODO: add description
+    public void clear() {
+        mWidgets.clear();
+    }
+
+    private int measureWrap(int orientation, ConstraintWidget widget) {
+        ConstraintWidget.DimensionBehaviour behaviour = widget.getDimensionBehaviour(orientation);
+        if (behaviour == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+                || behaviour == ConstraintWidget.DimensionBehaviour.MATCH_PARENT
+                || behaviour == ConstraintWidget.DimensionBehaviour.FIXED) {
+            int dimension;
+            if (orientation == HORIZONTAL) {
+                dimension = widget.getWidth();
+            } else {
+                dimension = widget.getHeight();
+            }
+            return dimension;
+        }
+        return -1;
+    }
+
+    // @TODO: add description
+    public int measureWrap(LinearSystem system, int orientation) {
+        int count = mWidgets.size();
+        if (count == 0) {
+            return 0;
+        }
+        // TODO: add direct wrap computation for simpler cases instead of calling the solver
+        return solverMeasure(system, mWidgets, orientation);
+    }
+
+    private int solverMeasure(LinearSystem system,
+            ArrayList<ConstraintWidget> widgets,
+            int orientation) {
+        ConstraintWidgetContainer container =
+                (ConstraintWidgetContainer) widgets.get(0).getParent();
+        system.reset();
+        @SuppressWarnings("unused") boolean prevDebug = LinearSystem.FULL_DEBUG;
+        container.addToSolver(system, false);
+        for (int i = 0; i < widgets.size(); i++) {
+            ConstraintWidget widget = widgets.get(i);
+            widget.addToSolver(system, false);
+        }
+        if (orientation == HORIZONTAL) {
+            if (container.mHorizontalChainsSize > 0) {
+                Chain.applyChainConstraints(container, system, widgets, HORIZONTAL);
+            }
+        }
+        if (orientation == VERTICAL) {
+            if (container.mVerticalChainsSize > 0) {
+                Chain.applyChainConstraints(container, system, widgets, VERTICAL);
+            }
+        }
+
+        try {
+            system.minimize();
+        } catch (Exception e) {
+            //TODO remove fancy version of e.printStackTrace()
+            System.err.println(e.toString()+"\n"+Arrays.toString(e.getStackTrace())
+                    .replace("[","   at ")
+                    .replace(",","\n   at")
+                    .replace("]",""));
+        }
+
+        // save results
+        mResults = new ArrayList<>();
+        for (int i = 0; i < widgets.size(); i++) {
+            ConstraintWidget widget = widgets.get(i);
+            MeasureResult result = new MeasureResult(widget, system, orientation);
+            mResults.add(result);
+        }
+
+        if (orientation == HORIZONTAL) {
+            int left = system.getObjectVariableValue(container.mLeft);
+            int right = system.getObjectVariableValue(container.mRight);
+            system.reset();
+            return right - left;
+        } else {
+            int top = system.getObjectVariableValue(container.mTop);
+            int bottom = system.getObjectVariableValue(container.mBottom);
+            system.reset();
+            return bottom - top;
+        }
+    }
+
+    public void setOrientation(int orientation) {
+        this.mOrientation = orientation;
+    }
+
+    // @TODO: add description
+    public void apply() {
+        if (mResults == null) {
+            return;
+        }
+        if (!mAuthoritative) {
+            return;
+        }
+        for (int i = 0; i < mResults.size(); i++) {
+            MeasureResult result = mResults.get(i);
+            result.apply();
+        }
+    }
+
+    // @TODO: add description
+    public boolean intersectWith(WidgetGroup group) {
+        for (int i = 0; i < mWidgets.size(); i++) {
+            ConstraintWidget widget = mWidgets.get(i);
+            if (group.contains(widget)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean contains(ConstraintWidget widget) {
+        return mWidgets.contains(widget);
+    }
+
+    // @TODO: add description
+    public int size() {
+        return mWidgets.size();
+    }
+
+    // @TODO: add description
+    public void cleanup(ArrayList<WidgetGroup> dependencyLists) {
+        final int count = mWidgets.size();
+        if (mMoveTo != -1 && count > 0) {
+            for (int i = 0; i < dependencyLists.size(); i++) {
+                WidgetGroup group = dependencyLists.get(i);
+                if (mMoveTo == group.mId) {
+                    moveTo(mOrientation, group);
+                }
+            }
+        }
+        if (count == 0) {
+            dependencyLists.remove(this);
+            return;
+        }
+    }
+
+
+    static class MeasureResult {
+        WeakReference<ConstraintWidget> mWidgetRef;
+        int mLeft;
+        int mTop;
+        int mRight;
+        int mBottom;
+        int mBaseline;
+        int mOrientation;
+
+        MeasureResult(ConstraintWidget widget, LinearSystem system, int orientation) {
+            mWidgetRef = new WeakReference<>(widget);
+            mLeft = system.getObjectVariableValue(widget.mLeft);
+            mTop = system.getObjectVariableValue(widget.mTop);
+            mRight = system.getObjectVariableValue(widget.mRight);
+            mBottom = system.getObjectVariableValue(widget.mBottom);
+            mBaseline = system.getObjectVariableValue(widget.mBaseline);
+            this.mOrientation = orientation;
+        }
+
+        public void apply() {
+            ConstraintWidget widget = mWidgetRef.get();
+            if (widget != null) {
+                widget.setFinalFrame(mLeft, mTop, mRight, mBottom, mBaseline, mOrientation);
+            }
+        }
+    }
+}

--- a/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/WidgetRun.java
+++ b/parity/src/oracle/java/androidx/constraintlayout/core/widgets/analyzer/WidgetRun.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets.analyzer;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_PERCENT;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_RATIO;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+
+public abstract class WidgetRun implements Dependency {
+    public int matchConstraintsType;
+    ConstraintWidget mWidget;
+    RunGroup mRunGroup;
+    protected ConstraintWidget.DimensionBehaviour mDimensionBehavior;
+    DimensionDependency mDimension = new DimensionDependency(this);
+
+    public int orientation = HORIZONTAL;
+    boolean mResolved = false;
+    public DependencyNode start = new DependencyNode(this);
+    public DependencyNode end = new DependencyNode(this);
+
+    @SuppressWarnings("HiddenTypeParameter")
+    protected RunType mRunType = RunType.NONE;
+
+    public WidgetRun(ConstraintWidget widget) {
+        this.mWidget = widget;
+    }
+
+    @SuppressWarnings("HiddenAbstractMethod")
+    abstract void clear();
+
+    @SuppressWarnings("HiddenAbstractMethod")
+    abstract void apply();
+
+    @SuppressWarnings("HiddenAbstractMethod")
+    abstract void applyToWidget();
+
+    @SuppressWarnings("HiddenAbstractMethod")
+    abstract void reset();
+
+    @SuppressWarnings("HiddenAbstractMethod")
+    abstract boolean supportsWrapComputation();
+
+    public boolean isDimensionResolved() {
+        return mDimension.resolved;
+    }
+
+    // @TODO: add description
+    public boolean isCenterConnection() {
+        int connections = 0;
+        int count = start.mTargets.size();
+        for (int i = 0; i < count; i++) {
+            DependencyNode dependency = start.mTargets.get(i);
+            if (dependency.mRun != this) {
+                connections++;
+            }
+        }
+        count = end.mTargets.size();
+        for (int i = 0; i < count; i++) {
+            DependencyNode dependency = end.mTargets.get(i);
+            if (dependency.mRun != this) {
+                connections++;
+            }
+        }
+        return connections >= 2;
+    }
+
+    // @TODO: add description
+    public long wrapSize(int direction) {
+        if (mDimension.resolved) {
+            long size = mDimension.value;
+            if (isCenterConnection()) { //start.targets.size() > 0 && end.targets.size() > 0) {
+                size += start.mMargin - end.mMargin;
+            } else {
+                if (direction == RunGroup.START) {
+                    size += start.mMargin;
+                } else {
+                    size -= end.mMargin;
+                }
+            }
+            return size;
+        }
+        return 0;
+    }
+
+    protected final DependencyNode getTarget(ConstraintAnchor anchor) {
+        if (anchor.mTarget == null) {
+            return null;
+        }
+        DependencyNode target = null;
+        ConstraintWidget targetWidget = anchor.mTarget.mOwner;
+        ConstraintAnchor.Type targetType = anchor.mTarget.mType;
+        switch (targetType) {
+            case LEFT: {
+                HorizontalWidgetRun run = targetWidget.mHorizontalRun;
+                target = run.start;
+            }
+            break;
+            case RIGHT: {
+                HorizontalWidgetRun run = targetWidget.mHorizontalRun;
+                target = run.end;
+            }
+            break;
+            case TOP: {
+                VerticalWidgetRun run = targetWidget.mVerticalRun;
+                target = run.start;
+            }
+            break;
+            case BASELINE: {
+                VerticalWidgetRun run = targetWidget.mVerticalRun;
+                target = run.baseline;
+            }
+            break;
+            case BOTTOM: {
+                VerticalWidgetRun run = targetWidget.mVerticalRun;
+                target = run.end;
+            }
+            break;
+            default:
+                break;
+        }
+        return target;
+    }
+
+    protected void updateRunCenter(Dependency dependency,
+            ConstraintAnchor startAnchor,
+            ConstraintAnchor endAnchor,
+            int orientation) {
+        DependencyNode startTarget = getTarget(startAnchor);
+        DependencyNode endTarget = getTarget(endAnchor);
+
+        if (!(startTarget.resolved && endTarget.resolved)) {
+            return;
+        }
+
+        int startPos = startTarget.value + startAnchor.getMargin();
+        int endPos = endTarget.value - endAnchor.getMargin();
+        int distance = endPos - startPos;
+
+        if (!mDimension.resolved
+                && mDimensionBehavior == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT) {
+            resolveDimension(orientation, distance);
+        }
+
+        if (!mDimension.resolved) {
+            return;
+        }
+
+        if (mDimension.value == distance) {
+            start.resolve(startPos);
+            end.resolve(endPos);
+            return;
+        }
+
+        // Otherwise, we have to center
+        float bias = orientation == HORIZONTAL ? mWidget.getHorizontalBiasPercent()
+                : mWidget.getVerticalBiasPercent();
+
+        if (startTarget == endTarget) {
+            startPos = startTarget.value;
+            endPos = endTarget.value;
+            // TODO: taking advantage of bias here would be a nice feature to support,
+            // but for now let's stay compatible with 1.1
+            bias = 0.5f;
+        }
+
+        int availableDistance = (endPos - startPos - mDimension.value);
+        start.resolve((int) (0.5f + startPos + availableDistance * bias));
+        end.resolve(start.value + mDimension.value);
+    }
+
+    private void resolveDimension(int orientation, int distance) {
+        switch (matchConstraintsType) {
+            case MATCH_CONSTRAINT_SPREAD: {
+                mDimension.resolve(getLimitedDimension(distance, orientation));
+            }
+            break;
+            case MATCH_CONSTRAINT_PERCENT: {
+                ConstraintWidget parent = mWidget.getParent();
+                if (parent != null) {
+                    WidgetRun run = orientation == HORIZONTAL
+                            ? parent.mHorizontalRun
+                            : parent.mVerticalRun;
+                    if (run.mDimension.resolved) {
+                        float percent = orientation == HORIZONTAL
+                                ? mWidget.mMatchConstraintPercentWidth
+                                : mWidget.mMatchConstraintPercentHeight;
+                        int targetDimensionValue = run.mDimension.value;
+                        int size = (int) (0.5f + targetDimensionValue * percent);
+                        mDimension.resolve(getLimitedDimension(size, orientation));
+                    }
+                }
+            }
+            break;
+            case MATCH_CONSTRAINT_WRAP: {
+                int wrapValue = getLimitedDimension(mDimension.wrapValue, orientation);
+                mDimension.resolve(Math.min(wrapValue, distance));
+            }
+            break;
+            case MATCH_CONSTRAINT_RATIO: {
+                if (mWidget.mHorizontalRun.mDimensionBehavior
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && mWidget.mHorizontalRun.matchConstraintsType == MATCH_CONSTRAINT_RATIO
+                        && mWidget.mVerticalRun.mDimensionBehavior
+                        == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                        && mWidget.mVerticalRun.matchConstraintsType == MATCH_CONSTRAINT_RATIO) {
+                    // pof
+                } else {
+                    WidgetRun run = (orientation == HORIZONTAL)
+                            ? mWidget.mVerticalRun : mWidget.mHorizontalRun;
+                    if (run.mDimension.resolved) {
+                        float ratio = mWidget.getDimensionRatio();
+                        int value;
+                        if (orientation == VERTICAL) {
+                            value = (int) (0.5f + run.mDimension.value / ratio);
+                        } else {
+                            value = (int) (0.5f + ratio * run.mDimension.value);
+                        }
+                        mDimension.resolve(value);
+                    }
+                }
+            }
+            break;
+            default:
+                break;
+        }
+    }
+
+    protected void updateRunStart(Dependency dependency) {
+
+    }
+
+    protected void updateRunEnd(Dependency dependency) {
+
+    }
+
+    // @TODO: add description
+    @Override
+    public void update(Dependency dependency) {
+    }
+
+    protected final int getLimitedDimension(int dimension, int orientation) {
+        if (orientation == HORIZONTAL) {
+            int max = mWidget.mMatchConstraintMaxWidth;
+            int min = mWidget.mMatchConstraintMinWidth;
+            int value = Math.max(min, dimension);
+            if (max > 0) {
+                value = Math.min(max, dimension);
+            }
+            if (value != dimension) {
+                dimension = value;
+            }
+        } else {
+            int max = mWidget.mMatchConstraintMaxHeight;
+            int min = mWidget.mMatchConstraintMinHeight;
+            int value = Math.max(min, dimension);
+            if (max > 0) {
+                value = Math.min(max, dimension);
+            }
+            if (value != dimension) {
+                dimension = value;
+            }
+        }
+        return dimension;
+    }
+
+    protected final DependencyNode getTarget(ConstraintAnchor anchor, int orientation) {
+        if (anchor.mTarget == null) {
+            return null;
+        }
+        DependencyNode target = null;
+        ConstraintWidget targetWidget = anchor.mTarget.mOwner;
+        WidgetRun run = (orientation == ConstraintWidget.HORIZONTAL)
+                ? targetWidget.mHorizontalRun : targetWidget.mVerticalRun;
+        ConstraintAnchor.Type targetType = anchor.mTarget.mType;
+        switch (targetType) {
+            case TOP:
+            case LEFT: {
+                target = run.start;
+            }
+            break;
+            case BOTTOM:
+            case RIGHT: {
+                target = run.end;
+            }
+            break;
+            default:
+                break;
+        }
+        return target;
+    }
+
+    protected final void addTarget(DependencyNode node,
+            DependencyNode target,
+            int margin) {
+        node.mTargets.add(target);
+        node.mMargin = margin;
+        target.mDependencies.add(node);
+    }
+
+    protected final void addTarget(DependencyNode node,
+            DependencyNode target,
+            int marginFactor,
+            @SuppressWarnings("HiddenTypeParameter") DimensionDependency
+                    dimensionDependency) {
+        node.mTargets.add(target);
+        node.mTargets.add(mDimension);
+        node.mMarginFactor = marginFactor;
+        node.mMarginDependency = dimensionDependency;
+        target.mDependencies.add(node);
+        dimensionDependency.mDependencies.add(node);
+    }
+
+    // @TODO: add description
+    public long getWrapDimension() {
+        if (mDimension.resolved) {
+            return mDimension.value;
+        }
+        return 0;
+    }
+
+    public boolean isResolved() {
+        return mResolved;
+    }
+
+    enum RunType {NONE, START, END, CENTER}
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/LayoutOutcome.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/LayoutOutcome.kt
@@ -1,0 +1,36 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+/**
+ * Everything observable about one layout pass, normalised so the two implementations become
+ * comparable despite living in different packages. Deliberately the same shape as `ParseOutcome`.
+ */
+sealed interface LayoutOutcome {
+    /**
+     * @param geometry every widget's position and size plus the root's final size. The root belongs
+     *   in here because wrap-content makes its size an output rather than an input, and that is
+     *   exactly where the minimum-size defect in #336 lived.
+     */
+    data class LaidOut(val geometry: String) : LayoutOutcome
+
+    /**
+     * An exception escaped `layout()`. Compared by portable category, not exception class: the port
+     * is multiplatform and cannot raise JVM-specific exception classes on Native or JS, so class
+     * equality would demand something no correct port could deliver.
+     */
+    data class Leaked(val category: String) : LayoutOutcome
+
+    data class Crashed(val error: String) : LayoutOutcome
+
+    companion object {
+        fun categorise(throwable: Throwable): String =
+            when (throwable) {
+                is IndexOutOfBoundsException -> "IndexOutOfBounds"
+                is NullPointerException -> "NullPointer"
+                is ArithmeticException -> "Arithmetic"
+                else -> throwable::class.simpleName ?: "Unknown"
+            }
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -1,0 +1,81 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import androidx.constraintlayout.core.widgets.ConstraintAnchor
+import androidx.constraintlayout.core.widgets.ConstraintWidget
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer
+
+/** The vendored upstream solver. It defines correct behaviour for every comparison here. */
+object OracleSolver : SolverSubject {
+    override val name: String = "oracle"
+
+    override fun layout(scenario: Scenario): LayoutOutcome =
+        try {
+            val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
+            root.debugName = "root"
+            root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
+            root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
+            if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
+            if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+            val widgets = scenario.widgets.map { spec ->
+                ConstraintWidget(spec.width, spec.height).apply {
+                    debugName = spec.name
+                    setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
+                    setVerticalDimensionBehaviour(behaviour(spec.vertical))
+                    if (spec.minWidth > 0) setMinWidth(spec.minWidth)
+                    if (spec.minHeight > 0) setMinHeight(spec.minHeight)
+                    if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
+                    if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
+                    horizontalBiasPercent = spec.horizontalBias
+                    verticalBiasPercent = spec.verticalBias
+                    root.add(this)
+                }
+            }
+
+            for (connection in scenario.connections) {
+                widgets[connection.from].connect(
+                    side(connection.fromSide),
+                    connection.target?.let { widgets[it] } ?: root,
+                    side(connection.toSide),
+                    connection.margin,
+                )
+            }
+
+            root.layout()
+            LayoutOutcome.LaidOut(render(root, widgets.map { it.debugName to it }))
+        } catch (e: Exception) {
+            LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
+        } catch (e: StackOverflowError) {
+            LayoutOutcome.Crashed("StackOverflowError")
+        } catch (e: OutOfMemoryError) {
+            LayoutOutcome.Crashed("OutOfMemoryError")
+        }
+
+    private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =
+        when (value) {
+            Behaviour.FIXED -> ConstraintWidget.DimensionBehaviour.FIXED
+            Behaviour.WRAP_CONTENT -> ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+            Behaviour.MATCH_CONSTRAINT -> ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+            Behaviour.MATCH_PARENT -> ConstraintWidget.DimensionBehaviour.MATCH_PARENT
+        }
+
+    private fun side(value: Side): ConstraintAnchor.Type =
+        when (value) {
+            Side.LEFT -> ConstraintAnchor.Type.LEFT
+            Side.TOP -> ConstraintAnchor.Type.TOP
+            Side.RIGHT -> ConstraintAnchor.Type.RIGHT
+            Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
+        }
+
+    private fun render(root: ConstraintWidgetContainer, widgets: List<Pair<String?, ConstraintWidget>>): String =
+        buildString {
+            append("root: ").append(root.width).append('x').append(root.height).append('\n')
+            for ((name, widget) in widgets) {
+                append(name).append(": (").append(widget.x).append(", ").append(widget.y)
+                    .append(") ").append(widget.width).append('x').append(widget.height).append('\n')
+            }
+        }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -52,6 +52,8 @@ object OracleSolver : SolverSubject {
             LayoutOutcome.Crashed("StackOverflowError")
         } catch (e: OutOfMemoryError) {
             LayoutOutcome.Crashed("OutOfMemoryError")
+        } catch (e: Throwable) {
+            LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
         }
 
     private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -52,6 +52,8 @@ object PortSolver : SolverSubject {
             LayoutOutcome.Crashed("StackOverflowError")
         } catch (e: OutOfMemoryError) {
             LayoutOutcome.Crashed("OutOfMemoryError")
+        } catch (e: Throwable) {
+            LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
         }
 
     private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -1,0 +1,81 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer
+
+/** The ported solver, taken from the shaded flavour so its packages do not collide with the oracle's. */
+object PortSolver : SolverSubject {
+    override val name: String = "port"
+
+    override fun layout(scenario: Scenario): LayoutOutcome =
+        try {
+            val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
+            root.debugName = "root"
+            root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
+            root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
+            if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
+            if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+            val widgets = scenario.widgets.map { spec ->
+                ConstraintWidget(spec.width, spec.height).apply {
+                    debugName = spec.name
+                    setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
+                    setVerticalDimensionBehaviour(behaviour(spec.vertical))
+                    if (spec.minWidth > 0) setMinWidth(spec.minWidth)
+                    if (spec.minHeight > 0) setMinHeight(spec.minHeight)
+                    if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
+                    if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
+                    horizontalBiasPercent = spec.horizontalBias
+                    verticalBiasPercent = spec.verticalBias
+                    root.add(this)
+                }
+            }
+
+            for (connection in scenario.connections) {
+                widgets[connection.from].connect(
+                    side(connection.fromSide),
+                    connection.target?.let { widgets[it] } ?: root,
+                    side(connection.toSide),
+                    connection.margin,
+                )
+            }
+
+            root.layout()
+            LayoutOutcome.LaidOut(render(root, widgets.map { it.debugName to it }))
+        } catch (e: Exception) {
+            LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
+        } catch (e: StackOverflowError) {
+            LayoutOutcome.Crashed("StackOverflowError")
+        } catch (e: OutOfMemoryError) {
+            LayoutOutcome.Crashed("OutOfMemoryError")
+        }
+
+    private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =
+        when (value) {
+            Behaviour.FIXED -> ConstraintWidget.DimensionBehaviour.FIXED
+            Behaviour.WRAP_CONTENT -> ConstraintWidget.DimensionBehaviour.WRAP_CONTENT
+            Behaviour.MATCH_CONSTRAINT -> ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+            Behaviour.MATCH_PARENT -> ConstraintWidget.DimensionBehaviour.MATCH_PARENT
+        }
+
+    private fun side(value: Side): ConstraintAnchor.Type =
+        when (value) {
+            Side.LEFT -> ConstraintAnchor.Type.LEFT
+            Side.TOP -> ConstraintAnchor.Type.TOP
+            Side.RIGHT -> ConstraintAnchor.Type.RIGHT
+            Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
+        }
+
+    private fun render(root: ConstraintWidgetContainer, widgets: List<Pair<String?, ConstraintWidget>>): String =
+        buildString {
+            append("root: ").append(root.width).append('x').append(root.height).append('\n')
+            for ((name, widget) in widgets) {
+                append(name).append(": (").append(widget.x).append(", ").append(widget.y)
+                    .append(") ").append(widget.width).append('x').append(widget.height).append('\n')
+            }
+        }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -1,0 +1,58 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+/**
+ * A layout described without reference to either implementation.
+ *
+ * The parser harness could put its inputs in files because a parser's input is data. A solver's
+ * input is a program — a sequence of API calls — and the two implementations expose that API under
+ * different package names, so no single piece of code can drive both. This is the shared
+ * description each subject replays with its own classes.
+ */
+
+/** Mirrors `ConstraintWidget.DimensionBehaviour`, which exists separately in each package. */
+enum class Behaviour { FIXED, WRAP_CONTENT, MATCH_CONSTRAINT, MATCH_PARENT }
+
+/** Mirrors the subset of `ConstraintAnchor.Type` this harness uses. */
+enum class Side { LEFT, TOP, RIGHT, BOTTOM }
+
+val Side.isHorizontal: Boolean
+    get() = this == Side.LEFT || this == Side.RIGHT
+
+/** `0` for a minimum means unset; `Int.MAX_VALUE` for a maximum means unset. */
+data class WidgetSpec(
+    val name: String,
+    val width: Int,
+    val height: Int,
+    val horizontal: Behaviour,
+    val vertical: Behaviour,
+    val minWidth: Int,
+    val minHeight: Int,
+    val maxWidth: Int,
+    val maxHeight: Int,
+    val horizontalBias: Float,
+    val verticalBias: Float,
+)
+
+/** [target] is an index into [Scenario.widgets], or `null` for the root. */
+data class ConnectionSpec(
+    val from: Int,
+    val fromSide: Side,
+    val target: Int?,
+    val toSide: Side,
+    val margin: Int,
+)
+
+data class Scenario(
+    val seed: Long,
+    val rootWidth: Int,
+    val rootHeight: Int,
+    val rootHorizontal: Behaviour,
+    val rootVertical: Behaviour,
+    val rootMinWidth: Int,
+    val rootMinHeight: Int,
+    val widgets: List<WidgetSpec>,
+    val connections: List<ConnectionSpec>,
+)

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -1,0 +1,84 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.random.Random
+
+/**
+ * Generates layouts from a seed.
+ *
+ * Two properties are load-bearing. Generation is a pure function of the seed, so a divergence
+ * reported by CI reproduces exactly. And connections only ever target the root or a lower-indexed
+ * widget, so the constraint graph is acyclic — a cycle would leave the solver failing to settle,
+ * and the harness would be measuring that instead of the port.
+ */
+object Scenarios {
+    private const val MIN_WIDGETS = 2
+    private const val MAX_WIDGETS = 8
+
+    fun generate(seed: Long): Scenario {
+        val random = Random(seed)
+        val count = random.nextInt(MIN_WIDGETS, MAX_WIDGETS + 1)
+
+        val widgets = (0 until count).map { index ->
+            WidgetSpec(
+                name = "w$index",
+                width = random.nextInt(20, 200),
+                height = random.nextInt(20, 200),
+                horizontal = behaviour(random),
+                vertical = behaviour(random),
+                minWidth = if (random.nextInt(4) == 0) random.nextInt(1, 150) else 0,
+                minHeight = if (random.nextInt(4) == 0) random.nextInt(1, 150) else 0,
+                maxWidth = if (random.nextInt(6) == 0) random.nextInt(150, 400) else Int.MAX_VALUE,
+                maxHeight = if (random.nextInt(6) == 0) random.nextInt(150, 400) else Int.MAX_VALUE,
+                horizontalBias = random.nextInt(0, 11) / 10f,
+                verticalBias = random.nextInt(0, 11) / 10f,
+            )
+        }
+
+        val connections = mutableListOf<ConnectionSpec>()
+        for (index in 0 until count) {
+            connections += axisConnections(random, index, horizontal = true)
+            connections += axisConnections(random, index, horizontal = false)
+        }
+
+        return Scenario(
+            seed = seed,
+            rootWidth = random.nextInt(400, 1200),
+            rootHeight = random.nextInt(400, 1200),
+            // The root is usually fixed — a wrap-content root is the interesting minority, and the
+            // minimum below only means anything when it is one.
+            rootHorizontal = if (random.nextInt(3) == 0) Behaviour.WRAP_CONTENT else Behaviour.FIXED,
+            rootVertical = if (random.nextInt(3) == 0) Behaviour.WRAP_CONTENT else Behaviour.FIXED,
+            rootMinWidth = if (random.nextInt(2) == 0) random.nextInt(1, 600) else 0,
+            rootMinHeight = if (random.nextInt(2) == 0) random.nextInt(1, 600) else 0,
+            widgets = widgets,
+            connections = connections,
+        )
+    }
+
+    private fun behaviour(random: Random): Behaviour =
+        Behaviour.entries[random.nextInt(Behaviour.entries.size)]
+
+    /**
+     * One or two connections on a single axis. Both sides are needed for `MATCH_CONSTRAINT` to mean
+     * anything, so the two-sided case is common rather than incidental.
+     */
+    private fun axisConnections(random: Random, index: Int, horizontal: Boolean): List<ConnectionSpec> {
+        val (start, end) = if (horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
+        val target = if (index == 0 || random.nextInt(2) == 0) null else random.nextInt(index)
+        val margin = random.nextInt(0, 40)
+
+        // Targeting a sibling's opposite side chains the widgets; targeting the root's same side
+        // anchors them. Both shapes matter, so pick between them rather than always chaining.
+        val toStart = if (target == null) start else if (random.nextInt(2) == 0) start else end
+        val first = ConnectionSpec(index, start, target, toStart, margin)
+
+        return if (random.nextInt(3) == 0) {
+            listOf(first)
+        } else {
+            listOf(first, ConnectionSpec(index, end, target, if (target == null) end else toStart, margin))
+        }
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -68,17 +68,23 @@ object Scenarios {
     private fun axisConnections(random: Random, index: Int, horizontal: Boolean): List<ConnectionSpec> {
         val (start, end) = if (horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
         val target = if (index == 0 || random.nextInt(2) == 0) null else random.nextInt(index)
-        val margin = random.nextInt(0, 40)
 
-        // Targeting a sibling's opposite side chains the widgets; targeting the root's same side
-        // anchors them. Both shapes matter, so pick between them rather than always chaining.
-        val toStart = if (target == null) start else if (random.nextInt(2) == 0) start else end
-        val first = ConnectionSpec(index, start, target, toStart, margin)
-
-        return if (random.nextInt(3) == 0) {
-            listOf(first)
-        } else {
-            listOf(first, ConnectionSpec(index, end, target, if (target == null) end else toStart, margin))
+        if (random.nextInt(3) == 0) {
+            // A single connection. Targeting a sibling's opposite side chains the widgets one after
+            // another; targeting the matching side of the root or a sibling anchors them together.
+            // Both shapes matter, so pick between them rather than always chaining.
+            val toSide = if (target != null && random.nextInt(2) == 0) end else start
+            return listOf(ConnectionSpec(index, start, target, toSide, random.nextInt(0, 40)))
         }
+
+        // Two connections anchor the widget to the container's two edges — the root's for a null
+        // target, a sibling's for a non-null one — each side to its matching side, so the span
+        // between them (and therefore a MATCH_CONSTRAINT dimension) is real and positive rather
+        // than collapsing both anchors onto the same edge. Margins are drawn independently so
+        // asymmetric margins can occur.
+        return listOf(
+            ConnectionSpec(index, start, target, start, random.nextInt(0, 40)),
+            ConnectionSpec(index, end, target, end, random.nextInt(0, 40)),
+        )
     }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -47,21 +47,35 @@ class ScenariosTest {
     }
 
     @Test
-    fun everyBehaviourIsReachable() {
+    fun everyChildBehaviourIsReachable() {
+        val seen = mutableSetOf<Behaviour>()
+        for (seed in 1L..200L) {
+            Scenarios.generate(seed).widgets.forEach { seen += it.horizontal; seen += it.vertical }
+        }
+        assertEquals(Behaviour.entries.toSet(), seen, "unreached: ${Behaviour.entries.toSet() - seen}")
+    }
+
+    @Test
+    fun rootBehaviourIsFixedOrWrapContentOnly() {
         val seen = mutableSetOf<Behaviour>()
         for (seed in 1L..200L) {
             val scenario = Scenarios.generate(seed)
             seen += scenario.rootHorizontal
             seen += scenario.rootVertical
-            scenario.widgets.forEach { seen += it.horizontal; seen += it.vertical }
         }
-        assertEquals(Behaviour.entries.toSet(), seen, "unreached: ${Behaviour.entries.toSet() - seen}")
+        assertEquals(
+            setOf(Behaviour.FIXED, Behaviour.WRAP_CONTENT),
+            seen,
+            "unreached or unexpected: ${setOf(Behaviour.FIXED, Behaviour.WRAP_CONTENT) - seen} / " +
+                "${seen - setOf(Behaviour.FIXED, Behaviour.WRAP_CONTENT)}",
+        )
     }
 
     /**
-     * The acceptance probe in Task 4 reverts the minimum-size fix from #336, which only bites a
-     * container whose wrap-content size lands below its minimum. If the generator never emits that
-     * combination the probe cannot fire, so it is a requirement rather than a happy accident.
+     * A wrap-content root with a minimum is the case where the root's own size becomes an output
+     * of the layout pass rather than an input — the minimum can only bind if wrap-content would
+     * otherwise have shrunk the root below it. If the generator never emits that combination, this
+     * corner of solver behaviour goes untested.
      */
     @Test
     fun someScenariosGiveTheRootWrapContentAndAMinimum() {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -1,0 +1,74 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ScenariosTest {
+    @Test
+    fun generationIsDeterministic() {
+        assertEquals(Scenarios.generate(1), Scenarios.generate(1))
+    }
+
+    @Test
+    fun differentSeedsGiveDifferentScenarios() {
+        val scenarios = (1L..50L).map { Scenarios.generate(it) }
+        assertTrue(scenarios.toSet().size > 40, "only ${scenarios.toSet().size} distinct of 50")
+    }
+
+    @Test
+    fun connectionsAreAcyclic() {
+        for (seed in 1L..200L) {
+            val scenario = Scenarios.generate(seed)
+            for (connection in scenario.connections) {
+                val target = connection.target
+                assertTrue(
+                    target == null || target < connection.from,
+                    "seed $seed: widget ${connection.from} targets $target",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun connectionsJoinTheSameAxis() {
+        for (seed in 1L..200L) {
+            for (connection in Scenarios.generate(seed).connections) {
+                assertEquals(
+                    connection.fromSide.isHorizontal,
+                    connection.toSide.isHorizontal,
+                    "seed $seed: ${connection.fromSide} -> ${connection.toSide}",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun everyBehaviourIsReachable() {
+        val seen = mutableSetOf<Behaviour>()
+        for (seed in 1L..200L) {
+            val scenario = Scenarios.generate(seed)
+            seen += scenario.rootHorizontal
+            seen += scenario.rootVertical
+            scenario.widgets.forEach { seen += it.horizontal; seen += it.vertical }
+        }
+        assertEquals(Behaviour.entries.toSet(), seen, "unreached: ${Behaviour.entries.toSet() - seen}")
+    }
+
+    /**
+     * The acceptance probe in Task 4 reverts the minimum-size fix from #336, which only bites a
+     * container whose wrap-content size lands below its minimum. If the generator never emits that
+     * combination the probe cannot fire, so it is a requirement rather than a happy accident.
+     */
+    @Test
+    fun someScenariosGiveTheRootWrapContentAndAMinimum() {
+        val matching = (1L..200L).map { Scenarios.generate(it) }.count {
+            (it.rootHorizontal == Behaviour.WRAP_CONTENT && it.rootMinWidth > 0) ||
+                (it.rootVertical == Behaviour.WRAP_CONTENT && it.rootMinHeight > 0)
+        }
+        assertTrue(matching >= 10, "only $matching of 200 scenarios exercise the root minimum")
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -1,0 +1,63 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Lays out a range of generated scenarios with both solvers and requires identical geometry.
+ *
+ * The oracle is upstream, so a disagreement is a defect in the port until proven otherwise. When
+ * this fails, read the report and fix the port — do not relax the harness to accommodate it.
+ *
+ * A caveat worth keeping in mind while triaging: a constraint solver can have several valid
+ * solutions for an underconstrained system, so two correct implementations could in principle
+ * disagree through collection iteration order alone. That would still be worth knowing — it would
+ * mean the engine's output depends on iteration order, which matters well beyond this harness.
+ */
+class SolverDifferentialTest {
+    private val seeds = 1L..2000L
+
+    @Test
+    fun thePortAgreesWithTheOracle() {
+        val divergences = mutableListOf<String>()
+
+        for (seed in seeds) {
+            val scenario = Scenarios.generate(seed)
+            val oracle = OracleSolver.layout(scenario)
+            val port = PortSolver.layout(scenario)
+            if (oracle != port) {
+                divergences += report(scenario, oracle, port)
+                if (divergences.size >= 5) break
+            }
+        }
+
+        if (divergences.isNotEmpty()) {
+            fail(
+                "${divergences.size} of ${seeds.count()} scenarios diverged " +
+                    "(stopped at the first 5):\n\n${divergences.joinToString("\n\n")}",
+            )
+        }
+    }
+
+    private fun report(scenario: Scenario, oracle: LayoutOutcome, port: LayoutOutcome): String =
+        buildString {
+            append("--- seed ").append(scenario.seed).append('\n')
+            append("root     : ").append(scenario.rootWidth).append('x').append(scenario.rootHeight)
+                .append(' ').append(scenario.rootHorizontal).append('/').append(scenario.rootVertical)
+                .append(" min ").append(scenario.rootMinWidth).append('/').append(scenario.rootMinHeight)
+                .append('\n')
+            scenario.widgets.forEach { append("widget   : ").append(it).append('\n') }
+            scenario.connections.forEach { append("connect  : ").append(it).append('\n') }
+            append("oracle   :\n").append(indent(oracle)).append('\n')
+            append("port     :\n").append(indent(port))
+        }
+
+    private fun indent(outcome: LayoutOutcome): String =
+        when (outcome) {
+            is LayoutOutcome.LaidOut -> outcome.geometry.trimEnd().lines().joinToString("\n") { "    $it" }
+            else -> "    $outcome"
+        }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -20,24 +20,42 @@ import kotlin.test.fail
 class SolverDifferentialTest {
     private val seeds = 1L..2000L
 
+    // A floor on how many seeds must actually reach LaidOut. If scenario construction or layout()
+    // started throwing for every seed, both sides would return an identical Leaked(...) and all
+    // 2000 seeds would compare equal and pass green — this makes that silent failure loud instead.
+    // In the spirit of DifferentialTest's `compared >= 1000` guard: all 2000 seeds currently reach
+    // LaidOut, so 1800 is a floor with real margin, not one hugging the observed value.
+    private val minimumLaidOut = 1800
+
     @Test
     fun thePortAgreesWithTheOracle() {
         val divergences = mutableListOf<String>()
+        var totalDivergences = 0
+        var laidOut = 0
 
         for (seed in seeds) {
             val scenario = Scenarios.generate(seed)
             val oracle = OracleSolver.layout(scenario)
             val port = PortSolver.layout(scenario)
+            if (oracle is LayoutOutcome.LaidOut) laidOut++
             if (oracle != port) {
-                divergences += report(scenario, oracle, port)
-                if (divergences.size >= 5) break
+                totalDivergences++
+                if (divergences.size < 5) divergences += report(scenario, oracle, port)
             }
         }
 
-        if (divergences.isNotEmpty()) {
+        if (laidOut < minimumLaidOut) {
             fail(
-                "${divergences.size} of ${seeds.count()} scenarios diverged " +
-                    "(stopped at the first 5):\n\n${divergences.joinToString("\n\n")}",
+                "only $laidOut of ${seeds.count()} scenarios reached LaidOut (need at least " +
+                    "$minimumLaidOut) — the generator or the solver wiring is broken, not just " +
+                    "under-covering behaviour",
+            )
+        }
+
+        if (totalDivergences > 0) {
+            fail(
+                "$totalDivergences of ${seeds.count()} scenarios diverged " +
+                    "(showing the first ${divergences.size}):\n\n${divergences.joinToString("\n\n")}",
             )
         }
     }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
@@ -1,0 +1,15 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+/**
+ * One side of the comparison. Implementations must never throw out of [layout]: a failure on one
+ * side against a success on the other is the finding, so it has to arrive as a value rather than
+ * end the run before the remaining scenarios are tried.
+ */
+interface SolverSubject {
+    val name: String
+
+    fun layout(scenario: Scenario): LayoutOutcome
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubjectTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubjectTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SolverSubjectTest {
+    private val subjects = listOf(OracleSolver, PortSolver)
+
+    @Test
+    fun bothSubjectsLayOutAScenario() {
+        val scenario = Scenarios.generate(1)
+        for (subject in subjects) {
+            val outcome = subject.layout(scenario)
+            assertTrue(outcome is LayoutOutcome.LaidOut, "${subject.name} returned $outcome")
+        }
+    }
+
+    @Test
+    fun geometryNamesEveryWidgetAndTheRoot() {
+        val scenario = Scenarios.generate(1)
+        for (subject in subjects) {
+            val geometry = (subject.layout(scenario) as LayoutOutcome.LaidOut).geometry
+            assertTrue(geometry.contains("root"), "${subject.name}: $geometry")
+            for (widget in scenario.widgets) {
+                assertTrue(geometry.contains(widget.name), "${subject.name} missing ${widget.name}")
+            }
+        }
+    }
+
+    @Test
+    fun subjectsAgreeOnASingleScenario() {
+        val scenario = Scenarios.generate(1)
+        assertEquals(OracleSolver.layout(scenario), PortSolver.layout(scenario))
+    }
+}


### PR DESCRIPTION
The parser comparison in #337 proved the technique; the solver is the larger prize. It is where the library spends its time, where most of the ported code lives, and where the one confirmed translation defect so far was found (#336) — a defect that survived all 442 inherited tests.

## How it works

The parser could keep its inputs in files, because a parser's input is data. A solver's input is a *program*: a sequence of API calls that builds a widget tree and runs `layout()`. The two implementations expose that API under different package names, so no single piece of code can drive both.

`Scenario` is the answer — a declarative layout description importing neither implementation. `OracleSolver` and `PortSolver` each replay it with their own classes, and the resulting geometry is compared exactly. Integers throughout, so no tolerance is needed; if one ever seemed necessary that would itself be a finding.

**2000 generated scenarios per run.** Each has a root and 2–8 widgets covering all four `DimensionBehaviour` values, margins, biases, and minimum and maximum sizes. Connections are acyclic by construction — a widget targets the root or a lower-indexed widget, never a higher one — because a cycle would leave the solver failing to settle and the harness measuring that instead of the port.

## Vendoring the whole of core

`:parity` previously vendored ten parser files. The solver's dependency closure is most of `core`, and a computed subset would be fragile: six class names are duplicated across `core` packages (`Barrier`, `Chain`, `Guideline`, `GuidelineReference`, `Helper`, `Transition`), so any name-based closure is ambiguous, and upstream refactors would move the boundary on every refresh.

`constraintlayout-core` is self-contained — 138 files, 47 699 lines, depending only on `java.*` and two annotation-only libraries — so the whole module is now vendored. One oracle, one provenance record, and no future comparison of any part of the engine needs further vendoring. `.gitattributes` marks the tree `linguist-vendored`.

## Proving the harness can fail

A differential test that cannot fail is worse than none, so this was verified rather than assumed. The plan called for reverting the real defect from #336 and watching the harness go red.

**It did not go red — and that turned out to be the interesting part.** The #336 defect is structurally unreachable through this API: `ConstraintWidget`'s `width`/`height` setters and `setFrame` all clamp to the minimum independently, in code #336 never touched. By the time the container's post-solve branch runs, the size has already been clamped, every time. This was established by instrumenting the reverted code, after first widening the generator and trying handcrafted adversarial scenarios.

**This refines what #336 claimed.** That fix remains correct as a faithful translation — the guard is dead where upstream's is live — but its description overstated the observable impact. On every path the core API exposes, the minimum is enforced by the setter regardless.

A mutation probe replaced it: `mWidth = mMinWidth` changed to `mWidth = mMinWidth + 1` in the port's setter, which propagates into `:compose-shaded` and therefore into `PortSolver`. The harness reported **19 of 2000 scenarios diverging**, each showing the port's root one pixel wider than the oracle's with dependent geometry shifted accordingly. Reverted, it is green. The mutation is not in this branch.

That probe is the better criterion anyway: it tests the property we actually want — would this harness notice if the port's solver behaved differently — without depending on a suitable historical bug existing.

## Findings from review, fixed here

The final review caught two things worth naming:

- **Sibling-targeted two-sided connections were degenerate.** Both anchors landed on the same sibling edge, so the span was always negative and a `MATCH_CONSTRAINT` widget spanning between two sibling edges — a core solver behaviour — was never generated. After the fix the mutation probe's divergence count rose from 5 to 19, which is direct evidence the coverage gap was real.
- **The vacuity guard was missing.** If scenario construction started throwing for every seed, both sides would return an identical `Leaked(...)` and all 2000 would pass green. The parser harness asserts a floor for exactly this reason; the solver one now does too, on scenarios that actually reached `LaidOut`.

Also fixed: the divergence count was a lower bound (the loop stopped at five but reported that as the total), both connections on an axis shared one margin draw, a duplicate version-catalog alias, and `Error`s other than stack-overflow and out-of-memory could escape `layout()` despite the interface promising otherwise.

## Verification

446 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`. 26 tests in `:parity`. CI's existing `Parity tests` step already runs the whole module, so no workflow change was needed.

## Known limitation

A constraint solver can have several valid solutions for an underconstrained system. If the two implementations ever pick different ones — through collection iteration order, which this port has been bitten by before in `Helper.configMap` — both would be correct and this test would still go red. That is not pre-empted: every divergence is reported and triaged, and a false positive of that kind would itself be worth knowing, since it would mean the engine's output depends on iteration order.

## Not in this PR

Helpers — chains, barriers, guidelines, ratios, circular constraints. The next step now that the base is proven.
