### PR TITLE
build: fail the build on casts that can never succeed

### DIFF
--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
@@ -71,7 +71,26 @@ class ConstraintLayoutLibraryPlugin : Plugin<Project> {
                 targets.configureEach {
                     compilations.configureEach {
                         compileTaskProvider.configure {
-                            compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+                            compilerOptions.freeCompilerArgs.addAll(
+                                "-Xexpect-actual-classes",
+                                // Casts the compiler can already prove will always throw. In a
+                                // mechanical Java-to-Kotlin port these are never a style question:
+                                // Java's `(float) x` narrows, Kotlin's `x as Float` throws, and the
+                                // two read almost alike. That is how #342 shipped a
+                                // ClassCastException in ArcCurveFit — reported as a warning nobody
+                                // read.
+                                //
+                                // Promoting these two and nothing else is deliberate. Blanket
+                                // `allWarningsAsErrors` would be the wrong tool: of the 74 warnings
+                                // on this tree, the ones checked against the Java original turned
+                                // out to be upstream's own redundancy made visible by Kotlin's
+                                // types — dead null checks on fields Java initialises at their
+                                // declaration. Silencing those would mean diverging from the
+                                // original in 74 places, and line-by-line comparison against
+                                // upstream is how defects get found here.
+                                "-Xwarning-level=NUMERIC_CAST_NEVER_SUCCEEDS_BUT_CAN_BE_REPLACED_WITH_TO_CALL:error",
+                                "-Xwarning-level=CAST_NEVER_SUCCEEDS:error",
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
Java's `(float) x` narrows. Kotlin's `x as Float` throws. The two read almost alike, which is how
[#342](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/342) shipped a
`ClassCastException` in `ArcCurveFit` — the compiler had been reporting it as a warning the entire
time, and nobody read the output.

This promotes exactly two diagnostics to errors:

```
NUMERIC_CAST_NEVER_SUCCEEDS_BUT_CAN_BE_REPLACED_WITH_TO_CALL
CAST_NEVER_SUCCEEDS
```

Both are at zero occurrences on this tree, so nothing had to be silenced to turn them on.

## Why not `allWarningsAsErrors`

That was the original plan. Measuring first changed it: there are 74 warnings on `main`, and every
one I checked against the Java original turned out to be **upstream's own redundancy made visible
by Kotlin's types**, not a translation defect.

| warning | why it fires | verdict |
|---|---|---|
| `Condition is always ...` ×24 | `mKeyList` is initialised at its declaration; `makeSpline` returns `new CoreSpline` unconditionally | the check was already dead **in Java** |
| `Elvis always returns the left operand` | `mInterpolated = new WidgetFrame()` in the constructor | same |
| `Check for instance is always true` | `CLParser.parse` returns `CLObject` | same |
| `Redundant call of conversion method` ×4 | `.toString()` on string concatenation in log messages | no numeric narrowing involved |

Java hands these back as platform types and says nothing; Kotlin declares them non-null and says so.
Silencing 74 of them would mean deliberately diverging from the original in 74 places — and
line-by-line comparison against upstream is how defects actually get found in this port. So the gate
is surgical instead: the diagnostics that can only ever mean a mistranslation become errors, the
ones that mirror upstream stay warnings.

## Verification

Mutation probe, the same discipline as the parity harness:

1. Revert one `ArcCurveFit` site to `as Float` → build fails with `e: ... This cast can never succeed`
2. Restore `.toFloat()` → build green

Getting there also cost one wrong turn worth recording: `CAST_NEVER_SUCCEEDS` alone does **not**
cover the numeric case. It is a valid diagnostic name, so the flag was accepted and the build stayed
green — silently doing nothing. The probe is what caught that; a control experiment
(`USELESS_CAST:disabled`, which did silence its warning) confirmed the mechanism worked and the name
was wrong.

All seven targets, both shaded flavours, `:compose:jvmTest` and `:parity:test` are green. The
warning count is unchanged at 74 — this promotes, it does not suppress.
