### PR TITLE
ci: move the artifact uploads off the retired v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-reports
           path: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-test-results
           path: |


### PR DESCRIPTION
`call-build` currently fails on every branch, including `main`, in about four seconds — before it
checks out the repository or runs a single step:

> This request has been automatically failed because it uses a deprecated version of
> `actions/upload-artifact: v3`

GitHub retired v3 of the artifact actions and now rejects the job outright rather than warning.
[build.yml](.github/workflows/build.yml) was the only workflow still pinned to it; `static-validations.yml` and
`release.yml` are already on v4.

A plain version bump is enough. v4's breaking change is that artifact names have to be unique
within a run, and the two steps here upload under distinct names (`android-reports`,
`android-test-results`) from a single job with no matrix, so nothing collides.

## While nearby

Two other actions in this workflow are aging but still function, and I left them alone to keep
this to one concern:

- `gradle/wrapper-validation-action@v1` — superseded by `gradle/actions/wrapper-validation`
- `gradle/gradle-build-action@v2.4.2` — superseded by `gradle/actions/setup-gradle`

Neither is auto-failed today. Worth a follow-up before they go the same way as v3.

## Verification

This one can only be verified by running: the failure is enforced by GitHub's action resolver, not
by anything reproducible locally. This PR's own `call-build` job is the test — it should now get
past resolution and actually build.
