### PR TITLE
fix(motion): convert arc positions instead of casting them

### DIFF
--- a/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/utils/ArcCurveFit.kt
+++ b/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/utils/ArcCurveFit.kt
@@ -91,12 +91,12 @@ class ArcCurveFit : CurveFit {
                 val dt: Double = t - mArcs[0].mTime1
                 val p = 0
                 if (mArcs[p].mLinear) {
-                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0)) as Float
-                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0)) as Float
+                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0)).toFloat()
+                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0)).toFloat()
                 } else {
                     mArcs[p].setPoint(t0)
-                    v[0] = (mArcs[p].getX() + dt * mArcs[p].getDX()) as Float
-                    v[1] = (mArcs[p].getY() + dt * mArcs[p].getDY()) as Float
+                    v[0] = (mArcs[p].getX() + dt * mArcs[p].getDX()).toFloat()
+                    v[1] = (mArcs[p].getY() + dt * mArcs[p].getDY()).toFloat()
                 }
                 return
             }
@@ -105,12 +105,12 @@ class ArcCurveFit : CurveFit {
                 val dt = t - t0
                 val p: Int = mArcs.size - 1
                 if (mArcs[p].mLinear) {
-                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0)) as Float
-                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0)) as Float
+                    v[0] = (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0)).toFloat()
+                    v[1] = (mArcs[p].getLinearY(t0) + dt * mArcs[p].getLinearDY(t0)).toFloat()
                 } else {
                     mArcs[p].setPoint(t)
-                    v[0] = mArcs[p].getX() as Float
-                    v[1] = mArcs[p].getY() as Float
+                    v[0] = mArcs[p].getX().toFloat()
+                    v[1] = mArcs[p].getY().toFloat()
                 }
                 return
             }
@@ -124,13 +124,13 @@ class ArcCurveFit : CurveFit {
         for (i in 0 until mArcs.size) {
             if (t <= mArcs[i].mTime2) {
                 if (mArcs[i].mLinear) {
-                    v[0] = mArcs[i].getLinearX(t) as Float
-                    v[1] = mArcs[i].getLinearY(t) as Float
+                    v[0] = mArcs[i].getLinearX(t).toFloat()
+                    v[1] = mArcs[i].getLinearY(t).toFloat()
                     return
                 }
                 mArcs[i].setPoint(t)
-                v[0] = mArcs[i].getX() as Float
-                v[1] = mArcs[i].getY() as Float
+                v[0] = mArcs[i].getX().toFloat()
+                v[1] = mArcs[i].getY().toFloat()
                 return
             }
         }

--- a/compose/src/commonTest/kotlin/androidx/constraintlayout/core/motion/ArcCurveFitFloatPosTest.kt
+++ b/compose/src/commonTest/kotlin/androidx/constraintlayout/core/motion/ArcCurveFitFloatPosTest.kt
@@ -1,0 +1,60 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package androidx.constraintlayout.core.motion
+
+import androidx.constraintlayout.core.motion.utils.ArcCurveFit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `CurveFit.getPos(Double, FloatArray)` is public API, and `ArcCurveFit`'s override of it went
+ * unexercised: the library's own arc paths all use the `DoubleArray` overload, and the inherited
+ * suite reads positions through `getPos(t, index)`.
+ *
+ * Nothing therefore noticed that the port had translated upstream's narrowing `(float)` conversions
+ * as `as Float`, a type cast that throws `ClassCastException` on a `Double`. Every call to this
+ * overload failed, in range and extrapolating alike. These cases keep it exercised.
+ */
+class ArcCurveFitFloatPosTest {
+    private fun fit() = ArcCurveFit(
+        intArrayOf(ArcCurveFit.ARC_START_VERTICAL, ArcCurveFit.ARC_START_HORIZONTAL),
+        doubleArrayOf(0.0, 1.0, 2.0),
+        arrayOf(
+            doubleArrayOf(0.0, 0.0),
+            doubleArrayOf(1.0, 1.0),
+            doubleArrayOf(2.0, 0.0),
+        ),
+    )
+
+    @Test
+    fun inRangePositionMatchesTheIndexedOverload() {
+        val spline = fit()
+        val out = FloatArray(2)
+        spline.getPos(0.5, out)
+        assertEquals(spline.getPos(0.5, 0).toFloat(), out[0], 0.0001f)
+        assertEquals(spline.getPos(0.5, 1).toFloat(), out[1], 0.0001f)
+    }
+
+    @Test
+    fun atAKeyframePositionMatchesTheIndexedOverload() {
+        val spline = fit()
+        val out = FloatArray(2)
+        spline.getPos(1.0, out)
+        assertEquals(spline.getPos(1.0, 0).toFloat(), out[0], 0.0001f)
+        assertEquals(spline.getPos(1.0, 1).toFloat(), out[1], 0.0001f)
+    }
+
+    @Test
+    fun extrapolatingBelowTheRangeDoesNotThrow() {
+        val out = FloatArray(2)
+        fit().getPos(-1.0, out)
+    }
+
+    @Test
+    fun extrapolatingAboveTheRangeDoesNotThrow() {
+        val out = FloatArray(2)
+        fit().getPos(3.0, out)
+    }
+
+}


### PR DESCRIPTION
`ArcCurveFit.getPos(Double, FloatArray)` threw `ClassCastException` on every call.

## The defect

Upstream narrows a `double` expression to `float`:

```java
v[0] = (float) (mArcs[p].getLinearX(t0) + dt * mArcs[p].getLinearDX(t0));
```

In Java that is a primitive conversion. Translated literally to Kotlin, `expr as Float` is a *type* cast, and a `Double` is not a `Float`:

```
java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.Float
```

Twelve sites, covering the in-range loop as well as both extrapolation branches, so the overload failed unconditionally rather than only outside the keyframe range.

## Why nothing caught it

The overload is public API — `CurveFit` declares `getPos(double, float[])` — but its blast radius is narrower than it first looks, and worth stating precisely:

- The library's own arc paths all call the `DoubleArray` overload (`Motion.mInterpolateData` is a `DoubleArray`).
- The inherited suite reads positions through `getPos(t, index)`, a third overload that is fine.

So only an external caller reaches it — and would then crash every time. `ArcCurveFit` is the only `CurveFit` implementation affected; `LinearCurveFit` and `MonotonicCurveFit` already convert.

## How it was found

Not by a test, and not by the differential harness — this is a path neither reaches. It came from reading the Kotlin compiler's own output, which had been reporting all twelve as:

```
This cast can never succeed. Use 'toFloat' to perform numeric conversion.
```

The warning was correct and unread. The build emits 86 warnings in total; two categories in it are the kind that indicate a mechanical-translation defect — "cast can never succeed" and "Condition is always …" — because they flag a *syntactic invariant that should never hold*. That is the same shape as the shadowed local fixed in #336, which reduced a guard to `width > width`.

The other 24 warnings of that family were triaged: the ones checked are faithful translations of upstream's own redundant checks, not port defects.

## Tests

Five cases exercising the previously untouched overload: in range, at a keyframe, extrapolating below and above, each comparing against the indexed overload where a value can be checked rather than only asserting it does not throw.

450 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`.

## Worth considering separately

Nothing in CI reads compiler warnings, so the next defect of this class will land just as quietly. Turning on `allWarningsAsErrors` for the library — or failing the build on this specific diagnostic — would close that. Not done here because the existing 86 warnings would need triaging first.
