### PR TITLE
fix(motion): read and write the same mask slot in different()

### DIFF
--- a/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/MotionConstrainedPoint.kt
+++ b/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/MotionConstrainedPoint.kt
@@ -130,13 +130,25 @@ class MotionConstrainedPoint : Comparable<MotionConstrainedPoint> {
         }
     }
 
+    // Upstream writes these as `mask[c++] |= expr`, where Java evaluates the index once and reads
+    // and writes the same slot. Kotlin has no `|=` for Boolean, and expanding it to
+    // `mask[c++] = mask[c++] or expr` evaluates the index twice: it wrote to every other slot,
+    // read from the ones in between, and advanced `c` by two per line. The index is now read once
+    // per slot, and `c` advances separately.
+    //
+    // Nothing calls this overload — neither here nor upstream — but it is corrected rather than
+    // removed, so it stays a faithful copy of the original.
     fun different(points: MotionConstrainedPoint, mask: BooleanArray, custom: Array<String?>?) {
         var c = 0
-        mask[c++] = mask[c++] or diff(mPosition, points.mPosition)
-        mask[c++] = mask[c++] or diff(mX, points.mX)
-        mask[c++] = mask[c++] or diff(mY, points.mY)
-        mask[c++] = mask[c++] or diff(mWidth, points.mWidth)
-        mask[c++] = mask[c++] or diff(mHeight, points.mHeight)
+        mask[c] = mask[c] or diff(mPosition, points.mPosition)
+        c++
+        mask[c] = mask[c] or diff(mX, points.mX)
+        c++
+        mask[c] = mask[c] or diff(mY, points.mY)
+        c++
+        mask[c] = mask[c] or diff(mWidth, points.mWidth)
+        c++
+        mask[c] = mask[c] or diff(mHeight, points.mHeight)
     }
 
     var mTempValue = DoubleArray(18)

--- a/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/MotionPaths.kt
+++ b/compose/src/commonMain/kotlin/androidx/constraintlayout/core/motion/MotionPaths.kt
@@ -275,15 +275,23 @@ class MotionPaths : Comparable<MotionPaths> {
         }
     }
 
+    // Upstream writes these as `mask[c++] |= expr`, where Java evaluates the index once and reads
+    // and writes the same slot. Kotlin has no `|=` for Boolean, and expanding it to
+    // `mask[c++] = mask[c] or expr` evaluates the index twice, so each slot took in its NEIGHBOUR's
+    // value instead of its own. The index is now read once per slot, and `c` advances separately.
     fun different(points: MotionPaths, mask: BooleanArray, custom: Array<String>, arcMode: Boolean) {
         var c = 0
         val diffx = diff(mX, points.mX)
         val diffy = diff(mY, points.mY)
-        mask[c++] = mask[c] or diff(mPosition, points.mPosition)
-        mask[c++] = mask[c] or (diffx || diffy || arcMode)
-        mask[c++] = mask[c] or (diffx || diffy || arcMode)
-        mask[c++] = mask[c] or diff(mWidth, points.mWidth)
-        mask[c++] = mask[c] or diff(mHeight, points.mHeight)
+        mask[c] = mask[c] or diff(mPosition, points.mPosition)
+        c++
+        mask[c] = mask[c] or (diffx || diffy || arcMode)
+        c++
+        mask[c] = mask[c] or (diffx || diffy || arcMode)
+        c++
+        mask[c] = mask[c] or diff(mWidth, points.mWidth)
+        c++
+        mask[c] = mask[c] or diff(mHeight, points.mHeight)
     }
 
     fun getCenter(p: Double, toUse: IntArray, data: DoubleArray, point: FloatArray, offset: Int) {

--- a/compose/src/commonTest/kotlin/androidx/constraintlayout/core/motion/DifferentMaskTest.kt
+++ b/compose/src/commonTest/kotlin/androidx/constraintlayout/core/motion/DifferentMaskTest.kt
@@ -1,0 +1,85 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package androidx.constraintlayout.core.motion
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `different()` accumulates, per animated property, whether it changes between two keyframes.
+ * Upstream writes each slot as `mask[c++] |= expr`, which in Java reads and writes the same slot.
+ * Kotlin has no `|=` for `Boolean`, and the expansion the port used evaluated the index twice — so
+ * a slot took in its neighbour's value instead of its own, and `Motion` went on to build splines
+ * for the wrong set of properties.
+ *
+ * These cases pin the mask down slot by slot, which is the only way the off-by-one shows: the
+ * inherited suite checks rendered motion, where a wrong mask still produces plausible output.
+ */
+class DifferentMaskTest {
+    private fun paths(x: Float, y: Float, width: Float, height: Float, position: Float) =
+        MotionPaths().also {
+            it.mX = x
+            it.mY = y
+            it.mWidth = width
+            it.mHeight = height
+            it.mPosition = position
+        }
+
+    @Test
+    fun aSingleChangedPropertyMarksOnlyItsOwnSlot() {
+        val a = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 0f)
+        val b = paths(x = 0f, y = 0f, width = 99f, height = 20f, position = 0f)
+        val mask = BooleanArray(5)
+
+        a.different(b, mask, arrayOf(), false)
+
+        // Slots are position, x, y, width, height. Only width differs.
+        assertEquals(listOf(false, false, false, true, false), mask.toList())
+    }
+
+    @Test
+    fun identicalPathsLeaveEverySlotClear() {
+        val a = paths(x = 1f, y = 2f, width = 3f, height = 4f, position = 5f)
+        val b = paths(x = 1f, y = 2f, width = 3f, height = 4f, position = 5f)
+        val mask = BooleanArray(5)
+
+        a.different(b, mask, arrayOf(), false)
+
+        assertEquals(List(5) { false }, mask.toList())
+    }
+
+    @Test
+    fun aChangedPositionMarksTheFirstSlot() {
+        val a = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 0f)
+        val b = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 1f)
+        val mask = BooleanArray(5)
+
+        a.different(b, mask, arrayOf(), false)
+
+        assertEquals(listOf(true, false, false, false, false), mask.toList())
+    }
+
+    @Test
+    fun accumulationAcrossCallsIsRetained() {
+        val mask = BooleanArray(5)
+        val base = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 0f)
+
+        base.different(paths(0f, 0f, 99f, 20f, 0f), mask, arrayOf(), false)
+        base.different(paths(0f, 0f, 10f, 77f, 0f), mask, arrayOf(), false)
+
+        // Width from the first call, height from the second; neither clears the other.
+        assertEquals(listOf(false, false, false, true, true), mask.toList())
+    }
+
+    @Test
+    fun arcModeMarksBothPositionSlots() {
+        val a = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 0f)
+        val b = paths(x = 0f, y = 0f, width = 10f, height = 20f, position = 0f)
+        val mask = BooleanArray(5)
+
+        a.different(b, mask, arrayOf(), true)
+
+        assertEquals(listOf(false, true, true, false, false), mask.toList())
+    }
+}


### PR DESCRIPTION
`MotionPaths.different()` built its mask from shifted data, so `Motion` created splines for the wrong set of properties.

## The defect

`different()` records, per animated property, whether it changes between two keyframes. Upstream accumulates each slot with a compound assignment:

```java
mask[c++] |= diff(mPosition, points.mPosition);
```

Java evaluates the index expression **once**: the read and the write hit the same slot, and `c` advances by one.

Kotlin has no `|=` for `Boolean`, so the port expanded it — and both expansions evaluate the index twice.

**`MotionPaths`**, the live one, driven from `Motion.setup`:

```kotlin
mask[c++] = mask[c] or expr        // writes mask[c], reads mask[c+1]
```

Write positions were right, but every slot took in its **neighbour's** value instead of its own. The mask decides which properties get splines, so a genuinely changed property could be dropped and an unchanged one animated.

**`MotionConstrainedPoint`**:

```kotlin
mask[c++] = mask[c++] or expr      // writes 0,2,4,6,8; reads 1,3,5,7,9; c ends at 10
```

Worse, but harmless in practice: that overload has no caller here or upstream. Corrected rather than removed, so the file stays a faithful copy of the original.

Both now read the index once per slot and advance `c` on its own line. The form is deliberately plain — the clever index expression is exactly what caused this.

## Why nothing caught it

The inherited suite exercises rendered motion, where a mask built from neighbouring slots still produces plausible-looking output. The defect only surfaces when the mask is inspected slot by slot.

The differential harness could not have caught it either: it compares the solver, and this is in `core/motion`, which has no differential coverage at all.

## How it was found

By comparing the port against the vendored upstream for a specific translation hazard — a side effect inside an index expression. Java has 64 such sites; a per-file count against the port flagged exactly one mismatch, `MotionConstrainedPoint`, and reading it led to the sibling defect in `MotionPaths`, which the count alone had not distinguished because there the site count matched.

Same method as #336 and #342: look for a *syntactic invariant that should not vary*, rather than for suspicious-looking code.

## Tests

Five cases pinning the mask slot by slot — a single changed property, no change at all, a changed position, accumulation across two calls, and arc mode. Reverting the fix turns all five red; that was verified rather than assumed.

455 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`.
