### PR TITLE
test(parity): compare chains, barriers, guidelines, ratios and circular constraints

### DIFF
--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -3,9 +3,11 @@
 
 package tech.annexflow.parity.solver
 
+import androidx.constraintlayout.core.widgets.Barrier
 import androidx.constraintlayout.core.widgets.ConstraintAnchor
 import androidx.constraintlayout.core.widgets.ConstraintWidget
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer
+import androidx.constraintlayout.core.widgets.Guideline
 
 /** The vendored upstream solver. It defines correct behaviour for every comparison here. */
 object OracleSolver : SolverSubject {
@@ -19,6 +21,19 @@ object OracleSolver : SolverSubject {
             root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
             if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
             if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+            val guidelines = scenario.guidelines.map { spec ->
+                Guideline().apply {
+                    debugName = spec.name
+                    setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
+                    when (val position = spec.position) {
+                        is GuidelinePosition.Begin -> setGuideBegin(position.value)
+                        is GuidelinePosition.End -> setGuideEnd(position.value)
+                        is GuidelinePosition.Percent -> setGuidePercent(position.value)
+                    }
+                    root.add(this)
+                }
+            }
 
             val widgets = scenario.widgets.map { spec ->
                 ConstraintWidget(spec.width, spec.height).apply {
@@ -36,10 +51,33 @@ object OracleSolver : SolverSubject {
                 }
             }
 
+            val barriers = scenario.barriers.map { spec ->
+                Barrier().apply {
+                    debugName = spec.name
+                    setBarrierType(
+                        when (spec.side) {
+                            Side.LEFT -> Barrier.LEFT
+                            Side.RIGHT -> Barrier.RIGHT
+                            Side.TOP -> Barrier.TOP
+                            Side.BOTTOM -> Barrier.BOTTOM
+                        },
+                    )
+                    setMargin(spec.margin)
+                    spec.referenced.forEach { add(widgets[it]) }
+                    root.add(this)
+                }
+            }
+
             for (connection in scenario.connections) {
+                val target = when (val to = connection.target) {
+                    is Target.Root -> root
+                    is Target.Widget -> widgets[to.index]
+                    is Target.Barrier -> barriers[to.index]
+                    is Target.Guideline -> guidelines[to.index]
+                }
                 widgets[connection.from].connect(
                     side(connection.fromSide),
-                    connection.target?.let { widgets[it] } ?: root,
+                    target,
                     side(connection.toSide),
                     connection.margin,
                 )
@@ -54,7 +92,7 @@ object OracleSolver : SolverSubject {
             }
 
             root.layout()
-            LayoutOutcome.LaidOut(render(root, widgets.map { it.debugName to it }))
+            LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
         } catch (e: Exception) {
             LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
         } catch (e: StackOverflowError) {
@@ -81,12 +119,18 @@ object OracleSolver : SolverSubject {
             Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
         }
 
-    private fun render(root: ConstraintWidgetContainer, widgets: List<Pair<String?, ConstraintWidget>>): String =
+    private fun render(
+        root: ConstraintWidgetContainer,
+        guidelines: List<ConstraintWidget>,
+        widgets: List<ConstraintWidget>,
+        barriers: List<ConstraintWidget>,
+    ): String =
         buildString {
             append("root: ").append(root.width).append('x').append(root.height).append('\n')
-            for ((name, widget) in widgets) {
-                append(name).append(": (").append(widget.x).append(", ").append(widget.y)
-                    .append(") ").append(widget.width).append('x').append(widget.height).append('\n')
+            for (participant in guidelines + widgets + barriers) {
+                append(participant.debugName).append(": (").append(participant.x).append(", ")
+                    .append(participant.y).append(") ").append(participant.width).append('x')
+                    .append(participant.height).append('\n')
             }
         }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -91,6 +91,20 @@ object OracleSolver : SolverSubject {
                 )
             }
 
+            for (chain in scenario.chains) {
+                val head = widgets[chain.members.first()]
+                val style = when (chain.style) {
+                    ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
+                    ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
+                    ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
+                }
+                if (chain.horizontal) {
+                    head.setHorizontalChainStyle(style)
+                } else {
+                    head.setVerticalChainStyle(style)
+                }
+            }
+
             root.layout()
             LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
         } catch (e: Exception) {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -31,6 +31,7 @@ object OracleSolver : SolverSubject {
                     if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
                     horizontalBiasPercent = spec.horizontalBias
                     verticalBiasPercent = spec.verticalBias
+                    spec.dimensionRatio?.let { setDimensionRatio(it) }
                     root.add(this)
                 }
             }
@@ -41,6 +42,14 @@ object OracleSolver : SolverSubject {
                     connection.target?.let { widgets[it] } ?: root,
                     side(connection.toSide),
                     connection.margin,
+                )
+            }
+
+            for (circle in scenario.circular) {
+                widgets[circle.from].connectCircularConstraint(
+                    widgets[circle.target],
+                    circle.angle,
+                    circle.radius,
                 )
             }
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -3,9 +3,11 @@
 
 package tech.annexflow.parity.solver
 
+import tech.annexflow.constraintlayout.core.widgets.Barrier
 import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer
+import tech.annexflow.constraintlayout.core.widgets.Guideline
 
 /** The ported solver, taken from the shaded flavour so its packages do not collide with the oracle's. */
 object PortSolver : SolverSubject {
@@ -19,6 +21,19 @@ object PortSolver : SolverSubject {
             root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
             if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
             if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+            val guidelines = scenario.guidelines.map { spec ->
+                Guideline().apply {
+                    debugName = spec.name
+                    setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
+                    when (val position = spec.position) {
+                        is GuidelinePosition.Begin -> setGuideBegin(position.value)
+                        is GuidelinePosition.End -> setGuideEnd(position.value)
+                        is GuidelinePosition.Percent -> setGuidePercent(position.value)
+                    }
+                    root.add(this)
+                }
+            }
 
             val widgets = scenario.widgets.map { spec ->
                 ConstraintWidget(spec.width, spec.height).apply {
@@ -36,10 +51,33 @@ object PortSolver : SolverSubject {
                 }
             }
 
+            val barriers = scenario.barriers.map { spec ->
+                Barrier().apply {
+                    debugName = spec.name
+                    setBarrierType(
+                        when (spec.side) {
+                            Side.LEFT -> Barrier.LEFT
+                            Side.RIGHT -> Barrier.RIGHT
+                            Side.TOP -> Barrier.TOP
+                            Side.BOTTOM -> Barrier.BOTTOM
+                        },
+                    )
+                    setMargin(spec.margin)
+                    spec.referenced.forEach { add(widgets[it]) }
+                    root.add(this)
+                }
+            }
+
             for (connection in scenario.connections) {
+                val target = when (val to = connection.target) {
+                    is Target.Root -> root
+                    is Target.Widget -> widgets[to.index]
+                    is Target.Barrier -> barriers[to.index]
+                    is Target.Guideline -> guidelines[to.index]
+                }
                 widgets[connection.from].connect(
                     side(connection.fromSide),
-                    connection.target?.let { widgets[it] } ?: root,
+                    target,
                     side(connection.toSide),
                     connection.margin,
                 )
@@ -54,7 +92,7 @@ object PortSolver : SolverSubject {
             }
 
             root.layout()
-            LayoutOutcome.LaidOut(render(root, widgets.map { it.debugName to it }))
+            LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
         } catch (e: Exception) {
             LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
         } catch (e: StackOverflowError) {
@@ -81,12 +119,18 @@ object PortSolver : SolverSubject {
             Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
         }
 
-    private fun render(root: ConstraintWidgetContainer, widgets: List<Pair<String?, ConstraintWidget>>): String =
+    private fun render(
+        root: ConstraintWidgetContainer,
+        guidelines: List<ConstraintWidget>,
+        widgets: List<ConstraintWidget>,
+        barriers: List<ConstraintWidget>,
+    ): String =
         buildString {
             append("root: ").append(root.width).append('x').append(root.height).append('\n')
-            for ((name, widget) in widgets) {
-                append(name).append(": (").append(widget.x).append(", ").append(widget.y)
-                    .append(") ").append(widget.width).append('x').append(widget.height).append('\n')
+            for (participant in guidelines + widgets + barriers) {
+                append(participant.debugName).append(": (").append(participant.x).append(", ")
+                    .append(participant.y).append(") ").append(participant.width).append('x')
+                    .append(participant.height).append('\n')
             }
         }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -91,6 +91,20 @@ object PortSolver : SolverSubject {
                 )
             }
 
+            for (chain in scenario.chains) {
+                val head = widgets[chain.members.first()]
+                val style = when (chain.style) {
+                    ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
+                    ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
+                    ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
+                }
+                if (chain.horizontal) {
+                    head.setHorizontalChainStyle(style)
+                } else {
+                    head.setVerticalChainStyle(style)
+                }
+            }
+
             root.layout()
             LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
         } catch (e: Exception) {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -31,6 +31,7 @@ object PortSolver : SolverSubject {
                     if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
                     horizontalBiasPercent = spec.horizontalBias
                     verticalBiasPercent = spec.verticalBias
+                    spec.dimensionRatio?.let { setDimensionRatio(it) }
                     root.add(this)
                 }
             }
@@ -41,6 +42,14 @@ object PortSolver : SolverSubject {
                     connection.target?.let { widgets[it] } ?: root,
                     side(connection.toSide),
                     connection.margin,
+                )
+            }
+
+            for (circle in scenario.circular) {
+                widgets[circle.from].connectCircularConstraint(
+                    widgets[circle.target],
+                    circle.angle,
+                    circle.radius,
                 )
             }
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -38,13 +38,49 @@ data class WidgetSpec(
     val dimensionRatio: String?,
 )
 
-/** [target] is an index into [Scenario.widgets], or `null` for the root. */
+/** What a connection can point at. */
+sealed interface Target {
+    data object Root : Target
+
+    data class Widget(val index: Int) : Target
+
+    data class Barrier(val index: Int) : Target
+
+    data class Guideline(val index: Int) : Target
+}
+
 data class ConnectionSpec(
     val from: Int,
     val fromSide: Side,
-    val target: Int?,
+    val target: Target,
     val toSide: Side,
     val margin: Int,
+)
+
+/**
+ * A barrier resolves to the extreme edge of the widgets it references. [referenced] is never empty:
+ * a barrier over nothing resolves to nothing useful and would be inert coverage.
+ */
+data class BarrierSpec(
+    val name: String,
+    val side: Side,
+    val margin: Int,
+    val referenced: List<Int>,
+)
+
+/** The three ways `Guideline` accepts a position, matching its `RELATIVE_*` modes. */
+sealed interface GuidelinePosition {
+    data class Begin(val value: Int) : GuidelinePosition
+
+    data class End(val value: Int) : GuidelinePosition
+
+    data class Percent(val value: Float) : GuidelinePosition
+}
+
+data class GuidelineSpec(
+    val name: String,
+    val vertical: Boolean,
+    val position: GuidelinePosition,
 )
 
 /**
@@ -64,4 +100,6 @@ data class Scenario(
     val widgets: List<WidgetSpec>,
     val connections: List<ConnectionSpec>,
     val circular: List<CircularSpec>,
+    val barriers: List<BarrierSpec>,
+    val guidelines: List<GuidelineSpec>,
 )

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -83,6 +83,19 @@ data class GuidelineSpec(
     val position: GuidelinePosition,
 )
 
+enum class ChainStyle { SPREAD, SPREAD_INSIDE, PACKED }
+
+/**
+ * A chain is not a class in the engine — it emerges from a run of widgets linked to each other in
+ * both directions, with a style set on the head. This record exists so the pattern can be asserted
+ * complete; the connections themselves still live in [Scenario.connections].
+ */
+data class ChainSpec(
+    val members: List<Int>,
+    val horizontal: Boolean,
+    val style: ChainStyle,
+)
+
 /**
  * A circular constraint, which positions a widget at an angle and distance from another rather than
  * by anchors. [target] is always lower than [from], so it cannot reintroduce a cycle.
@@ -102,4 +115,5 @@ data class Scenario(
     val circular: List<CircularSpec>,
     val barriers: List<BarrierSpec>,
     val guidelines: List<GuidelineSpec>,
+    val chains: List<ChainSpec>,
 )

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -34,6 +34,8 @@ data class WidgetSpec(
     val maxHeight: Int,
     val horizontalBias: Float,
     val verticalBias: Float,
+    /** `setDimensionRatio`'s documented format: `[H|V],[float|x:y]` or `[float|x:y]`. Null when unset. */
+    val dimensionRatio: String?,
 )
 
 /** [target] is an index into [Scenario.widgets], or `null` for the root. */
@@ -45,6 +47,12 @@ data class ConnectionSpec(
     val margin: Int,
 )
 
+/**
+ * A circular constraint, which positions a widget at an angle and distance from another rather than
+ * by anchors. [target] is always lower than [from], so it cannot reintroduce a cycle.
+ */
+data class CircularSpec(val from: Int, val target: Int, val angle: Float, val radius: Int)
+
 data class Scenario(
     val seed: Long,
     val rootWidth: Int,
@@ -55,4 +63,5 @@ data class Scenario(
     val rootMinHeight: Int,
     val widgets: List<WidgetSpec>,
     val connections: List<ConnectionSpec>,
+    val circular: List<CircularSpec>,
 )

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -17,30 +17,57 @@ object Scenarios {
     private const val MIN_WIDGETS = 2
     private const val MAX_WIDGETS = 8
 
+    private val RATIOS = listOf("16:9", "4:3", "1:1", "3:2", "W,16:9", "H,2:3", "0.5", "2.0")
+
     fun generate(seed: Long): Scenario {
         val random = Random(seed)
         val count = random.nextInt(MIN_WIDGETS, MAX_WIDGETS + 1)
 
         val widgets = (0 until count).map { index ->
+            val horizontal = behaviour(random)
+            val vertical = behaviour(random)
+            val ratioIsMeaningful =
+                horizontal == Behaviour.MATCH_CONSTRAINT || vertical == Behaviour.MATCH_CONSTRAINT
             WidgetSpec(
                 name = "w$index",
                 width = random.nextInt(20, 200),
                 height = random.nextInt(20, 200),
-                horizontal = behaviour(random),
-                vertical = behaviour(random),
+                horizontal = horizontal,
+                vertical = vertical,
                 minWidth = if (random.nextInt(4) == 0) random.nextInt(1, 150) else 0,
                 minHeight = if (random.nextInt(4) == 0) random.nextInt(1, 150) else 0,
                 maxWidth = if (random.nextInt(6) == 0) random.nextInt(150, 400) else Int.MAX_VALUE,
                 maxHeight = if (random.nextInt(6) == 0) random.nextInt(150, 400) else Int.MAX_VALUE,
                 horizontalBias = random.nextInt(0, 11) / 10f,
                 verticalBias = random.nextInt(0, 11) / 10f,
+                // A ratio on a widget whose dimensions are both fixed is inert — the fixed sizes
+                // win and nothing is exercised. Drawing it only when an axis is MATCH_CONSTRAINT
+                // keeps generated coverage honest.
+                dimensionRatio = if (ratioIsMeaningful && random.nextInt(3) == 0) {
+                    RATIOS[random.nextInt(RATIOS.size)]
+                } else {
+                    null
+                },
             )
         }
 
+        // A widget is anchored either by its edges or circularly, never both: the two together
+        // over-constrain it, and the solver's resolution of that conflict is not what this
+        // harness is measuring.
+        val circular = mutableListOf<CircularSpec>()
         val connections = mutableListOf<ConnectionSpec>()
         for (index in 0 until count) {
-            connections += axisConnections(random, index, horizontal = true)
-            connections += axisConnections(random, index, horizontal = false)
+            if (index > 0 && random.nextInt(5) == 0) {
+                circular += CircularSpec(
+                    from = index,
+                    target = random.nextInt(index),
+                    angle = random.nextInt(0, 360).toFloat(),
+                    radius = random.nextInt(10, 200),
+                )
+            } else {
+                connections += axisConnections(random, index, horizontal = true)
+                connections += axisConnections(random, index, horizontal = false)
+            }
         }
 
         return Scenario(
@@ -55,6 +82,7 @@ object Scenarios {
             rootMinHeight = if (random.nextInt(2) == 0) random.nextInt(1, 600) else 0,
             widgets = widgets,
             connections = connections,
+            circular = circular,
         )
     }
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -58,17 +58,20 @@ object Scenarios {
             GuidelineSpec(
                 name = "g$index",
                 vertical = random.nextBoolean(),
+                // The root is at least 400 (see rootWidth/rootHeight below), so an upper bound past
+                // that lets some draws land beyond the root's edge, not just short of it. Percent
+                // spans the full 0..100 inclusive so the 0% and 100% edges are reached too.
                 position = when (random.nextInt(3)) {
-                    0 -> GuidelinePosition.Begin(random.nextInt(10, 300))
-                    1 -> GuidelinePosition.End(random.nextInt(10, 300))
-                    else -> GuidelinePosition.Percent(random.nextInt(1, 100) / 100f)
+                    0 -> GuidelinePosition.Begin(random.nextInt(10, 500))
+                    1 -> GuidelinePosition.End(random.nextInt(10, 500))
+                    else -> GuidelinePosition.Percent(random.nextInt(0, 101) / 100f)
                 },
             )
         }
 
         // A barrier sits over widgets from the lower half, so widgets above it can target it
         // without closing a cycle. With fewer than two widgets there is no room for that.
-        val barriers = if (count >= 3 && random.nextInt(2) == 0) {
+        val barriers = if (count >= 2 && random.nextInt(2) == 0) {
             val ceiling = count / 2
             val referenced = (0 until ceiling).filter { random.nextBoolean() }.ifEmpty { listOf(0) }
             listOf(
@@ -158,18 +161,19 @@ object Scenarios {
         for ((position, member) in chain.members.withIndex()) {
             val previous = chain.members.getOrNull(position - 1)
             val next = chain.members.getOrNull(position + 1)
-            val margin = random.nextInt(0, 30)
 
+            // Margins are drawn independently per connection, same as the non-chain path, so
+            // asymmetric margins can occur here too.
             out += if (previous == null) {
-                ConnectionSpec(member, startSide, Target.Root, startSide, margin)
+                ConnectionSpec(member, startSide, Target.Root, startSide, random.nextInt(0, 30))
             } else {
-                ConnectionSpec(member, startSide, Target.Widget(previous), endSide, margin)
+                ConnectionSpec(member, startSide, Target.Widget(previous), endSide, random.nextInt(0, 30))
             }
 
             out += if (next == null) {
-                ConnectionSpec(member, endSide, Target.Root, endSide, margin)
+                ConnectionSpec(member, endSide, Target.Root, endSide, random.nextInt(0, 30))
             } else {
-                ConnectionSpec(member, endSide, Target.Widget(next), startSide, margin)
+                ConnectionSpec(member, endSide, Target.Widget(next), startSide, random.nextInt(0, 30))
             }
         }
         return out
@@ -188,19 +192,25 @@ object Scenarios {
     ): List<ConnectionSpec> {
         val (start, end) = if (horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
         val target = pickTarget(random, index, horizontal, barriers, guidelines)
+        val isLine = target is Target.Barrier || target is Target.Guideline
 
-        if (random.nextInt(3) == 0) {
+        if (isLine || random.nextInt(3) == 0) {
             // A single connection. Targeting a sibling's opposite side chains the widgets one after
             // another; targeting the matching side of the root or a sibling anchors them together.
-            // Both shapes matter, so pick between them rather than always chaining.
+            // Both shapes matter, so pick between them rather than always chaining. A barrier or
+            // guideline is a line rather than a span — `Guideline.getAnchor` returns the same
+            // anchor for both of its sides, and a barrier is likewise one-sided — so it is always
+            // single-connected here regardless of the roll.
             val toSide = if (target is Target.Widget && random.nextInt(2) == 0) end else start
             return listOf(ConnectionSpec(index, start, target, toSide, random.nextInt(0, 40)))
         }
 
         // Two connections anchor the widget to the container's two edges — each side to its
         // matching side, so the span between them (and therefore a MATCH_CONSTRAINT dimension) is
-        // real and positive rather than collapsing both anchors onto the same edge. Margins are
-        // drawn independently so asymmetric margins can occur.
+        // real and positive rather than collapsing both anchors onto the same edge. That only holds
+        // when the target has two distinct edges, true of the root and of a sibling widget; a
+        // barrier or guideline is handled above instead. Margins are drawn independently so
+        // asymmetric margins can occur.
         return listOf(
             ConnectionSpec(index, start, target, start, random.nextInt(0, 40)),
             ConnectionSpec(index, end, target, end, random.nextInt(0, 40)),
@@ -209,9 +219,11 @@ object Scenarios {
 
     /**
      * A barrier is only a legal target for a widget above every widget the barrier references —
-     * otherwise the barrier would depend on a widget that depends on the barrier. A guideline is
-     * only legal on the axis it divides: a vertical guideline is a vertical line, so widgets
-     * constrain to it horizontally.
+     * otherwise the barrier would depend on a widget that depends on the barrier. Both a barrier
+     * and a guideline are only legal on the axis they constrain: upstream `Barrier.addToSolver`
+     * emits equations for its own axis alone and never calls `super`, so a LEFT/RIGHT barrier is a
+     * vertical line usable only for horizontal connections, and likewise TOP/BOTTOM for vertical —
+     * the same rule `Guideline` follows, where a vertical guideline is a vertical line.
      */
     private fun pickTarget(
         random: Random,
@@ -220,7 +232,9 @@ object Scenarios {
         barriers: List<BarrierSpec>,
         guidelines: List<GuidelineSpec>,
     ): Target {
-        val barrierIndex = barriers.indices.filter { index > barriers[it].referenced.max() }
+        val barrierIndex = barriers.indices.filter {
+            index > barriers[it].referenced.max() && barriers[it].side.isHorizontal == horizontal
+        }
         val guidelineIndex = guidelines.indices.filter { guidelines[it].vertical == horizontal }
 
         val choices = buildList {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -9,9 +9,10 @@ import kotlin.random.Random
  * Generates layouts from a seed.
  *
  * Two properties are load-bearing. Generation is a pure function of the seed, so a divergence
- * reported by CI reproduces exactly. And connections only ever target the root or a lower-indexed
- * widget, so the constraint graph is acyclic — a cycle would leave the solver failing to settle,
- * and the harness would be measuring that instead of the port.
+ * reported by CI reproduces exactly. And connections only ever target the root, a lower-indexed
+ * widget, a guideline, or a barrier whose referenced widgets are all lower-indexed, so the
+ * constraint graph is acyclic — a cycle would leave the solver failing to settle, and the harness
+ * would be measuring that instead of the port.
  */
 object Scenarios {
     private const val MIN_WIDGETS = 2
@@ -51,6 +52,36 @@ object Scenarios {
             )
         }
 
+        // Guidelines depend on nothing, so any widget may target one.
+        val guidelines = (0 until random.nextInt(0, 3)).map { index ->
+            GuidelineSpec(
+                name = "g$index",
+                vertical = random.nextBoolean(),
+                position = when (random.nextInt(3)) {
+                    0 -> GuidelinePosition.Begin(random.nextInt(10, 300))
+                    1 -> GuidelinePosition.End(random.nextInt(10, 300))
+                    else -> GuidelinePosition.Percent(random.nextInt(1, 100) / 100f)
+                },
+            )
+        }
+
+        // A barrier sits over widgets from the lower half, so widgets above it can target it
+        // without closing a cycle. With fewer than two widgets there is no room for that.
+        val barriers = if (count >= 3 && random.nextInt(2) == 0) {
+            val ceiling = count / 2
+            val referenced = (0 until ceiling).filter { random.nextBoolean() }.ifEmpty { listOf(0) }
+            listOf(
+                BarrierSpec(
+                    name = "b0",
+                    side = Side.entries[random.nextInt(Side.entries.size)],
+                    margin = random.nextInt(0, 30),
+                    referenced = referenced,
+                ),
+            )
+        } else {
+            emptyList()
+        }
+
         // A widget is anchored either by its edges or circularly, never both: the two together
         // over-constrain it, and the solver's resolution of that conflict is not what this
         // harness is measuring.
@@ -65,8 +96,8 @@ object Scenarios {
                     radius = random.nextInt(10, 200),
                 )
             } else {
-                connections += axisConnections(random, index, horizontal = true)
-                connections += axisConnections(random, index, horizontal = false)
+                connections += axisConnections(random, index, horizontal = true, barriers, guidelines)
+                connections += axisConnections(random, index, horizontal = false, barriers, guidelines)
             }
         }
 
@@ -83,6 +114,8 @@ object Scenarios {
             widgets = widgets,
             connections = connections,
             circular = circular,
+            barriers = barriers,
+            guidelines = guidelines,
         )
     }
 
@@ -93,26 +126,60 @@ object Scenarios {
      * One or two connections on a single axis. Both sides are needed for `MATCH_CONSTRAINT` to mean
      * anything, so the two-sided case is common rather than incidental.
      */
-    private fun axisConnections(random: Random, index: Int, horizontal: Boolean): List<ConnectionSpec> {
+    private fun axisConnections(
+        random: Random,
+        index: Int,
+        horizontal: Boolean,
+        barriers: List<BarrierSpec>,
+        guidelines: List<GuidelineSpec>,
+    ): List<ConnectionSpec> {
         val (start, end) = if (horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
-        val target = if (index == 0 || random.nextInt(2) == 0) null else random.nextInt(index)
+        val target = pickTarget(random, index, horizontal, barriers, guidelines)
 
         if (random.nextInt(3) == 0) {
             // A single connection. Targeting a sibling's opposite side chains the widgets one after
             // another; targeting the matching side of the root or a sibling anchors them together.
             // Both shapes matter, so pick between them rather than always chaining.
-            val toSide = if (target != null && random.nextInt(2) == 0) end else start
+            val toSide = if (target is Target.Widget && random.nextInt(2) == 0) end else start
             return listOf(ConnectionSpec(index, start, target, toSide, random.nextInt(0, 40)))
         }
 
-        // Two connections anchor the widget to the container's two edges — the root's for a null
-        // target, a sibling's for a non-null one — each side to its matching side, so the span
-        // between them (and therefore a MATCH_CONSTRAINT dimension) is real and positive rather
-        // than collapsing both anchors onto the same edge. Margins are drawn independently so
-        // asymmetric margins can occur.
+        // Two connections anchor the widget to the container's two edges — each side to its
+        // matching side, so the span between them (and therefore a MATCH_CONSTRAINT dimension) is
+        // real and positive rather than collapsing both anchors onto the same edge. Margins are
+        // drawn independently so asymmetric margins can occur.
         return listOf(
             ConnectionSpec(index, start, target, start, random.nextInt(0, 40)),
             ConnectionSpec(index, end, target, end, random.nextInt(0, 40)),
         )
+    }
+
+    /**
+     * A barrier is only a legal target for a widget above every widget the barrier references —
+     * otherwise the barrier would depend on a widget that depends on the barrier. A guideline is
+     * only legal on the axis it divides: a vertical guideline is a vertical line, so widgets
+     * constrain to it horizontally.
+     */
+    private fun pickTarget(
+        random: Random,
+        index: Int,
+        horizontal: Boolean,
+        barriers: List<BarrierSpec>,
+        guidelines: List<GuidelineSpec>,
+    ): Target {
+        val barrierIndex = barriers.indices.filter { index > barriers[it].referenced.max() }
+        val guidelineIndex = guidelines.indices.filter { guidelines[it].vertical == horizontal }
+
+        val choices = buildList {
+            add { Target.Root }
+            if (index > 0) add { Target.Widget(random.nextInt(index)) }
+            if (barrierIndex.isNotEmpty()) {
+                add { Target.Barrier(barrierIndex[random.nextInt(barrierIndex.size)]) }
+            }
+            if (guidelineIndex.isNotEmpty()) {
+                add { Target.Guideline(guidelineIndex[random.nextInt(guidelineIndex.size)]) }
+            }
+        }
+        return choices[random.nextInt(choices.size)]()
     }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -12,7 +12,8 @@ import kotlin.random.Random
  * reported by CI reproduces exactly. And connections only ever target the root, a lower-indexed
  * widget, a guideline, or a barrier whose referenced widgets are all lower-indexed, so the
  * constraint graph is acyclic — a cycle would leave the solver failing to settle, and the harness
- * would be measuring that instead of the port.
+ * would be measuring that instead of the port. The one deliberate exception is a chain: its members
+ * link to each other in both directions, which is what makes a run of widgets a chain at all.
  */
 object Scenarios {
     private const val MIN_WIDGETS = 2
@@ -82,12 +83,31 @@ object Scenarios {
             emptyList()
         }
 
+        // A chain claims a contiguous run of widgets on one axis. Its members get no ordinary
+        // connections on that axis — the chain supplies them — and none on the other either, to
+        // keep the generated shape simple enough to reason about when a divergence is reported.
+        val chains = if (count >= 3 && random.nextInt(2) == 0) {
+            val length = random.nextInt(2, minOf(count, 4) + 1)
+            val first = random.nextInt(0, count - length + 1)
+            listOf(
+                ChainSpec(
+                    members = (first until first + length).toList(),
+                    horizontal = random.nextBoolean(),
+                    style = ChainStyle.entries[random.nextInt(ChainStyle.entries.size)],
+                ),
+            )
+        } else {
+            emptyList()
+        }
+        val chained = chains.flatMap { it.members }.toSet()
+
         // A widget is anchored either by its edges or circularly, never both: the two together
         // over-constrain it, and the solver's resolution of that conflict is not what this
         // harness is measuring.
         val circular = mutableListOf<CircularSpec>()
         val connections = mutableListOf<ConnectionSpec>()
         for (index in 0 until count) {
+            if (index in chained) continue
             if (index > 0 && random.nextInt(5) == 0) {
                 circular += CircularSpec(
                     from = index,
@@ -100,6 +120,7 @@ object Scenarios {
                 connections += axisConnections(random, index, horizontal = false, barriers, guidelines)
             }
         }
+        chains.forEach { connections += chainConnections(random, it) }
 
         return Scenario(
             seed = seed,
@@ -116,11 +137,43 @@ object Scenarios {
             circular = circular,
             barriers = barriers,
             guidelines = guidelines,
+            chains = chains,
         )
     }
 
     private fun behaviour(random: Random): Behaviour =
         Behaviour.entries[random.nextInt(Behaviour.entries.size)]
+
+    /**
+     * Emits a chain as one unit: the head anchored outward, every adjacent pair linked in both
+     * directions, the tail anchored outward. There is no path through this function that produces a
+     * partial chain — the reverse links are what make it a chain at all, and a run missing one is
+     * just a row of widgets that looks like coverage.
+     */
+    private fun chainConnections(random: Random, chain: ChainSpec): List<ConnectionSpec> {
+        val (startSide, endSide) =
+            if (chain.horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
+        val out = mutableListOf<ConnectionSpec>()
+
+        for ((position, member) in chain.members.withIndex()) {
+            val previous = chain.members.getOrNull(position - 1)
+            val next = chain.members.getOrNull(position + 1)
+            val margin = random.nextInt(0, 30)
+
+            out += if (previous == null) {
+                ConnectionSpec(member, startSide, Target.Root, startSide, margin)
+            } else {
+                ConnectionSpec(member, startSide, Target.Widget(previous), endSide, margin)
+            }
+
+            out += if (next == null) {
+                ConnectionSpec(member, endSide, Target.Root, endSide, margin)
+            } else {
+                ConnectionSpec(member, endSide, Target.Widget(next), startSide, margin)
+            }
+        }
+        return out
+    }
 
     /**
      * One or two connections on a single axis. Both sides are needed for `MATCH_CONSTRAINT` to mean

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -23,9 +23,13 @@ class ScenariosTest {
     fun connectionsAreAcyclic() {
         for (seed in 1L..200L) {
             val scenario = Scenarios.generate(seed)
+            val chained = scenario.chains.flatMap { it.members }.toSet()
             for (connection in scenario.connections) {
                 val target = connection.target
-                if (target is Target.Widget) {
+                // A chain's own forward links deliberately target a higher-indexed widget — that
+                // reverse link is what makes it a chain. Every other connection still only ever
+                // targets the root or a lower-indexed widget.
+                if (target is Target.Widget && connection.from !in chained) {
                     assertTrue(
                         target.index < connection.from,
                         "seed $seed: widget ${connection.from} targets ${target.index}",
@@ -211,5 +215,86 @@ class ScenariosTest {
             }
         }
         assertEquals(setOf("Begin", "End", "Percent"), kinds, "generated kinds: $kinds")
+    }
+
+    @Test
+    fun someScenariosCarryAChain() {
+        val matching = (1L..300L).count { Scenarios.generate(it).chains.isNotEmpty() }
+        assertTrue(matching >= 30, "only $matching of 300 scenarios carry a chain")
+    }
+
+    @Test
+    fun chainMembersAreContiguousAndAtLeastTwo() {
+        for (seed in 1L..300L) {
+            for (chain in Scenarios.generate(seed).chains) {
+                assertTrue(chain.members.size >= 2, "seed $seed: chain of ${chain.members.size}")
+                assertEquals(
+                    chain.members,
+                    chain.members.sorted(),
+                    "seed $seed: chain members out of order",
+                )
+            }
+        }
+    }
+
+    /**
+     * The whole point. A chain is a bidirectional run: every adjacent pair links both ways, and the
+     * two ends anchor outward. A partially emitted chain is the exact shape of the degenerate
+     * connections that once passed unnoticed, so completeness is asserted rather than assumed.
+     */
+    @Test
+    fun everyChainIsEmittedWhole() {
+        for (seed in 1L..300L) {
+            val scenario = Scenarios.generate(seed)
+            for (chain in scenario.chains) {
+                val (startSide, endSide) =
+                    if (chain.horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
+                val links = scenario.connections.filter { it.from in chain.members }
+
+                for ((position, member) in chain.members.withIndex()) {
+                    val previous = chain.members.getOrNull(position - 1)
+                    val next = chain.members.getOrNull(position + 1)
+
+                    val backward = links.single { it.from == member && it.fromSide == startSide }
+                    if (previous == null) {
+                        assertTrue(
+                            backward.target is Target.Root,
+                            "seed $seed: chain head $member is not anchored outward",
+                        )
+                    } else {
+                        assertEquals(
+                            Target.Widget(previous),
+                            backward.target,
+                            "seed $seed: chain member $member does not link back to $previous",
+                        )
+                        assertEquals(endSide, backward.toSide, "seed $seed: member $member")
+                    }
+
+                    val forward = links.single { it.from == member && it.fromSide == endSide }
+                    if (next == null) {
+                        assertTrue(
+                            forward.target is Target.Root,
+                            "seed $seed: chain tail $member is not anchored outward",
+                        )
+                    } else {
+                        assertEquals(
+                            Target.Widget(next),
+                            forward.target,
+                            "seed $seed: chain member $member does not link on to $next",
+                        )
+                        assertEquals(startSide, forward.toSide, "seed $seed: member $member")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun everyChainStyleIsGenerated() {
+        val styles = mutableSetOf<ChainStyle>()
+        for (seed in 1L..300L) {
+            Scenarios.generate(seed).chains.forEach { styles += it.style }
+        }
+        assertEquals(ChainStyle.entries.toSet(), styles, "generated styles: $styles")
     }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -85,4 +85,61 @@ class ScenariosTest {
         }
         assertTrue(matching >= 10, "only $matching of 200 scenarios exercise the root minimum")
     }
+
+    @Test
+    fun ratiosOnlyAppearOnWidgetsWithAMatchConstraintAxis() {
+        for (seed in 1L..300L) {
+            for (widget in Scenarios.generate(seed).widgets) {
+                if (widget.dimensionRatio != null) {
+                    assertTrue(
+                        widget.horizontal == Behaviour.MATCH_CONSTRAINT ||
+                            widget.vertical == Behaviour.MATCH_CONSTRAINT,
+                        "seed $seed: ${widget.name} has ratio ${widget.dimensionRatio} " +
+                            "but neither axis is MATCH_CONSTRAINT, so the ratio is inert",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun someScenariosCarryARatio() {
+        val matching = (1L..300L).count { seed ->
+            Scenarios.generate(seed).widgets.any { it.dimensionRatio != null }
+        }
+        assertTrue(matching >= 30, "only $matching of 300 scenarios carry a ratio")
+    }
+
+    @Test
+    fun circularConstraintsTargetLowerIndices() {
+        for (seed in 1L..300L) {
+            for (circular in Scenarios.generate(seed).circular) {
+                assertTrue(
+                    circular.target < circular.from,
+                    "seed $seed: widget ${circular.from} circles ${circular.target}",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun circularlyConstrainedWidgetsHaveNoAnchorConnections() {
+        for (seed in 1L..300L) {
+            val scenario = Scenarios.generate(seed)
+            val circled = scenario.circular.map { it.from }.toSet()
+            for (connection in scenario.connections) {
+                assertTrue(
+                    connection.from !in circled,
+                    "seed $seed: widget ${connection.from} has both a circular constraint and " +
+                        "an anchor connection, which over-constrains it",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun someScenariosCarryACircularConstraint() {
+        val matching = (1L..300L).count { Scenarios.generate(it).circular.isNotEmpty() }
+        assertTrue(matching >= 30, "only $matching of 300 scenarios carry a circular constraint")
+    }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -23,13 +23,14 @@ class ScenariosTest {
     fun connectionsAreAcyclic() {
         for (seed in 1L..200L) {
             val scenario = Scenarios.generate(seed)
-            val chained = scenario.chains.flatMap { it.members }.toSet()
+            // A chain's own forward link is the one deliberate exception: it targets the next
+            // (higher-indexed) member, which is what makes the run a chain. That exception is
+            // scoped to exactly those (from, target) pairs — a chain member's *backward* link
+            // still only ever targets the root or a lower-indexed widget, same as everything else.
+            val chainForwardLinks = scenario.chains.flatMap { it.members.zipWithNext() }.toSet()
             for (connection in scenario.connections) {
                 val target = connection.target
-                // A chain's own forward links deliberately target a higher-indexed widget — that
-                // reverse link is what makes it a chain. Every other connection still only ever
-                // targets the root or a lower-indexed widget.
-                if (target is Target.Widget && connection.from !in chained) {
+                if (target is Target.Widget && (connection.from to target.index) !in chainForwardLinks) {
                     assertTrue(
                         target.index < connection.from,
                         "seed $seed: widget ${connection.from} targets ${target.index}",
@@ -284,6 +285,39 @@ class ScenariosTest {
                         )
                         assertEquals(startSide, forward.toSide, "seed $seed: member $member")
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * Completes the guarantee `everyChainIsEmittedWhole` leaves open: that test pins down what a
+     * chain member's two axis-side connections point at, but never asserts there are only two —
+     * a stray connection on the orthogonal axis, or a duplicate on the same side, would still pass
+     * it. Without this, chain-member acyclicity rests on reading `generate()`'s `continue` guard
+     * rather than on the suite actually proving it.
+     */
+    @Test
+    fun chainMembersHaveExactlyTheChainsTwoConnections() {
+        for (seed in 1L..300L) {
+            val scenario = Scenarios.generate(seed)
+            for (chain in scenario.chains) {
+                val (startSide, endSide) =
+                    if (chain.horizontal) Side.LEFT to Side.RIGHT else Side.TOP to Side.BOTTOM
+                for (member in chain.members) {
+                    val fromMember = scenario.connections.filter { it.from == member }
+                    assertEquals(
+                        2,
+                        fromMember.size,
+                        "seed $seed: chain member $member has ${fromMember.size} connections, " +
+                            "expected exactly the 2 the chain supplies",
+                    )
+                    assertEquals(
+                        setOf(startSide, endSide),
+                        fromMember.map { it.fromSide }.toSet(),
+                        "seed $seed: chain member $member's connections are not exactly one per " +
+                            "chain-axis side",
+                    )
                 }
             }
         }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -25,10 +25,12 @@ class ScenariosTest {
             val scenario = Scenarios.generate(seed)
             for (connection in scenario.connections) {
                 val target = connection.target
-                assertTrue(
-                    target == null || target < connection.from,
-                    "seed $seed: widget ${connection.from} targets $target",
-                )
+                if (target is Target.Widget) {
+                    assertTrue(
+                        target.index < connection.from,
+                        "seed $seed: widget ${connection.from} targets ${target.index}",
+                    )
+                }
             }
         }
     }
@@ -141,5 +143,73 @@ class ScenariosTest {
     fun someScenariosCarryACircularConstraint() {
         val matching = (1L..300L).count { Scenarios.generate(it).circular.isNotEmpty() }
         assertTrue(matching >= 30, "only $matching of 300 scenarios carry a circular constraint")
+    }
+
+    @Test
+    fun barriersAlwaysReferenceAtLeastOneWidget() {
+        for (seed in 1L..300L) {
+            for (barrier in Scenarios.generate(seed).barriers) {
+                assertTrue(
+                    barrier.referenced.isNotEmpty(),
+                    "seed $seed: ${barrier.name} references nothing and resolves to nothing useful",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun connectionsToABarrierComeFromWidgetsBelowItsReferences() {
+        for (seed in 1L..300L) {
+            val scenario = Scenarios.generate(seed)
+            for (connection in scenario.connections) {
+                val target = connection.target
+                if (target is Target.Barrier) {
+                    val highest = scenario.barriers[target.index].referenced.max()
+                    assertTrue(
+                        connection.from > highest,
+                        "seed $seed: widget ${connection.from} targets a barrier over widget " +
+                            "$highest, which would close a cycle",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun everyConnectionTargetResolves() {
+        for (seed in 1L..300L) {
+            val scenario = Scenarios.generate(seed)
+            for (connection in scenario.connections) {
+                when (val target = connection.target) {
+                    is Target.Root -> Unit
+                    is Target.Widget -> assertTrue(target.index in scenario.widgets.indices)
+                    is Target.Barrier -> assertTrue(target.index in scenario.barriers.indices)
+                    is Target.Guideline -> assertTrue(target.index in scenario.guidelines.indices)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun someScenariosCarryABarrier() {
+        val matching = (1L..300L).count { Scenarios.generate(it).barriers.isNotEmpty() }
+        assertTrue(matching >= 30, "only $matching of 300 scenarios carry a barrier")
+    }
+
+    @Test
+    fun someScenariosCarryAGuideline() {
+        val matching = (1L..300L).count { Scenarios.generate(it).guidelines.isNotEmpty() }
+        assertTrue(matching >= 30, "only $matching of 300 scenarios carry a guideline")
+    }
+
+    @Test
+    fun everyGuidelinePositionKindIsGenerated() {
+        val kinds = mutableSetOf<String>()
+        for (seed in 1L..300L) {
+            for (guideline in Scenarios.generate(seed).guidelines) {
+                kinds += guideline.position::class.simpleName.orEmpty()
+            }
+        }
+        assertEquals(setOf("Begin", "End", "Percent"), kinds, "generated kinds: $kinds")
     }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -180,19 +180,25 @@ class ScenariosTest {
         }
     }
 
+    /**
+     * `someScenariosCarryABarrier` and `someScenariosCarryAGuideline` below only prove those
+     * participants get constructed — neither proves any connection actually points at one. An
+     * off-by-one in the barrier index or axis filtering inside `pickTarget` could silently drop
+     * every barrier (or guideline) connection while every other test, including those two, stayed
+     * green: the branch would claim coverage it did not have. This also folds in what
+     * `everyConnectionTargetResolves` used to check — every target's index is constructed from
+     * `.indices` inside `pickTarget`, so resolution can never fail; a variant simply never
+     * appearing was the real gap.
+     */
     @Test
-    fun everyConnectionTargetResolves() {
+    fun everyTargetVariantIsEmittedAsAConnectionTarget() {
+        val kinds = mutableSetOf<String>()
         for (seed in 1L..300L) {
-            val scenario = Scenarios.generate(seed)
-            for (connection in scenario.connections) {
-                when (val target = connection.target) {
-                    is Target.Root -> Unit
-                    is Target.Widget -> assertTrue(target.index in scenario.widgets.indices)
-                    is Target.Barrier -> assertTrue(target.index in scenario.barriers.indices)
-                    is Target.Guideline -> assertTrue(target.index in scenario.guidelines.indices)
-                }
+            for (connection in Scenarios.generate(seed).connections) {
+                kinds += connection.target::class.simpleName.orEmpty()
             }
         }
+        assertEquals(setOf("Root", "Widget", "Barrier", "Guideline"), kinds, "generated kinds: $kinds")
     }
 
     @Test
@@ -229,11 +235,13 @@ class ScenariosTest {
         for (seed in 1L..300L) {
             for (chain in Scenarios.generate(seed).chains) {
                 assertTrue(chain.members.size >= 2, "seed $seed: chain of ${chain.members.size}")
-                assertEquals(
-                    chain.members,
-                    chain.members.sorted(),
-                    "seed $seed: chain members out of order",
-                )
+                for ((a, b) in chain.members.zipWithNext()) {
+                    assertEquals(
+                        a + 1,
+                        b,
+                        "seed $seed: chain members are not contiguous: ${chain.members}",
+                    )
+                }
             }
         }
     }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -69,6 +69,9 @@ class SolverDifferentialTest {
                 .append('\n')
             scenario.widgets.forEach { append("widget   : ").append(it).append('\n') }
             scenario.connections.forEach { append("connect  : ").append(it).append('\n') }
+            scenario.circular.forEach { append("circular : ").append(it).append('\n') }
+            scenario.barriers.forEach { append("barrier  : ").append(it).append('\n') }
+            scenario.guidelines.forEach { append("guideline: ").append(it).append('\n') }
             append("oracle   :\n").append(indent(oracle)).append('\n')
             append("port     :\n").append(indent(port))
         }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -72,6 +72,7 @@ class SolverDifferentialTest {
             scenario.circular.forEach { append("circular : ").append(it).append('\n') }
             scenario.barriers.forEach { append("barrier  : ").append(it).append('\n') }
             scenario.guidelines.forEach { append("guideline: ").append(it).append('\n') }
+            scenario.chains.forEach { append("chain    : ").append(it).append('\n') }
             append("oracle   :\n").append(indent(oracle)).append('\n')
             append("port     :\n").append(indent(port))
         }


### PR DESCRIPTION
Builds on #338, which compares the solver on dimension behaviours, margins, biases and plain anchor connections. That found nothing — the right result, but it only speaks for the ground it covers. Everything a real layout leans on beyond that was untested by comparison, and `widgets/analyzer` alone is sixteen files largely about chain and barrier resolution.

This adds five helpers, grouped by the three mechanisms they actually are rather than by name.

## Three mechanisms

| Helper | What it is in `core` terms |
|---|---|
| Aspect ratio, circular constraint | Properties of a widget |
| Barrier, guideline | New participants in the tree — `Barrier` extends `HelperWidget`, `Guideline` extends `ConstraintWidget` |
| Chain | Not a class at all — a pattern of bidirectional connections plus a style on the head |

Barriers and guidelines exist to be constrained against, so `ConnectionSpec.target` stops being `Int?` and becomes a `Target` sealed interface over root, widget, barrier and guideline. Both new participants are rendered into the compared geometry: without that the harness could construct a barrier, have the two implementations resolve it to different positions, and report success.

## The chain invariant

A chain is a bidirectional link pair — upstream's own tests show it plainly:

```java
a.connect(RIGHT, b, LEFT);
b.connect(LEFT,  a, RIGHT);   // the reverse link IS the chain
```

That deliberately violates the generator's rule that a connection targets the root or a lower-indexed widget. The rule is reformulated rather than dropped: **connections are acyclic except within a chain, and a chain is emitted whole or not at all.** A run missing its reverse links is just a row of widgets that looks like coverage — the exact failure that slipped through in #338's first generator — so completeness is asserted, not assumed. `everyChainIsEmittedWhole` checks every member's anchoring and both link directions; a companion test asserts exclusivity, that a member has exactly the two connections the chain supplies and nothing on the orthogonal axis.

## Keeping generated coverage honest

The recurring lesson from this harness is that a generator can produce inputs that look like coverage and exercise nothing. Three such traps are closed by construction and pinned by tests:

- A ratio only appears on a widget with a `MATCH_CONSTRAINT` axis. On a fixed-size widget the ratio is inert.
- A circularly-constrained widget gets no anchor connections. The two together over-constrain it, and what the solver does with that conflict is not what this harness measures.
- A barrier is only offered as a target on its own axis. `Barrier.addToSolver` emits equations for one axis and never calls `super`, so a TOP/BOTTOM connection onto a LEFT/RIGHT barrier anchors a widget to a free variable.

Every mechanism also has an assertion that it is genuinely generated, and a census that each `Target` variant is actually emitted — an off-by-one in the barrier filter would otherwise silently drop every barrier connection while the suite stayed green.

## Proving the new coverage reaches helper code

#338 proved its harness by mutating `ConstraintWidget`'s minimum clamp. Repeating that here would prove nothing about helpers: it is a path shared by everything. Two targeted probes instead, each mutating one line in the port and requiring the harness to go red.

- **Barrier** — `Barrier.kt:429`, `barrierPosition += mMargin` → `+ mMargin + 1`: **17 of 2000** scenarios diverged. Seed 75, barrier `b0`: oracle x=437, port x=438.
- **Chain** — `Chain.kt:441`, the `isChainSpread` centring bias `0.5f` → `0.6f`: **51 of 2000** diverged. Seed 54, members `w3`/`w4`/`w5` shifted by 19, 9 and −19.

Both reverted; nothing under `compose/` is modified.

## A coverage limitation worth stating plainly

The chain probe first targeted `analyzer/ChainRun.kt` and did **not** fire. That code only runs under `Optimizer.OPTIMIZATION_GRAPH`, and both subjects call `root.layout()` at the default `OPTIMIZATION_STANDARD` — so the graph-optimizer path is not exercised by this harness at all.

This matters more than a skipped corner, because `optimizationLevel` is a public API parameter. A consumer can put `ChainRun`, `DependencyGraph`, `WidgetRun` and the rest of that hand-ported subtree on the hot path today with no differential coverage behind them. Read "the solver is compared" as covering the standard path, not the whole `core/widgets` tree.

The fix is small — an optimization-level axis on `Scenario` and one line in each subject — and is the natural follow-up.

## Verification

446 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`. 42 tests in `:parity`, up from 26. CI's existing `Parity tests` step runs the whole module, so no workflow change was needed.

## Not in this PR

`Flow`, `Grid`, `Placeholder` and the other `VirtualLayout` subclasses — markedly more involved to construct, and worth doing only once these five have earned their keep.
