### PR TITLE
test(parity): compare the measure entry point, not just the solver

### DIFF
--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/LayoutOutcome.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/LayoutOutcome.kt
@@ -16,9 +16,9 @@ sealed interface LayoutOutcome {
     data class LaidOut(val geometry: String) : LayoutOutcome
 
     /**
-     * An exception escaped `layout()`. Compared by portable category, not exception class: the port
-     * is multiplatform and cannot raise JVM-specific exception classes on Native or JS, so class
-     * equality would demand something no correct port could deliver.
+     * An exception escaped `layout()` or `measure()`. Compared by portable category, not exception
+     * class: the port is multiplatform and cannot raise JVM-specific exception classes on Native or
+     * JS, so class equality would demand something no correct port could deliver.
      */
     data class Leaked(val category: String) : LayoutOutcome
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -8,6 +8,7 @@ import androidx.constraintlayout.core.widgets.ConstraintAnchor
 import androidx.constraintlayout.core.widgets.ConstraintWidget
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer
 import androidx.constraintlayout.core.widgets.Guideline
+import androidx.constraintlayout.core.widgets.analyzer.BasicMeasure
 
 /** The vendored upstream solver. It defines correct behaviour for every comparison here. */
 object OracleSolver : SolverSubject {
@@ -33,6 +34,68 @@ object OracleSolver : SolverSubject {
             LayoutOutcome.Crashed("OutOfMemoryError")
         } catch (e: Throwable) {
             LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
+        }
+
+    /**
+     * Answers with each widget's intrinsic size, taken from its spec, matched by `debugName`.
+     *
+     * Deliberately stateless: `solverMeasure` calls back repeatedly across re-measure passes, and a
+     * measurer that remembered anything would make the outcome depend on call order — inventing
+     * divergences between the two implementations and masking real ones.
+     */
+    private class SpecMeasurer(private val scenario: Scenario) : BasicMeasure.Measurer {
+        override fun measure(widget: ConstraintWidget, measure: BasicMeasure.Measure) {
+            val spec = scenario.widgets.firstOrNull { it.name == widget.debugName }
+            measure.measuredWidth =
+                if (measure.horizontalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                    spec?.width ?: widget.width
+                } else {
+                    measure.horizontalDimension
+                }
+            measure.measuredHeight =
+                if (measure.verticalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                    spec?.height ?: widget.height
+                } else {
+                    measure.verticalDimension
+                }
+            measure.measuredHasBaseline = false
+            measure.measuredNeedsSolverPass = false
+        }
+
+        override fun didMeasures() = Unit
+    }
+
+    override fun measure(scenario: Scenario): LayoutOutcome =
+        try {
+            val tree = build(scenario)
+            tree.root.measurer = SpecMeasurer(scenario)
+            tree.root.measure(
+                scenario.measureSpec.optimizationLevel,
+                mode(scenario.measureSpec.widthMode),
+                scenario.rootWidth,
+                mode(scenario.measureSpec.heightMode),
+                scenario.rootHeight,
+                0,
+                0,
+                0,
+                0,
+            )
+            LayoutOutcome.LaidOut(render(tree))
+        } catch (e: Exception) {
+            LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
+        } catch (e: StackOverflowError) {
+            LayoutOutcome.Crashed("StackOverflowError")
+        } catch (e: OutOfMemoryError) {
+            LayoutOutcome.Crashed("OutOfMemoryError")
+        } catch (e: Throwable) {
+            LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
+        }
+
+    private fun mode(value: MeasureMode): Int =
+        when (value) {
+            MeasureMode.UNSPECIFIED -> BasicMeasure.UNSPECIFIED
+            MeasureMode.EXACTLY -> BasicMeasure.EXACTLY
+            MeasureMode.AT_MOST -> BasicMeasure.AT_MOST
         }
 
     private fun build(scenario: Scenario): Tree {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -8,6 +8,7 @@ import androidx.constraintlayout.core.widgets.ConstraintAnchor
 import androidx.constraintlayout.core.widgets.ConstraintWidget
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer
 import androidx.constraintlayout.core.widgets.Guideline
+import androidx.constraintlayout.core.widgets.Optimizer
 import androidx.constraintlayout.core.widgets.analyzer.BasicMeasure
 
 /** The vendored upstream solver. It defines correct behaviour for every comparison here. */
@@ -48,13 +49,13 @@ object OracleSolver : SolverSubject {
             val spec = scenario.widgets.firstOrNull { it.name == widget.debugName }
             measure.measuredWidth =
                 if (measure.horizontalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
-                    spec?.width ?: widget.width
+                    spec?.width ?: error("no spec for widget ${widget.debugName}")
                 } else {
                     measure.horizontalDimension
                 }
             measure.measuredHeight =
                 if (measure.verticalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
-                    spec?.height ?: widget.height
+                    spec?.height ?: error("no spec for widget ${widget.debugName}")
                 } else {
                     measure.verticalDimension
                 }
@@ -70,7 +71,7 @@ object OracleSolver : SolverSubject {
             val tree = build(scenario)
             tree.root.measurer = SpecMeasurer(scenario)
             tree.root.measure(
-                scenario.measureSpec.optimizationLevel,
+                optimizationLevel(scenario.measureSpec.optimizationLevel),
                 mode(scenario.measureSpec.widthMode),
                 scenario.rootWidth,
                 mode(scenario.measureSpec.heightMode),
@@ -96,6 +97,11 @@ object OracleSolver : SolverSubject {
             MeasureMode.UNSPECIFIED -> BasicMeasure.UNSPECIFIED
             MeasureMode.EXACTLY -> BasicMeasure.EXACTLY
             MeasureMode.AT_MOST -> BasicMeasure.AT_MOST
+        }
+
+    private fun optimizationLevel(value: OptimizationLevel): Int =
+        when (value) {
+            OptimizationLevel.STANDARD -> Optimizer.OPTIMIZATION_STANDARD
         }
 
     private fun build(scenario: Scenario): Tree {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/OracleSolver.kt
@@ -13,100 +13,18 @@ import androidx.constraintlayout.core.widgets.Guideline
 object OracleSolver : SolverSubject {
     override val name: String = "oracle"
 
+    private class Tree(
+        val root: ConstraintWidgetContainer,
+        val guidelines: List<ConstraintWidget>,
+        val widgets: List<ConstraintWidget>,
+        val barriers: List<ConstraintWidget>,
+    )
+
     override fun layout(scenario: Scenario): LayoutOutcome =
         try {
-            val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
-            root.debugName = "root"
-            root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
-            root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
-            if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
-            if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
-
-            val guidelines = scenario.guidelines.map { spec ->
-                Guideline().apply {
-                    debugName = spec.name
-                    setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
-                    when (val position = spec.position) {
-                        is GuidelinePosition.Begin -> setGuideBegin(position.value)
-                        is GuidelinePosition.End -> setGuideEnd(position.value)
-                        is GuidelinePosition.Percent -> setGuidePercent(position.value)
-                    }
-                    root.add(this)
-                }
-            }
-
-            val widgets = scenario.widgets.map { spec ->
-                ConstraintWidget(spec.width, spec.height).apply {
-                    debugName = spec.name
-                    setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
-                    setVerticalDimensionBehaviour(behaviour(spec.vertical))
-                    if (spec.minWidth > 0) setMinWidth(spec.minWidth)
-                    if (spec.minHeight > 0) setMinHeight(spec.minHeight)
-                    if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
-                    if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
-                    horizontalBiasPercent = spec.horizontalBias
-                    verticalBiasPercent = spec.verticalBias
-                    spec.dimensionRatio?.let { setDimensionRatio(it) }
-                    root.add(this)
-                }
-            }
-
-            val barriers = scenario.barriers.map { spec ->
-                Barrier().apply {
-                    debugName = spec.name
-                    setBarrierType(
-                        when (spec.side) {
-                            Side.LEFT -> Barrier.LEFT
-                            Side.RIGHT -> Barrier.RIGHT
-                            Side.TOP -> Barrier.TOP
-                            Side.BOTTOM -> Barrier.BOTTOM
-                        },
-                    )
-                    setMargin(spec.margin)
-                    spec.referenced.forEach { add(widgets[it]) }
-                    root.add(this)
-                }
-            }
-
-            for (connection in scenario.connections) {
-                val target = when (val to = connection.target) {
-                    is Target.Root -> root
-                    is Target.Widget -> widgets[to.index]
-                    is Target.Barrier -> barriers[to.index]
-                    is Target.Guideline -> guidelines[to.index]
-                }
-                widgets[connection.from].connect(
-                    side(connection.fromSide),
-                    target,
-                    side(connection.toSide),
-                    connection.margin,
-                )
-            }
-
-            for (circle in scenario.circular) {
-                widgets[circle.from].connectCircularConstraint(
-                    widgets[circle.target],
-                    circle.angle,
-                    circle.radius,
-                )
-            }
-
-            for (chain in scenario.chains) {
-                val head = widgets[chain.members.first()]
-                val style = when (chain.style) {
-                    ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
-                    ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
-                    ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
-                }
-                if (chain.horizontal) {
-                    head.setHorizontalChainStyle(style)
-                } else {
-                    head.setVerticalChainStyle(style)
-                }
-            }
-
-            root.layout()
-            LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
+            val tree = build(scenario)
+            tree.root.layout()
+            LayoutOutcome.LaidOut(render(tree))
         } catch (e: Exception) {
             LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
         } catch (e: StackOverflowError) {
@@ -116,6 +34,100 @@ object OracleSolver : SolverSubject {
         } catch (e: Throwable) {
             LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
         }
+
+    private fun build(scenario: Scenario): Tree {
+        val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
+        root.debugName = "root"
+        root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
+        root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
+        if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
+        if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+        val guidelines = scenario.guidelines.map { spec ->
+            Guideline().apply {
+                debugName = spec.name
+                setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
+                when (val position = spec.position) {
+                    is GuidelinePosition.Begin -> setGuideBegin(position.value)
+                    is GuidelinePosition.End -> setGuideEnd(position.value)
+                    is GuidelinePosition.Percent -> setGuidePercent(position.value)
+                }
+                root.add(this)
+            }
+        }
+
+        val widgets = scenario.widgets.map { spec ->
+            ConstraintWidget(spec.width, spec.height).apply {
+                debugName = spec.name
+                setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
+                setVerticalDimensionBehaviour(behaviour(spec.vertical))
+                if (spec.minWidth > 0) setMinWidth(spec.minWidth)
+                if (spec.minHeight > 0) setMinHeight(spec.minHeight)
+                if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
+                if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
+                horizontalBiasPercent = spec.horizontalBias
+                verticalBiasPercent = spec.verticalBias
+                spec.dimensionRatio?.let { setDimensionRatio(it) }
+                root.add(this)
+            }
+        }
+
+        val barriers = scenario.barriers.map { spec ->
+            Barrier().apply {
+                debugName = spec.name
+                setBarrierType(
+                    when (spec.side) {
+                        Side.LEFT -> Barrier.LEFT
+                        Side.RIGHT -> Barrier.RIGHT
+                        Side.TOP -> Barrier.TOP
+                        Side.BOTTOM -> Barrier.BOTTOM
+                    },
+                )
+                setMargin(spec.margin)
+                spec.referenced.forEach { add(widgets[it]) }
+                root.add(this)
+            }
+        }
+
+        for (connection in scenario.connections) {
+            val target = when (val to = connection.target) {
+                is Target.Root -> root
+                is Target.Widget -> widgets[to.index]
+                is Target.Barrier -> barriers[to.index]
+                is Target.Guideline -> guidelines[to.index]
+            }
+            widgets[connection.from].connect(
+                side(connection.fromSide),
+                target,
+                side(connection.toSide),
+                connection.margin,
+            )
+        }
+
+        for (circle in scenario.circular) {
+            widgets[circle.from].connectCircularConstraint(
+                widgets[circle.target],
+                circle.angle,
+                circle.radius,
+            )
+        }
+
+        for (chain in scenario.chains) {
+            val head = widgets[chain.members.first()]
+            val style = when (chain.style) {
+                ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
+                ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
+                ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
+            }
+            if (chain.horizontal) {
+                head.setHorizontalChainStyle(style)
+            } else {
+                head.setVerticalChainStyle(style)
+            }
+        }
+
+        return Tree(root, guidelines, widgets, barriers)
+    }
 
     private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =
         when (value) {
@@ -133,15 +145,10 @@ object OracleSolver : SolverSubject {
             Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
         }
 
-    private fun render(
-        root: ConstraintWidgetContainer,
-        guidelines: List<ConstraintWidget>,
-        widgets: List<ConstraintWidget>,
-        barriers: List<ConstraintWidget>,
-    ): String =
+    private fun render(tree: Tree): String =
         buildString {
-            append("root: ").append(root.width).append('x').append(root.height).append('\n')
-            for (participant in guidelines + widgets + barriers) {
+            append("root: ").append(tree.root.width).append('x').append(tree.root.height).append('\n')
+            for (participant in tree.guidelines + tree.widgets + tree.barriers) {
                 append(participant.debugName).append(": (").append(participant.x).append(", ")
                     .append(participant.y).append(") ").append(participant.width).append('x')
                     .append(participant.height).append('\n')

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -8,6 +8,7 @@ import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer
 import tech.annexflow.constraintlayout.core.widgets.Guideline
+import tech.annexflow.constraintlayout.core.widgets.Optimizer
 import tech.annexflow.constraintlayout.core.widgets.analyzer.BasicMeasure
 
 /** The ported solver, taken from the shaded flavour so its packages do not collide with the oracle's. */
@@ -48,13 +49,13 @@ object PortSolver : SolverSubject {
             val spec = scenario.widgets.firstOrNull { it.name == widget.debugName }
             measure.measuredWidth =
                 if (measure.horizontalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
-                    spec?.width ?: widget.width
+                    spec?.width ?: error("no spec for widget ${widget.debugName}")
                 } else {
                     measure.horizontalDimension
                 }
             measure.measuredHeight =
                 if (measure.verticalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
-                    spec?.height ?: widget.height
+                    spec?.height ?: error("no spec for widget ${widget.debugName}")
                 } else {
                     measure.verticalDimension
                 }
@@ -70,7 +71,7 @@ object PortSolver : SolverSubject {
             val tree = build(scenario)
             tree.root.measurer = SpecMeasurer(scenario)
             tree.root.measure(
-                scenario.measureSpec.optimizationLevel,
+                optimizationLevel(scenario.measureSpec.optimizationLevel),
                 mode(scenario.measureSpec.widthMode),
                 scenario.rootWidth,
                 mode(scenario.measureSpec.heightMode),
@@ -96,6 +97,11 @@ object PortSolver : SolverSubject {
             MeasureMode.UNSPECIFIED -> BasicMeasure.UNSPECIFIED
             MeasureMode.EXACTLY -> BasicMeasure.EXACTLY
             MeasureMode.AT_MOST -> BasicMeasure.AT_MOST
+        }
+
+    private fun optimizationLevel(value: OptimizationLevel): Int =
+        when (value) {
+            OptimizationLevel.STANDARD -> Optimizer.OPTIMIZATION_STANDARD
         }
 
     private fun build(scenario: Scenario): Tree {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -8,6 +8,7 @@ import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget
 import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer
 import tech.annexflow.constraintlayout.core.widgets.Guideline
+import tech.annexflow.constraintlayout.core.widgets.analyzer.BasicMeasure
 
 /** The ported solver, taken from the shaded flavour so its packages do not collide with the oracle's. */
 object PortSolver : SolverSubject {
@@ -33,6 +34,68 @@ object PortSolver : SolverSubject {
             LayoutOutcome.Crashed("OutOfMemoryError")
         } catch (e: Throwable) {
             LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
+        }
+
+    /**
+     * Answers with each widget's intrinsic size, taken from its spec, matched by `debugName`.
+     *
+     * Deliberately stateless: `solverMeasure` calls back repeatedly across re-measure passes, and a
+     * measurer that remembered anything would make the outcome depend on call order — inventing
+     * divergences between the two implementations and masking real ones.
+     */
+    private class SpecMeasurer(private val scenario: Scenario) : BasicMeasure.Measurer {
+        override fun measure(widget: ConstraintWidget, measure: BasicMeasure.Measure) {
+            val spec = scenario.widgets.firstOrNull { it.name == widget.debugName }
+            measure.measuredWidth =
+                if (measure.horizontalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                    spec?.width ?: widget.width
+                } else {
+                    measure.horizontalDimension
+                }
+            measure.measuredHeight =
+                if (measure.verticalBehavior == ConstraintWidget.DimensionBehaviour.WRAP_CONTENT) {
+                    spec?.height ?: widget.height
+                } else {
+                    measure.verticalDimension
+                }
+            measure.measuredHasBaseline = false
+            measure.measuredNeedsSolverPass = false
+        }
+
+        override fun didMeasures() = Unit
+    }
+
+    override fun measure(scenario: Scenario): LayoutOutcome =
+        try {
+            val tree = build(scenario)
+            tree.root.measurer = SpecMeasurer(scenario)
+            tree.root.measure(
+                scenario.measureSpec.optimizationLevel,
+                mode(scenario.measureSpec.widthMode),
+                scenario.rootWidth,
+                mode(scenario.measureSpec.heightMode),
+                scenario.rootHeight,
+                0,
+                0,
+                0,
+                0,
+            )
+            LayoutOutcome.LaidOut(render(tree))
+        } catch (e: Exception) {
+            LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
+        } catch (e: StackOverflowError) {
+            LayoutOutcome.Crashed("StackOverflowError")
+        } catch (e: OutOfMemoryError) {
+            LayoutOutcome.Crashed("OutOfMemoryError")
+        } catch (e: Throwable) {
+            LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
+        }
+
+    private fun mode(value: MeasureMode): Int =
+        when (value) {
+            MeasureMode.UNSPECIFIED -> BasicMeasure.UNSPECIFIED
+            MeasureMode.EXACTLY -> BasicMeasure.EXACTLY
+            MeasureMode.AT_MOST -> BasicMeasure.AT_MOST
         }
 
     private fun build(scenario: Scenario): Tree {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/PortSolver.kt
@@ -13,100 +13,18 @@ import tech.annexflow.constraintlayout.core.widgets.Guideline
 object PortSolver : SolverSubject {
     override val name: String = "port"
 
+    private class Tree(
+        val root: ConstraintWidgetContainer,
+        val guidelines: List<ConstraintWidget>,
+        val widgets: List<ConstraintWidget>,
+        val barriers: List<ConstraintWidget>,
+    )
+
     override fun layout(scenario: Scenario): LayoutOutcome =
         try {
-            val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
-            root.debugName = "root"
-            root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
-            root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
-            if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
-            if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
-
-            val guidelines = scenario.guidelines.map { spec ->
-                Guideline().apply {
-                    debugName = spec.name
-                    setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
-                    when (val position = spec.position) {
-                        is GuidelinePosition.Begin -> setGuideBegin(position.value)
-                        is GuidelinePosition.End -> setGuideEnd(position.value)
-                        is GuidelinePosition.Percent -> setGuidePercent(position.value)
-                    }
-                    root.add(this)
-                }
-            }
-
-            val widgets = scenario.widgets.map { spec ->
-                ConstraintWidget(spec.width, spec.height).apply {
-                    debugName = spec.name
-                    setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
-                    setVerticalDimensionBehaviour(behaviour(spec.vertical))
-                    if (spec.minWidth > 0) setMinWidth(spec.minWidth)
-                    if (spec.minHeight > 0) setMinHeight(spec.minHeight)
-                    if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
-                    if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
-                    horizontalBiasPercent = spec.horizontalBias
-                    verticalBiasPercent = spec.verticalBias
-                    spec.dimensionRatio?.let { setDimensionRatio(it) }
-                    root.add(this)
-                }
-            }
-
-            val barriers = scenario.barriers.map { spec ->
-                Barrier().apply {
-                    debugName = spec.name
-                    setBarrierType(
-                        when (spec.side) {
-                            Side.LEFT -> Barrier.LEFT
-                            Side.RIGHT -> Barrier.RIGHT
-                            Side.TOP -> Barrier.TOP
-                            Side.BOTTOM -> Barrier.BOTTOM
-                        },
-                    )
-                    setMargin(spec.margin)
-                    spec.referenced.forEach { add(widgets[it]) }
-                    root.add(this)
-                }
-            }
-
-            for (connection in scenario.connections) {
-                val target = when (val to = connection.target) {
-                    is Target.Root -> root
-                    is Target.Widget -> widgets[to.index]
-                    is Target.Barrier -> barriers[to.index]
-                    is Target.Guideline -> guidelines[to.index]
-                }
-                widgets[connection.from].connect(
-                    side(connection.fromSide),
-                    target,
-                    side(connection.toSide),
-                    connection.margin,
-                )
-            }
-
-            for (circle in scenario.circular) {
-                widgets[circle.from].connectCircularConstraint(
-                    widgets[circle.target],
-                    circle.angle,
-                    circle.radius,
-                )
-            }
-
-            for (chain in scenario.chains) {
-                val head = widgets[chain.members.first()]
-                val style = when (chain.style) {
-                    ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
-                    ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
-                    ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
-                }
-                if (chain.horizontal) {
-                    head.setHorizontalChainStyle(style)
-                } else {
-                    head.setVerticalChainStyle(style)
-                }
-            }
-
-            root.layout()
-            LayoutOutcome.LaidOut(render(root, guidelines, widgets, barriers))
+            val tree = build(scenario)
+            tree.root.layout()
+            LayoutOutcome.LaidOut(render(tree))
         } catch (e: Exception) {
             LayoutOutcome.Leaked(LayoutOutcome.categorise(e))
         } catch (e: StackOverflowError) {
@@ -116,6 +34,100 @@ object PortSolver : SolverSubject {
         } catch (e: Throwable) {
             LayoutOutcome.Crashed(e::class.simpleName ?: "Unknown")
         }
+
+    private fun build(scenario: Scenario): Tree {
+        val root = ConstraintWidgetContainer(0, 0, scenario.rootWidth, scenario.rootHeight)
+        root.debugName = "root"
+        root.setHorizontalDimensionBehaviour(behaviour(scenario.rootHorizontal))
+        root.setVerticalDimensionBehaviour(behaviour(scenario.rootVertical))
+        if (scenario.rootMinWidth > 0) root.setMinWidth(scenario.rootMinWidth)
+        if (scenario.rootMinHeight > 0) root.setMinHeight(scenario.rootMinHeight)
+
+        val guidelines = scenario.guidelines.map { spec ->
+            Guideline().apply {
+                debugName = spec.name
+                setOrientation(if (spec.vertical) Guideline.VERTICAL else Guideline.HORIZONTAL)
+                when (val position = spec.position) {
+                    is GuidelinePosition.Begin -> setGuideBegin(position.value)
+                    is GuidelinePosition.End -> setGuideEnd(position.value)
+                    is GuidelinePosition.Percent -> setGuidePercent(position.value)
+                }
+                root.add(this)
+            }
+        }
+
+        val widgets = scenario.widgets.map { spec ->
+            ConstraintWidget(spec.width, spec.height).apply {
+                debugName = spec.name
+                setHorizontalDimensionBehaviour(behaviour(spec.horizontal))
+                setVerticalDimensionBehaviour(behaviour(spec.vertical))
+                if (spec.minWidth > 0) setMinWidth(spec.minWidth)
+                if (spec.minHeight > 0) setMinHeight(spec.minHeight)
+                if (spec.maxWidth != Int.MAX_VALUE) maxWidth = spec.maxWidth
+                if (spec.maxHeight != Int.MAX_VALUE) maxHeight = spec.maxHeight
+                horizontalBiasPercent = spec.horizontalBias
+                verticalBiasPercent = spec.verticalBias
+                spec.dimensionRatio?.let { setDimensionRatio(it) }
+                root.add(this)
+            }
+        }
+
+        val barriers = scenario.barriers.map { spec ->
+            Barrier().apply {
+                debugName = spec.name
+                setBarrierType(
+                    when (spec.side) {
+                        Side.LEFT -> Barrier.LEFT
+                        Side.RIGHT -> Barrier.RIGHT
+                        Side.TOP -> Barrier.TOP
+                        Side.BOTTOM -> Barrier.BOTTOM
+                    },
+                )
+                setMargin(spec.margin)
+                spec.referenced.forEach { add(widgets[it]) }
+                root.add(this)
+            }
+        }
+
+        for (connection in scenario.connections) {
+            val target = when (val to = connection.target) {
+                is Target.Root -> root
+                is Target.Widget -> widgets[to.index]
+                is Target.Barrier -> barriers[to.index]
+                is Target.Guideline -> guidelines[to.index]
+            }
+            widgets[connection.from].connect(
+                side(connection.fromSide),
+                target,
+                side(connection.toSide),
+                connection.margin,
+            )
+        }
+
+        for (circle in scenario.circular) {
+            widgets[circle.from].connectCircularConstraint(
+                widgets[circle.target],
+                circle.angle,
+                circle.radius,
+            )
+        }
+
+        for (chain in scenario.chains) {
+            val head = widgets[chain.members.first()]
+            val style = when (chain.style) {
+                ChainStyle.SPREAD -> ConstraintWidget.CHAIN_SPREAD
+                ChainStyle.SPREAD_INSIDE -> ConstraintWidget.CHAIN_SPREAD_INSIDE
+                ChainStyle.PACKED -> ConstraintWidget.CHAIN_PACKED
+            }
+            if (chain.horizontal) {
+                head.setHorizontalChainStyle(style)
+            } else {
+                head.setVerticalChainStyle(style)
+            }
+        }
+
+        return Tree(root, guidelines, widgets, barriers)
+    }
 
     private fun behaviour(value: Behaviour): ConstraintWidget.DimensionBehaviour =
         when (value) {
@@ -133,15 +145,10 @@ object PortSolver : SolverSubject {
             Side.BOTTOM -> ConstraintAnchor.Type.BOTTOM
         }
 
-    private fun render(
-        root: ConstraintWidgetContainer,
-        guidelines: List<ConstraintWidget>,
-        widgets: List<ConstraintWidget>,
-        barriers: List<ConstraintWidget>,
-    ): String =
+    private fun render(tree: Tree): String =
         buildString {
-            append("root: ").append(root.width).append('x').append(root.height).append('\n')
-            for (participant in guidelines + widgets + barriers) {
+            append("root: ").append(tree.root.width).append('x').append(tree.root.height).append('\n')
+            for (participant in tree.guidelines + tree.widgets + tree.barriers) {
                 append(participant.debugName).append(": (").append(participant.x).append(", ")
                     .append(participant.y).append(") ").append(participant.width).append('x')
                     .append(participant.height).append('\n')

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -96,6 +96,21 @@ data class ChainSpec(
     val style: ChainStyle,
 )
 
+/** Mirrors `BasicMeasure`'s modes: `UNSPECIFIED` 0, `EXACTLY` 1 shl 30, `AT_MOST` 2 shl 30. */
+enum class MeasureMode { UNSPECIFIED, EXACTLY, AT_MOST }
+
+/**
+ * The arguments `ConstraintWidgetContainer.measure` needs and `layout` does not.
+ *
+ * `AT_MOST` is the interesting mode: it is what makes a wrap-content root re-measure, which is the
+ * loop this harness reaches only through the measure entry point.
+ */
+data class MeasureSpec(
+    val widthMode: MeasureMode,
+    val heightMode: MeasureMode,
+    val optimizationLevel: Int,
+)
+
 /**
  * A circular constraint, which positions a widget at an angle and distance from another rather than
  * by anchors. [target] is always lower than [from], so it cannot reintroduce a cycle.
@@ -116,4 +131,5 @@ data class Scenario(
     val barriers: List<BarrierSpec>,
     val guidelines: List<GuidelineSpec>,
     val chains: List<ChainSpec>,
+    val measureSpec: MeasureSpec,
 )

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenario.kt
@@ -100,15 +100,24 @@ data class ChainSpec(
 enum class MeasureMode { UNSPECIFIED, EXACTLY, AT_MOST }
 
 /**
+ * Mirrors `Optimizer`'s level constants, which exist separately in each package. Only `STANDARD`
+ * is generated today — see [Scenarios] for why.
+ */
+enum class OptimizationLevel { STANDARD }
+
+/**
  * The arguments `ConstraintWidgetContainer.measure` needs and `layout` does not.
  *
- * `AT_MOST` is the interesting mode: it is what makes a wrap-content root re-measure, which is the
- * loop this harness reaches only through the measure entry point.
+ * These are carried through to `measure()` but are inert at `OPTIMIZATION_STANDARD`:
+ * `BasicMeasure.solverMeasure` only reads `widthMode`/`heightMode`/`widthSize`/`heightSize` inside
+ * its `if (optimize)` branch, and `optimize` requires `OPTIMIZATION_GRAPH` or
+ * `OPTIMIZATION_GRAPH_WRAP` — neither of which `OPTIMIZATION_STANDARD` sets. They are plumbed and
+ * generated now so that raising the optimization level later needs no change to the scenario model.
  */
 data class MeasureSpec(
     val widthMode: MeasureMode,
     val heightMode: MeasureMode,
-    val optimizationLevel: Int,
+    val optimizationLevel: OptimizationLevel,
 )
 
 /**

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -3,6 +3,7 @@
 
 package tech.annexflow.parity.solver
 
+import androidx.constraintlayout.core.widgets.Optimizer
 import kotlin.random.Random
 
 /**
@@ -125,6 +126,16 @@ object Scenarios {
         }
         chains.forEach { connections += chainConnections(random, it) }
 
+        // A wrap-content root only re-measures under AT_MOST, so that mode is drawn often rather
+        // than uniformly — it is the branch the measure entry point exists to reach.
+        val measureSpec = MeasureSpec(
+            widthMode = measureMode(random),
+            heightMode = measureMode(random),
+            // Widening this is the next step, not this one: the graph path lives behind
+            // OPTIMIZATION_GRAPH and belongs on the measure path once it is compared at all.
+            optimizationLevel = Optimizer.OPTIMIZATION_STANDARD,
+        )
+
         return Scenario(
             seed = seed,
             rootWidth = random.nextInt(400, 1200),
@@ -141,11 +152,20 @@ object Scenarios {
             barriers = barriers,
             guidelines = guidelines,
             chains = chains,
+            measureSpec = measureSpec,
         )
     }
 
     private fun behaviour(random: Random): Behaviour =
         Behaviour.entries[random.nextInt(Behaviour.entries.size)]
+
+    private fun measureMode(random: Random): MeasureMode =
+        when (random.nextInt(4)) {
+            0 -> MeasureMode.UNSPECIFIED
+            1 -> MeasureMode.AT_MOST
+            2 -> MeasureMode.AT_MOST
+            else -> MeasureMode.EXACTLY
+        }
 
     /**
      * Emits a chain as one unit: the head anchored outward, every adjacent pair linked in both

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/Scenarios.kt
@@ -3,7 +3,6 @@
 
 package tech.annexflow.parity.solver
 
-import androidx.constraintlayout.core.widgets.Optimizer
 import kotlin.random.Random
 
 /**
@@ -126,14 +125,15 @@ object Scenarios {
         }
         chains.forEach { connections += chainConnections(random, it) }
 
-        // A wrap-content root only re-measures under AT_MOST, so that mode is drawn often rather
-        // than uniformly — it is the branch the measure entry point exists to reach.
+        // AT_MOST is drawn often rather than uniformly so that, once the optimization level is
+        // raised enough for the modes to matter, a wrap-content root re-measuring under AT_MOST is
+        // already well represented rather than a rare draw.
         val measureSpec = MeasureSpec(
             widthMode = measureMode(random),
             heightMode = measureMode(random),
             // Widening this is the next step, not this one: the graph path lives behind
             // OPTIMIZATION_GRAPH and belongs on the measure path once it is compared at all.
-            optimizationLevel = Optimizer.OPTIMIZATION_STANDARD,
+            optimizationLevel = OptimizationLevel.STANDARD,
         )
 
         return Scenario(

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -3,6 +3,7 @@
 
 package tech.annexflow.parity.solver
 
+import androidx.constraintlayout.core.widgets.Optimizer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -338,5 +339,45 @@ class ScenariosTest {
             Scenarios.generate(seed).chains.forEach { styles += it.style }
         }
         assertEquals(ChainStyle.entries.toSet(), styles, "generated styles: $styles")
+    }
+
+    @Test
+    fun everyMeasureModeIsGenerated() {
+        val widthModes = mutableSetOf<MeasureMode>()
+        val heightModes = mutableSetOf<MeasureMode>()
+        for (seed in 1L..300L) {
+            val spec = Scenarios.generate(seed).measureSpec
+            widthModes += spec.widthMode
+            heightModes += spec.heightMode
+        }
+        assertEquals(MeasureMode.entries.toSet(), widthModes, "width modes: $widthModes")
+        assertEquals(MeasureMode.entries.toSet(), heightModes, "height modes: $heightModes")
+    }
+
+    /**
+     * `AT_MOST` on a wrap-content root is what drives `BasicMeasure`'s re-measure loop, which is the
+     * whole reason the measure entry point is being compared. If the generator stops producing that
+     * combination the loop goes unexercised while the suite still passes, so it is pinned.
+     */
+    @Test
+    fun someScenariosMeasureAWrapContentRootAtMost() {
+        val matching = (1L..300L).count { seed ->
+            val scenario = Scenarios.generate(seed)
+            (scenario.rootHorizontal == Behaviour.WRAP_CONTENT &&
+                scenario.measureSpec.widthMode == MeasureMode.AT_MOST) ||
+                (scenario.rootVertical == Behaviour.WRAP_CONTENT &&
+                    scenario.measureSpec.heightMode == MeasureMode.AT_MOST)
+        }
+        assertTrue(matching >= 20, "only $matching of 300 scenarios measure a wrap root AT_MOST")
+    }
+
+    @Test
+    fun theOptimizationLevelIsStandard() {
+        for (seed in 1L..50L) {
+            assertEquals(
+                Optimizer.OPTIMIZATION_STANDARD,
+                Scenarios.generate(seed).measureSpec.optimizationLevel,
+            )
+        }
     }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/ScenariosTest.kt
@@ -3,7 +3,6 @@
 
 package tech.annexflow.parity.solver
 
-import androidx.constraintlayout.core.widgets.Optimizer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -341,6 +340,12 @@ class ScenariosTest {
         assertEquals(ChainStyle.entries.toSet(), styles, "generated styles: $styles")
     }
 
+    /**
+     * The modes are inert at the `OPTIMIZATION_STANDARD` level this harness runs at — see
+     * [MeasureSpec] — so this does not pin any observable behaviour. It pins forward-preparation:
+     * the day the optimization level is raised and the modes start mattering, every value must
+     * already be reachable rather than requiring a change to the generator at that point.
+     */
     @Test
     fun everyMeasureModeIsGenerated() {
         val widthModes = mutableSetOf<MeasureMode>()
@@ -355,9 +360,11 @@ class ScenariosTest {
     }
 
     /**
-     * `AT_MOST` on a wrap-content root is what drives `BasicMeasure`'s re-measure loop, which is the
-     * whole reason the measure entry point is being compared. If the generator stops producing that
-     * combination the loop goes unexercised while the suite still passes, so it is pinned.
+     * `AT_MOST` on a wrap-content root is what would drive `BasicMeasure`'s re-measure loop once the
+     * optimization level is raised enough for the modes to matter — see [MeasureSpec], where they
+     * are inert at `OPTIMIZATION_STANDARD`. This does not pin any behaviour reached today; it pins
+     * forward-preparation, so that combination is already well represented in the generator rather
+     * than needing to be added when the level is raised.
      */
     @Test
     fun someScenariosMeasureAWrapContentRootAtMost() {
@@ -372,10 +379,10 @@ class ScenariosTest {
     }
 
     @Test
-    fun theOptimizationLevelIsStandard() {
+    fun theOptimizationLevelIsAlwaysStandard() {
         for (seed in 1L..50L) {
             assertEquals(
-                Optimizer.OPTIMIZATION_STANDARD,
+                OptimizationLevel.STANDARD,
                 Scenarios.generate(seed).measureSpec.optimizationLevel,
             )
         }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -16,57 +16,79 @@ import kotlin.test.fail
  * solutions for an underconstrained system, so two correct implementations could in principle
  * disagree through collection iteration order alone. That would still be worth knowing — it would
  * mean the engine's output depends on iteration order, which matters well beyond this harness.
+ *
+ * Both `layout()` and `measure()` entry points are exercised, and each is compared only against
+ * its own counterpart on the other side — never against the other entry point — since they are
+ * different contracts and a cross comparison would fail for reasons that say nothing about the
+ * port.
  */
 class SolverDifferentialTest {
     private val seeds = 1L..2000L
-
-    // A floor on how many seeds must actually reach LaidOut. If scenario construction or layout()
-    // started throwing for every seed, both sides would return an identical Leaked(...) and all
-    // 2000 seeds would compare equal and pass green — this makes that silent failure loud instead.
-    // In the spirit of DifferentialTest's `compared >= 1000` guard: all 2000 seeds currently reach
-    // LaidOut, so 1800 is a floor with real margin, not one hugging the observed value.
     private val minimumLaidOut = 1800
+
+    private enum class Entry(val label: String) {
+        LAYOUT("layout"),
+        MEASURE("measure"),
+    }
+
+    private fun run(entry: Entry, subject: SolverSubject, scenario: Scenario) =
+        when (entry) {
+            Entry.LAYOUT -> subject.layout(scenario)
+            Entry.MEASURE -> subject.measure(scenario)
+        }
 
     @Test
     fun thePortAgreesWithTheOracle() {
         val divergences = mutableListOf<String>()
         var totalDivergences = 0
-        var laidOut = 0
+        val laidOut = mutableMapOf(Entry.LAYOUT to 0, Entry.MEASURE to 0)
 
         for (seed in seeds) {
             val scenario = Scenarios.generate(seed)
-            val oracle = OracleSolver.layout(scenario)
-            val port = PortSolver.layout(scenario)
-            if (oracle is LayoutOutcome.LaidOut) laidOut++
-            if (oracle != port) {
-                totalDivergences++
-                if (divergences.size < 5) divergences += report(scenario, oracle, port)
+            for (entry in Entry.entries) {
+                val oracle = run(entry, OracleSolver, scenario)
+                val port = run(entry, PortSolver, scenario)
+                if (oracle is LayoutOutcome.LaidOut) laidOut[entry] = laidOut.getValue(entry) + 1
+                if (oracle != port) {
+                    totalDivergences++
+                    if (divergences.size < 5) divergences += report(entry, scenario, oracle, port)
+                }
             }
         }
 
-        if (laidOut < minimumLaidOut) {
-            fail(
-                "only $laidOut of ${seeds.count()} scenarios reached LaidOut (need at least " +
-                    "$minimumLaidOut) — the generator or the solver wiring is broken, not just " +
-                    "under-covering behaviour",
-            )
+        // A harness that silently compared nothing would report success, so the count is part of
+        // the contract rather than an incidental detail — and it is checked per entry point,
+        // because one of them failing to run at all is exactly the failure worth catching.
+        for (entry in Entry.entries) {
+            if (laidOut.getValue(entry) < minimumLaidOut) {
+                fail(
+                    "only ${laidOut.getValue(entry)} of ${seeds.count()} scenarios reached " +
+                        "LaidOut through ${entry.label} — that path is not wired up",
+                )
+            }
         }
 
         if (totalDivergences > 0) {
             fail(
-                "$totalDivergences of ${seeds.count()} scenarios diverged " +
+                "$totalDivergences of ${seeds.count() * Entry.entries.size} comparisons diverged " +
                     "(showing the first ${divergences.size}):\n\n${divergences.joinToString("\n\n")}",
             )
         }
     }
 
-    private fun report(scenario: Scenario, oracle: LayoutOutcome, port: LayoutOutcome): String =
+    private fun report(
+        entry: Entry,
+        scenario: Scenario,
+        oracle: LayoutOutcome,
+        port: LayoutOutcome,
+    ): String =
         buildString {
-            append("--- seed ").append(scenario.seed).append('\n')
+            append("--- seed ").append(scenario.seed).append(" via ").append(entry.label).append('\n')
             append("root     : ").append(scenario.rootWidth).append('x').append(scenario.rootHeight)
                 .append(' ').append(scenario.rootHorizontal).append('/').append(scenario.rootVertical)
                 .append(" min ").append(scenario.rootMinWidth).append('/').append(scenario.rootMinHeight)
                 .append('\n')
+            append("measure  : ").append(scenario.measureSpec).append('\n')
             scenario.widgets.forEach { append("widget   : ").append(it).append('\n') }
             scenario.connections.forEach { append("connect  : ").append(it).append('\n') }
             scenario.circular.forEach { append("circular : ").append(it).append('\n') }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverDifferentialTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.fail
 class SolverDifferentialTest {
     private val seeds = 1L..2000L
     private val minimumLaidOut = 1800
+    private val maxExamplesPerEntry = 5
 
     private enum class Entry(val label: String) {
         LAYOUT("layout"),
@@ -39,7 +40,11 @@ class SolverDifferentialTest {
 
     @Test
     fun thePortAgreesWithTheOracle() {
-        val divergences = mutableListOf<String>()
+        // Keyed per entry point rather than one shared list: LAYOUT runs before MEASURE for every
+        // seed, so a global cap would let early layout divergences crowd out every measure
+        // divergence from the reported examples while the counts stayed correct and the diagnostic
+        // went blind.
+        val divergences = mutableMapOf(Entry.LAYOUT to mutableListOf<String>(), Entry.MEASURE to mutableListOf<String>())
         var totalDivergences = 0
         val laidOut = mutableMapOf(Entry.LAYOUT to 0, Entry.MEASURE to 0)
 
@@ -51,7 +56,8 @@ class SolverDifferentialTest {
                 if (oracle is LayoutOutcome.LaidOut) laidOut[entry] = laidOut.getValue(entry) + 1
                 if (oracle != port) {
                     totalDivergences++
-                    if (divergences.size < 5) divergences += report(entry, scenario, oracle, port)
+                    val examples = divergences.getValue(entry)
+                    if (examples.size < maxExamplesPerEntry) examples += report(entry, scenario, oracle, port)
                 }
             }
         }
@@ -69,9 +75,10 @@ class SolverDifferentialTest {
         }
 
         if (totalDivergences > 0) {
+            val examples = Entry.entries.flatMap { divergences.getValue(it) }
             fail(
                 "$totalDivergences of ${seeds.count() * Entry.entries.size} comparisons diverged " +
-                    "(showing the first ${divergences.size}):\n\n${divergences.joinToString("\n\n")}",
+                    "(showing up to $maxExamplesPerEntry per entry point):\n\n${examples.joinToString("\n\n")}",
             )
         }
     }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
@@ -11,5 +11,19 @@ package tech.annexflow.parity.solver
 interface SolverSubject {
     val name: String
 
+    /**
+     * The solver's own entry point. Production does not call this directly, but both mutation
+     * probes so far fired through it, so it stays compared in its own right.
+     */
     fun layout(scenario: Scenario): LayoutOutcome
+
+    /**
+     * The entry point production uses: `ConstraintWidgetContainer.measure`, which runs the
+     * orchestration in `BasicMeasure` and only reaches `layout` as one of its branches.
+     *
+     * Compared against the other implementation's `measure`, never against `layout` — the two are
+     * different contracts and a cross comparison would fail for reasons that say nothing about the
+     * port.
+     */
+    fun measure(scenario: Scenario): LayoutOutcome
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubject.kt
@@ -4,9 +4,9 @@
 package tech.annexflow.parity.solver
 
 /**
- * One side of the comparison. Implementations must never throw out of [layout]: a failure on one
- * side against a success on the other is the finding, so it has to arrive as a value rather than
- * end the run before the remaining scenarios are tried.
+ * One side of the comparison. Implementations must never throw out of [layout] or [measure]: a
+ * failure on one side against a success on the other is the finding, so it has to arrive as a value
+ * rather than end the run before the remaining scenarios are tried.
  */
 interface SolverSubject {
     val name: String

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubjectTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/SolverSubjectTest.kt
@@ -36,4 +36,45 @@ class SolverSubjectTest {
         val scenario = Scenarios.generate(1)
         assertEquals(OracleSolver.layout(scenario), PortSolver.layout(scenario))
     }
+
+    @Test
+    fun bothSubjectsMeasureAScenario() {
+        val scenario = Scenarios.generate(1)
+        for (subject in subjects) {
+            val outcome = subject.measure(scenario)
+            assertTrue(outcome is LayoutOutcome.LaidOut, "${subject.name} returned $outcome")
+        }
+    }
+
+    @Test
+    fun measuredGeometryNamesEveryParticipant() {
+        val scenario = Scenarios.generate(1)
+        for (subject in subjects) {
+            val geometry = (subject.measure(scenario) as LayoutOutcome.LaidOut).geometry
+            assertTrue(geometry.contains("root"), "${subject.name}: $geometry")
+            for (widget in scenario.widgets) {
+                assertTrue(geometry.contains(widget.name), "${subject.name} missing ${widget.name}")
+            }
+        }
+    }
+
+    @Test
+    fun subjectsAgreeWhenMeasuringASingleScenario() {
+        val scenario = Scenarios.generate(1)
+        assertEquals(OracleSolver.measure(scenario), PortSolver.measure(scenario))
+    }
+
+    /**
+     * The two entry points answer different questions, so they are never compared against each
+     * other — only oracle-to-port within each. This case documents that they genuinely differ, so a
+     * future change that silently made `measure` delegate to `layout` would be visible.
+     */
+    @Test
+    fun measuringAndLayingOutAreDistinctPaths() {
+        val differing = (1L..200L).count { seed ->
+            val scenario = Scenarios.generate(seed)
+            OracleSolver.measure(scenario) != OracleSolver.layout(scenario)
+        }
+        assertTrue(differing > 0, "measure() and layout() produced identical results on 200 seeds")
+    }
 }


### PR DESCRIPTION
Builds on #339. The harness compares the solver through `ConstraintWidgetContainer.layout()`; production does not go that way.

The Compose layer calls `root.measure(optimizationLevel, …)` (`ConstraintLayout.kt:1941`), which runs `BasicMeasure.solverMeasure` and only reaches `layout()` as one of its branches. That is 516 lines of measure orchestration sitting *above* the harness's entry point, with no differential coverage at all — and unlike the `OPTIMIZATION_GRAPH` gap noted in #339, nothing gates it: every real layout goes through it.

## What this adds

- Tree construction is extracted into a private `build`/`render` in each subject, so both entry points share it. Pure refactor, verified by the 2000-scenario comparison being unchanged.
- `Scenario` gains a `MeasureSpec` — width and height measure modes, plus a neutral optimization level.
- Each subject gains a stub `Measurer` reporting each widget's intrinsic size from its spec, and a `measure(scenario)` entry point.
- The differential test runs all 2000 scenarios through **both** entry points, comparing them pairwise and separately — `layout` against `layout`, `measure` against `measure`, never across. 4000 comparisons, all passing, with 2000/2000 scenarios reaching `LaidOut` through each.

`layout()` is kept rather than replaced: both mutation probes in #338 and #339 fired through it, so it is demonstrably load-bearing coverage.

## A defect in the spec this PR corrects

The design claimed `AT_MOST` on a wrap-content root would drive `BasicMeasure`'s re-measure loop, and that generating that combination was the point of the measure-mode axis. **That is false at the level this harness uses.** In `solverMeasure` the mode arguments are only consulted when `optimize` is set, which requires `OPTIMIZATION_GRAPH` or `OPTIMIZATION_GRAPH_WRAP`; `OPTIMIZATION_STANDARD` is `DIRECT | CACHE_MEASURES`. The re-measure loop still runs, but from the container's constructor dimensions, not the measure arguments.

The modes are kept, generated and asserted — but as forward-preparation for raising the optimization level, which is the natural follow-up. The comments now say that rather than the reverse. Caught by review, not by me.

## What the mutation probe does and does not establish

Mutating `widget.width = mMeasure.measuredWidth` to `+ 1` inside `BasicMeasure` produced **1778 divergences of 4000, every one labelled `via measure` and none `via layout`**. The discrimination is structural rather than statistical: the mutated method is reachable only from `solverMeasure`, and `layout()` never touches `mBasicMeasureSolver`. Example, seed 2: widths `26→27`, `168→170`, `119→121` in the port against the oracle.

Stated plainly, because the previous PRs in this series overstated similar claims: this proves the measure entry point genuinely reaches `BasicMeasure`'s per-widget measure application, and that a difference there is detected and correctly attributed. It does **not** prove the intermediate re-measure loop is exercised — that line runs on the first `measureChildren` pass. A probe inside the iteration loop is the follow-up that would close it.

## Neutrality of the scenario layer

Review caught the generator storing the *oracle's* numeric `Optimizer.OPTIMIZATION_STANDARD` in `Scenario` and handing it to both solvers. Had the port's constant ever diverged from upstream's — precisely the defect class this module exists to catch — the harness would have fed the oracle's value to both sides and hidden it. The level is now a neutral enum that each subject maps to its own package's constant, matching how `Behaviour`, `Side` and `MeasureMode` already work.

## Known limitation

The stub measurer is not what Compose measures with. This answers "do the two implementations orchestrate measurement identically", not "does the library measure correctly in a real application" — a question no differential harness against a vendored oracle can answer, since both sides share the stub.

## One parked residual

`Scenario.kt`'s corrected KDoc says `solverMeasure` reads the modes "only inside its `if (optimize)` branch". `BasicMeasure.kt:213` also reads them while computing `optimize` itself. The conclusion — inert at `OPTIMIZATION_STANDARD` — holds, because `optimize` is already false by then; the stated mechanism is imprecise. Flagged rather than silently shipped.

## Verification

446 tests, 0 failures on `jvmTest`, `testAndroidHostTest`, `macosArm64Test`, `iosSimulatorArm64Test` and `wasmJsTest`. 49 in `:parity`. 446 rather than 455 is expected: this branch forked before two motion fixes landed on `main`.
