### PR TITLE
test(parity): compare the ported motion engine against upstream

### DIFF
--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionDifferentialTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Compares the ported `core/motion` against the vendored upstream Java over generated scenarios.
+ *
+ * A green run here means the two agree on every scenario the generator produced — not that the
+ * animation is correct. If upstream animates wrongly, both sides are wrong together and this stays
+ * green. That is the price of an oracle, and it is the same price the parser, solver and measure
+ * harnesses pay.
+ */
+class MotionDifferentialTest {
+    @Test
+    fun thePortAgreesWithTheOracle() {
+        val oracle = OracleMotion()
+        val port = PortMotion()
+        val divergences =
+            (0L until SEEDS).mapNotNull { seed ->
+                val scenario = Scenarios.generate(seed)
+                val fromOracle = oracle.run(scenario)
+                val fromPort = port.run(scenario)
+                if (fromOracle == fromPort) null else report(scenario, fromOracle, fromPort)
+            }
+
+        assertTrue(
+            divergences.isEmpty(),
+            buildString {
+                append(divergences.size).append(" of ").append(SEEDS).append(" scenarios diverged.\n\n")
+                divergences.take(MAX_REPORTED).forEach { append(it).append('\n') }
+                if (divergences.size > MAX_REPORTED) {
+                    append("… and ").append(divergences.size - MAX_REPORTED).append(" more.")
+                }
+            },
+        )
+    }
+
+    private fun report(scenario: MotionScenario, oracle: MotionOutcome, port: MotionOutcome): String =
+        buildString {
+            append("seed     : ").append(scenario.seed).append('\n')
+            append("start    : ").append(scenario.start).append('\n')
+            append("end      : ").append(scenario.end).append('\n')
+            append("arc      : ").append(scenario.pathMotionArc)
+                .append("  easing: ").append(scenario.easing).append('\n')
+            scenario.keys.forEach { append("key      : ").append(it).append('\n') }
+            append("oracle   :\n").append(indent(oracle)).append('\n')
+            append("port     :\n").append(indent(port)).append('\n')
+        }
+
+    private fun indent(outcome: MotionOutcome): String =
+        when (outcome) {
+            is MotionOutcome.Sampled -> outcome.snapshot
+            is MotionOutcome.Leaked -> "leaked ${outcome.category}"
+            is MotionOutcome.Crashed -> "crashed ${outcome.error}"
+        }.lines().joinToString("\n") { "    $it" }
+
+    private companion object {
+        const val SEEDS = 1000L
+        const val MAX_REPORTED = 3
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionDifferentialTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionDifferentialTest.kt
@@ -19,11 +19,13 @@ class MotionDifferentialTest {
     fun thePortAgreesWithTheOracle() {
         val oracle = OracleMotion()
         val port = PortMotion()
+        var sampled = 0
         val divergences =
             (0L until SEEDS).mapNotNull { seed ->
                 val scenario = Scenarios.generate(seed)
                 val fromOracle = oracle.run(scenario)
                 val fromPort = port.run(scenario)
+                if (fromOracle is MotionOutcome.Sampled && fromPort is MotionOutcome.Sampled) sampled++
                 if (fromOracle == fromPort) null else report(scenario, fromOracle, fromPort)
             }
 
@@ -36,6 +38,13 @@ class MotionDifferentialTest {
                     append("… and ").append(divergences.size - MAX_REPORTED).append(" more.")
                 }
             },
+        )
+
+        // A shared harness-side failure makes both sides Leaked with the same category, which
+        // compares equal above and would read as agreement. Guard against measuring nothing.
+        assertTrue(
+            sampled == SEEDS.toInt(),
+            "only $sampled of $SEEDS scenarios actually sampled on both sides; the rest leaked or crashed",
         )
     }
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionOutcome.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionOutcome.kt
@@ -1,0 +1,31 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+/**
+ * Everything observable about one motion run, normalised so the two implementations become
+ * comparable despite living in different packages. Deliberately the same shape as `LayoutOutcome`.
+ */
+internal sealed interface MotionOutcome {
+    data class Sampled(val snapshot: String) : MotionOutcome
+
+    /**
+     * An exception escaped `Motion`. Compared by portable category, not exception class: the port
+     * is multiplatform and cannot raise JVM-specific exception classes on Native or JS, so class
+     * equality would demand something no correct port could deliver.
+     */
+    data class Leaked(val category: String) : MotionOutcome
+
+    data class Crashed(val error: String) : MotionOutcome
+
+    companion object {
+        fun categorise(throwable: Throwable): String =
+            when (throwable) {
+                is IndexOutOfBoundsException -> "IndexOutOfBounds"
+                is NullPointerException -> "NullPointer"
+                is ArithmeticException -> "Arithmetic"
+                else -> throwable::class.simpleName ?: "Unknown"
+            }
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSample.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSample.kt
@@ -1,0 +1,69 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+/** One sweep position: what `interpolate` produced there, plus the centre and velocity. */
+internal data class PositionSample(
+    val p: Float,
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+    val rotationZ: Float,
+    val scaleX: Float,
+    val scaleY: Float,
+    val alpha: Float,
+    val translationX: Float,
+    val translationY: Float,
+    val centerX: Float,
+    val centerY: Float,
+    val velocityX: Float,
+    val velocityY: Float,
+)
+
+/**
+ * Raw values collected from one side, before rendering. Subjects fill this and nothing else.
+ *
+ * Rendering lives here rather than in the subjects for the same reason the scenario names no
+ * side's types: if each subject formatted its own string, a difference in how one of them formats
+ * would be indistinguishable from a difference in what `Motion` computed, and the harness would
+ * report a defect that does not exist.
+ */
+internal data class MotionSample(
+    val positions: List<PositionSample>,
+    val path: List<Float>,
+    val keyFrames: List<Float>,
+    val keyFrameModes: List<Int>,
+    val keyFramePositions: List<Int>,
+    val keyFrameCount: Int,
+) {
+    /**
+     * `Float.toString` is the whole formatting strategy, deliberately. Both sides run on the JVM,
+     * where it is the same `java.lang.Float.toString`, so matching computations produce identical
+     * text down to the last bit. `NaN` reads as "NaN" on both sides — agreement, which is what two
+     * implementations degenerating the same way should report — and `-0.0` stays distinct from
+     * "0.0", which a tolerance would have erased.
+     */
+    fun render(): String = buildString {
+        positions.forEach { s ->
+            append("p=").append(s.p)
+            append(" bounds=").append(s.left).append(',').append(s.top).append(',')
+                .append(s.right).append(',').append(s.bottom)
+            append(" rotationZ=").append(s.rotationZ)
+            append(" scaleX=").append(s.scaleX)
+            append(" scaleY=").append(s.scaleY)
+            append(" alpha=").append(s.alpha)
+            append(" translationX=").append(s.translationX)
+            append(" translationY=").append(s.translationY)
+            append(" center=").append(s.centerX).append(',').append(s.centerY)
+            append(" velocity=").append(s.velocityX).append(',').append(s.velocityY)
+            append('\n')
+        }
+        append("path=").append(path.joinToString(",")).append('\n')
+        append("keyFrames=").append(keyFrames.joinToString(",")).append('\n')
+        append("keyFrameModes=").append(keyFrameModes.joinToString(",")).append('\n')
+        append("keyFramePositions=").append(keyFramePositions.joinToString(",")).append('\n')
+        append("count=").append(keyFrameCount)
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSampleTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSampleTest.kt
@@ -1,0 +1,62 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MotionSampleTest {
+    private fun sample() =
+        MotionSample(
+            positions = listOf(
+                PositionSample(
+                    p = 0.5f, left = 1, top = 2, right = 3, bottom = 4,
+                    rotationZ = 5f, scaleX = 6f, scaleY = 7f, alpha = 8f,
+                    translationX = 9f, translationY = 10f,
+                    centerX = 11f, centerY = 12f, velocityX = 13f, velocityY = 14f,
+                ),
+            ),
+            path = listOf(1f, 2f),
+            keyFrames = listOf(3f, 4f),
+            keyFrameModes = listOf(5),
+            keyFramePositions = listOf(6),
+            keyFrameCount = 1,
+        )
+
+    @Test
+    fun renderingIsStable() {
+        assertEquals(sample().render(), sample().render())
+    }
+
+    @Test
+    fun everyFieldReachesTheSnapshot() {
+        val rendered = sample().render()
+        listOf("0.5", "1,2,3,4", "5.0", "13.0", "count=1").forEach {
+            assertTrue(it in rendered, "'$it' missing from:\n$rendered")
+        }
+    }
+
+    @Test
+    fun negativeZeroStaysDistinctFromZero() {
+        val zero = sample().copy(path = listOf(0f))
+        val negativeZero = sample().copy(path = listOf(-0f))
+        assertTrue(zero.render() != negativeZero.render(), "-0.0 collapsed into 0.0")
+    }
+
+    @Test
+    fun nanRendersIdenticallyOnBothSides() {
+        val a = sample().copy(path = listOf(Float.NaN))
+        val b = sample().copy(path = listOf(Float.NaN))
+        assertEquals(a.render(), b.render())
+    }
+
+    @Test
+    fun exceptionsAreCategorisedPortably() {
+        assertEquals("IndexOutOfBounds", MotionOutcome.categorise(IndexOutOfBoundsException()))
+        assertEquals("NullPointer", MotionOutcome.categorise(NullPointerException()))
+        assertEquals("Arithmetic", MotionOutcome.categorise(ArithmeticException()))
+        assertEquals("IllegalStateException", MotionOutcome.categorise(IllegalStateException()))
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionScenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionScenario.kt
@@ -1,0 +1,81 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+/**
+ * Numeric ids from `TypedValues`, duplicated here by value on purpose. The scenario has to describe
+ * its input without naming a type from either side: the moment it imports the oracle's constants,
+ * the two subjects stop being fed the same thing by construction. #339 had to repair that leak.
+ */
+internal object TypeIds {
+    const val ATTR_CURVE_FIT = 301
+    const val ATTR_ALPHA = 303
+    const val ATTR_TRANSLATION_X = 304
+    const val ATTR_TRANSLATION_Y = 305
+    const val ATTR_ROTATION_Z = 310
+    const val ATTR_SCALE_X = 311
+    const val ATTR_SCALE_Y = 312
+
+    const val POSITION_TRANSITION_EASING = 501
+    const val POSITION_PERCENT_WIDTH = 503
+    const val POSITION_PERCENT_HEIGHT = 504
+    const val POSITION_PERCENT_X = 506
+    const val POSITION_PERCENT_Y = 507
+    const val POSITION_CURVE_FIT = 508
+    const val POSITION_PATH_MOTION_ARC = 509
+
+    const val MOTION_EASING = 603
+}
+
+internal data class Bounds(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+/** `Float.NaN` means "not set", exactly as the originals use it. */
+internal data class Attributes(
+    val rotationZ: Float,
+    val scaleX: Float,
+    val scaleY: Float,
+    val alpha: Float,
+    val translationX: Float,
+    val translationY: Float,
+)
+
+internal sealed interface KeySpec {
+    val framePosition: Int
+
+    data class PositionKey(
+        override val framePosition: Int,
+        val percentX: Float,
+        val percentY: Float,
+        val percentWidth: Float,
+        val percentHeight: Float,
+        val curveFit: Int,
+        val transitionEasing: String?,
+        val pathMotionArc: Int,
+    ) : KeySpec
+
+    data class AttributesKey(
+        override val framePosition: Int,
+        val rotationZ: Float,
+        val scaleX: Float,
+        val scaleY: Float,
+        val alpha: Float,
+        val curveFit: Int,
+        val transitionEasing: String?,
+    ) : KeySpec
+}
+
+internal data class MotionScenario(
+    val seed: Long,
+    val start: Bounds,
+    val end: Bounds,
+    val startAttributes: Attributes,
+    val endAttributes: Attributes,
+    val keys: List<KeySpec>,
+    val pathMotionArc: Int,
+    val easing: String?,
+    val parentWidth: Int,
+    val parentHeight: Int,
+    val duration: Float,
+    val samples: Int,
+)

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionScenario.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionScenario.kt
@@ -61,7 +61,6 @@ internal sealed interface KeySpec {
         val scaleY: Float,
         val alpha: Float,
         val curveFit: Int,
-        val transitionEasing: String?,
     ) : KeySpec
 }
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubject.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubject.kt
@@ -1,0 +1,12 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+/**
+ * One motion run. Implemented twice over the same scenario — once against the vendored upstream
+ * Java, once against the shaded port — and the two results are compared verbatim.
+ */
+internal interface MotionSubject {
+    fun run(scenario: MotionScenario): MotionOutcome
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubjectTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubjectTest.kt
@@ -1,0 +1,57 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MotionSubjectTest {
+    private val trivial =
+        MotionScenario(
+            seed = 0L,
+            start = Bounds(0, 0, 100, 100),
+            end = Bounds(200, 200, 300, 300),
+            startAttributes = Attributes(Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN),
+            endAttributes = Attributes(Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN),
+            keys = emptyList(),
+            pathMotionArc = -1,
+            easing = null,
+            parentWidth = 1000,
+            parentHeight = 1000,
+            duration = 1000f,
+            samples = 5,
+        )
+
+    @Test
+    fun theOracleRunsTheTrivialScenario() {
+        val outcome = OracleMotion().run(trivial)
+        assertTrue(outcome is MotionOutcome.Sampled, "oracle returned $outcome")
+    }
+
+    @Test
+    fun thePortRunsTheTrivialScenario() {
+        val outcome = PortMotion().run(trivial)
+        assertTrue(outcome is MotionOutcome.Sampled, "port returned $outcome")
+    }
+
+    @Test
+    fun theSnapshotIsNotEmpty() {
+        val outcome = OracleMotion().run(trivial) as MotionOutcome.Sampled
+        assertTrue(outcome.snapshot.lines().size >= 5, "snapshot too short:\n${outcome.snapshot}")
+    }
+
+    @Test
+    fun aScenarioWithKeysAlsoRuns() {
+        val withKeys =
+            trivial.copy(
+                keys = listOf(
+                    KeySpec.PositionKey(50, 0.5f, 0.5f, Float.NaN, Float.NaN, -1, null, -1),
+                    KeySpec.AttributesKey(75, 45f, 2f, 2f, 0.5f, -1, null),
+                ),
+                pathMotionArc = 1,
+            )
+        assertTrue(OracleMotion().run(withKeys) is MotionOutcome.Sampled)
+        assertTrue(PortMotion().run(withKeys) is MotionOutcome.Sampled)
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubjectTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/MotionSubjectTest.kt
@@ -47,7 +47,7 @@ class MotionSubjectTest {
             trivial.copy(
                 keys = listOf(
                     KeySpec.PositionKey(50, 0.5f, 0.5f, Float.NaN, Float.NaN, -1, null, -1),
-                    KeySpec.AttributesKey(75, 45f, 2f, 2f, 0.5f, -1, null),
+                    KeySpec.AttributesKey(75, 45f, 2f, 2f, 0.5f, -1),
                 ),
                 pathMotionArc = 1,
             )

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/OracleMotion.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/OracleMotion.kt
@@ -22,8 +22,8 @@ internal class OracleMotion : MotionSubject {
         }
 
     private fun sample(scenario: MotionScenario): MotionSample {
-        val start = widget(scenario.start, scenario.startAttributes, easing = null)
-        val end = widget(scenario.end, scenario.endAttributes, easing = scenario.easing)
+        val start = widget(scenario.start, scenario.startAttributes, easing = scenario.easing)
+        val end = widget(scenario.end, scenario.endAttributes, easing = null)
 
         val motion = Motion(start)
         motion.setStart(start)
@@ -101,7 +101,7 @@ internal class OracleMotion : MotionSubject {
                     if (!spec.percentWidth.isNaN()) setValue(TypeIds.POSITION_PERCENT_WIDTH, spec.percentWidth)
                     if (!spec.percentHeight.isNaN()) setValue(TypeIds.POSITION_PERCENT_HEIGHT, spec.percentHeight)
                     setValue(TypeIds.POSITION_CURVE_FIT, spec.curveFit)
-                    setValue(TypeIds.POSITION_PATH_MOTION_ARC, spec.pathMotionArc)
+                    mPathMotionArc = spec.pathMotionArc
                     spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
                 }
 
@@ -113,7 +113,6 @@ internal class OracleMotion : MotionSubject {
                     if (!spec.scaleY.isNaN()) setValue(TypeIds.ATTR_SCALE_Y, spec.scaleY)
                     if (!spec.alpha.isNaN()) setValue(TypeIds.ATTR_ALPHA, spec.alpha)
                     setValue(TypeIds.ATTR_CURVE_FIT, spec.curveFit)
-                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
                 }
         }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/OracleMotion.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/OracleMotion.kt
@@ -1,0 +1,119 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import androidx.constraintlayout.core.motion.Motion
+import androidx.constraintlayout.core.motion.MotionWidget
+import androidx.constraintlayout.core.motion.key.MotionKeyAttributes
+import androidx.constraintlayout.core.motion.key.MotionKeyPosition
+import androidx.constraintlayout.core.motion.utils.KeyCache
+
+/**
+ * Drives the vendored upstream Java. `PortMotion` performs the same sequence against the shaded
+ * port; keeping the two in step is the whole contract, so any edit here needs the mirror edit there.
+ */
+internal class OracleMotion : MotionSubject {
+    override fun run(scenario: MotionScenario): MotionOutcome =
+        try {
+            MotionOutcome.Sampled(sample(scenario).render())
+        } catch (throwable: Throwable) {
+            MotionOutcome.Leaked(MotionOutcome.categorise(throwable))
+        }
+
+    private fun sample(scenario: MotionScenario): MotionSample {
+        val start = widget(scenario.start, scenario.startAttributes, easing = null)
+        val end = widget(scenario.end, scenario.endAttributes, easing = scenario.easing)
+
+        val motion = Motion(start)
+        motion.setStart(start)
+        motion.setEnd(end)
+        scenario.keys.forEach { motion.addKey(key(it)) }
+        motion.setPathMotionArc(scenario.pathMotionArc)
+        motion.setup(scenario.parentWidth, scenario.parentHeight, scenario.duration, 0L)
+
+        val cache = KeyCache()
+        val out = MotionWidget()
+        val centre = FloatArray(2)
+        val velocity = FloatArray(2)
+        val positions =
+            (0 until scenario.samples).map { index ->
+                val p = index.toFloat() / (scenario.samples - 1)
+                motion.interpolate(out, p, 0L, cache)
+                motion.getCenter(p.toDouble(), centre, velocity)
+                PositionSample(
+                    p = p,
+                    left = out.left, top = out.top, right = out.right, bottom = out.bottom,
+                    rotationZ = out.rotationZ, scaleX = out.scaleX, scaleY = out.scaleY,
+                    alpha = out.alpha, translationX = out.translationX, translationY = out.translationY,
+                    centerX = centre[0], centerY = centre[1],
+                    velocityX = velocity[0], velocityY = velocity[1],
+                )
+            }
+
+        val path = FloatArray(scenario.samples * 2)
+        motion.buildPath(path, scenario.samples)
+
+        // Sized from the upper bound on MotionPaths: start, end, and one per position key. Both
+        // arrays are pre-filled so unwritten slots read identically on both sides rather than
+        // depending on whatever the allocator left behind.
+        val pathCount = scenario.keys.count { it is KeySpec.PositionKey } + 2
+        val keyFrames = FloatArray(pathCount * 2) { Float.NaN }
+        val modes = IntArray(pathCount) { Int.MIN_VALUE }
+        val positionsOut = IntArray(pathCount) { Int.MIN_VALUE }
+        val count = motion.buildKeyFrames(keyFrames, modes, positionsOut)
+
+        return MotionSample(
+            positions = positions,
+            path = path.toList(),
+            keyFrames = keyFrames.toList(),
+            keyFrameModes = modes.toList(),
+            keyFramePositions = positionsOut.toList(),
+            keyFrameCount = count,
+        )
+    }
+
+    private fun widget(bounds: Bounds, attributes: Attributes, easing: String?): MotionWidget {
+        val widget = MotionWidget()
+        widget.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
+        attribute(widget, TypeIds.ATTR_ROTATION_Z, attributes.rotationZ)
+        attribute(widget, TypeIds.ATTR_SCALE_X, attributes.scaleX)
+        attribute(widget, TypeIds.ATTR_SCALE_Y, attributes.scaleY)
+        attribute(widget, TypeIds.ATTR_ALPHA, attributes.alpha)
+        attribute(widget, TypeIds.ATTR_TRANSLATION_X, attributes.translationX)
+        attribute(widget, TypeIds.ATTR_TRANSLATION_Y, attributes.translationY)
+        if (easing != null) widget.setValueMotion(TypeIds.MOTION_EASING, easing)
+        return widget
+    }
+
+    /** `NaN` means "not set" in the originals, so an unset attribute is one never applied at all. */
+    private fun attribute(widget: MotionWidget, id: Int, value: Float) {
+        if (!value.isNaN()) widget.setValueAttributes(id, value)
+    }
+
+    private fun key(spec: KeySpec) =
+        when (spec) {
+            is KeySpec.PositionKey ->
+                MotionKeyPosition().apply {
+                    mFramePosition = spec.framePosition
+                    if (!spec.percentX.isNaN()) setValue(TypeIds.POSITION_PERCENT_X, spec.percentX)
+                    if (!spec.percentY.isNaN()) setValue(TypeIds.POSITION_PERCENT_Y, spec.percentY)
+                    if (!spec.percentWidth.isNaN()) setValue(TypeIds.POSITION_PERCENT_WIDTH, spec.percentWidth)
+                    if (!spec.percentHeight.isNaN()) setValue(TypeIds.POSITION_PERCENT_HEIGHT, spec.percentHeight)
+                    setValue(TypeIds.POSITION_CURVE_FIT, spec.curveFit)
+                    setValue(TypeIds.POSITION_PATH_MOTION_ARC, spec.pathMotionArc)
+                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
+                }
+
+            is KeySpec.AttributesKey ->
+                MotionKeyAttributes().apply {
+                    mFramePosition = spec.framePosition
+                    if (!spec.rotationZ.isNaN()) setValue(TypeIds.ATTR_ROTATION_Z, spec.rotationZ)
+                    if (!spec.scaleX.isNaN()) setValue(TypeIds.ATTR_SCALE_X, spec.scaleX)
+                    if (!spec.scaleY.isNaN()) setValue(TypeIds.ATTR_SCALE_Y, spec.scaleY)
+                    if (!spec.alpha.isNaN()) setValue(TypeIds.ATTR_ALPHA, spec.alpha)
+                    setValue(TypeIds.ATTR_CURVE_FIT, spec.curveFit)
+                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
+                }
+        }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
@@ -10,8 +10,8 @@ import tech.annexflow.constraintlayout.core.motion.key.MotionKeyPosition
 import tech.annexflow.constraintlayout.core.motion.utils.KeyCache
 
 /**
- * Drives the vendored upstream Java. `PortMotion` performs the same sequence against the shaded
- * port; keeping the two in step is the whole contract, so any edit here needs the mirror edit there.
+ * Drives the shaded port. `OracleMotion` performs the same sequence against the vendored upstream
+ * Java; keeping the two in step is the whole contract, so any edit here needs the mirror edit there.
  */
 internal class PortMotion : MotionSubject {
     override fun run(scenario: MotionScenario): MotionOutcome =

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
@@ -22,8 +22,8 @@ internal class PortMotion : MotionSubject {
         }
 
     private fun sample(scenario: MotionScenario): MotionSample {
-        val start = widget(scenario.start, scenario.startAttributes, easing = null)
-        val end = widget(scenario.end, scenario.endAttributes, easing = scenario.easing)
+        val start = widget(scenario.start, scenario.startAttributes, easing = scenario.easing)
+        val end = widget(scenario.end, scenario.endAttributes, easing = null)
 
         val motion = Motion(start)
         motion.setStart(start)
@@ -101,7 +101,7 @@ internal class PortMotion : MotionSubject {
                     if (!spec.percentWidth.isNaN()) setValue(TypeIds.POSITION_PERCENT_WIDTH, spec.percentWidth)
                     if (!spec.percentHeight.isNaN()) setValue(TypeIds.POSITION_PERCENT_HEIGHT, spec.percentHeight)
                     setValue(TypeIds.POSITION_CURVE_FIT, spec.curveFit)
-                    setValue(TypeIds.POSITION_PATH_MOTION_ARC, spec.pathMotionArc)
+                    mPathMotionArc = spec.pathMotionArc
                     spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
                 }
 
@@ -113,7 +113,6 @@ internal class PortMotion : MotionSubject {
                     if (!spec.scaleY.isNaN()) setValue(TypeIds.ATTR_SCALE_Y, spec.scaleY)
                     if (!spec.alpha.isNaN()) setValue(TypeIds.ATTR_ALPHA, spec.alpha)
                     setValue(TypeIds.ATTR_CURVE_FIT, spec.curveFit)
-                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
                 }
         }
 }

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/PortMotion.kt
@@ -1,0 +1,119 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import tech.annexflow.constraintlayout.core.motion.Motion
+import tech.annexflow.constraintlayout.core.motion.MotionWidget
+import tech.annexflow.constraintlayout.core.motion.key.MotionKeyAttributes
+import tech.annexflow.constraintlayout.core.motion.key.MotionKeyPosition
+import tech.annexflow.constraintlayout.core.motion.utils.KeyCache
+
+/**
+ * Drives the vendored upstream Java. `PortMotion` performs the same sequence against the shaded
+ * port; keeping the two in step is the whole contract, so any edit here needs the mirror edit there.
+ */
+internal class PortMotion : MotionSubject {
+    override fun run(scenario: MotionScenario): MotionOutcome =
+        try {
+            MotionOutcome.Sampled(sample(scenario).render())
+        } catch (throwable: Throwable) {
+            MotionOutcome.Leaked(MotionOutcome.categorise(throwable))
+        }
+
+    private fun sample(scenario: MotionScenario): MotionSample {
+        val start = widget(scenario.start, scenario.startAttributes, easing = null)
+        val end = widget(scenario.end, scenario.endAttributes, easing = scenario.easing)
+
+        val motion = Motion(start)
+        motion.setStart(start)
+        motion.setEnd(end)
+        scenario.keys.forEach { motion.addKey(key(it)) }
+        motion.setPathMotionArc(scenario.pathMotionArc)
+        motion.setup(scenario.parentWidth, scenario.parentHeight, scenario.duration, 0L)
+
+        val cache = KeyCache()
+        val out = MotionWidget()
+        val centre = FloatArray(2)
+        val velocity = FloatArray(2)
+        val positions =
+            (0 until scenario.samples).map { index ->
+                val p = index.toFloat() / (scenario.samples - 1)
+                motion.interpolate(out, p, 0L, cache)
+                motion.getCenter(p.toDouble(), centre, velocity)
+                PositionSample(
+                    p = p,
+                    left = out.getLeft(), top = out.getTop(), right = out.getRight(), bottom = out.getBottom(),
+                    rotationZ = out.getRotationZ(), scaleX = out.getScaleX(), scaleY = out.getScaleY(),
+                    alpha = out.getAlpha(), translationX = out.getTranslationX(), translationY = out.getTranslationY(),
+                    centerX = centre[0], centerY = centre[1],
+                    velocityX = velocity[0], velocityY = velocity[1],
+                )
+            }
+
+        val path = FloatArray(scenario.samples * 2)
+        motion.buildPath(path, scenario.samples)
+
+        // Sized from the upper bound on MotionPaths: start, end, and one per position key. Both
+        // arrays are pre-filled so unwritten slots read identically on both sides rather than
+        // depending on whatever the allocator left behind.
+        val pathCount = scenario.keys.count { it is KeySpec.PositionKey } + 2
+        val keyFrames = FloatArray(pathCount * 2) { Float.NaN }
+        val modes = IntArray(pathCount) { Int.MIN_VALUE }
+        val positionsOut = IntArray(pathCount) { Int.MIN_VALUE }
+        val count = motion.buildKeyFrames(keyFrames, modes, positionsOut)
+
+        return MotionSample(
+            positions = positions,
+            path = path.toList(),
+            keyFrames = keyFrames.toList(),
+            keyFrameModes = modes.toList(),
+            keyFramePositions = positionsOut.toList(),
+            keyFrameCount = count,
+        )
+    }
+
+    private fun widget(bounds: Bounds, attributes: Attributes, easing: String?): MotionWidget {
+        val widget = MotionWidget()
+        widget.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
+        attribute(widget, TypeIds.ATTR_ROTATION_Z, attributes.rotationZ)
+        attribute(widget, TypeIds.ATTR_SCALE_X, attributes.scaleX)
+        attribute(widget, TypeIds.ATTR_SCALE_Y, attributes.scaleY)
+        attribute(widget, TypeIds.ATTR_ALPHA, attributes.alpha)
+        attribute(widget, TypeIds.ATTR_TRANSLATION_X, attributes.translationX)
+        attribute(widget, TypeIds.ATTR_TRANSLATION_Y, attributes.translationY)
+        if (easing != null) widget.setValueMotion(TypeIds.MOTION_EASING, easing)
+        return widget
+    }
+
+    /** `NaN` means "not set" in the originals, so an unset attribute is one never applied at all. */
+    private fun attribute(widget: MotionWidget, id: Int, value: Float) {
+        if (!value.isNaN()) widget.setValueAttributes(id, value)
+    }
+
+    private fun key(spec: KeySpec) =
+        when (spec) {
+            is KeySpec.PositionKey ->
+                MotionKeyPosition().apply {
+                    mFramePosition = spec.framePosition
+                    if (!spec.percentX.isNaN()) setValue(TypeIds.POSITION_PERCENT_X, spec.percentX)
+                    if (!spec.percentY.isNaN()) setValue(TypeIds.POSITION_PERCENT_Y, spec.percentY)
+                    if (!spec.percentWidth.isNaN()) setValue(TypeIds.POSITION_PERCENT_WIDTH, spec.percentWidth)
+                    if (!spec.percentHeight.isNaN()) setValue(TypeIds.POSITION_PERCENT_HEIGHT, spec.percentHeight)
+                    setValue(TypeIds.POSITION_CURVE_FIT, spec.curveFit)
+                    setValue(TypeIds.POSITION_PATH_MOTION_ARC, spec.pathMotionArc)
+                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
+                }
+
+            is KeySpec.AttributesKey ->
+                MotionKeyAttributes().apply {
+                    mFramePosition = spec.framePosition
+                    if (!spec.rotationZ.isNaN()) setValue(TypeIds.ATTR_ROTATION_Z, spec.rotationZ)
+                    if (!spec.scaleX.isNaN()) setValue(TypeIds.ATTR_SCALE_X, spec.scaleX)
+                    if (!spec.scaleY.isNaN()) setValue(TypeIds.ATTR_SCALE_Y, spec.scaleY)
+                    if (!spec.alpha.isNaN()) setValue(TypeIds.ATTR_ALPHA, spec.alpha)
+                    setValue(TypeIds.ATTR_CURVE_FIT, spec.curveFit)
+                    spec.transitionEasing?.let { setValue(TypeIds.POSITION_TRANSITION_EASING, it) }
+                }
+        }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/Scenarios.kt
@@ -1,0 +1,90 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import kotlin.random.Random
+
+/**
+ * Builds one scenario per seed. Seeded rather than curated because a motion scenario is a
+ * combination of parameters, not a document: the parser harness wants a corpus, this one wants
+ * enumeration. The seed travels in the divergence report, so a red run reproduces from one line.
+ */
+internal object Scenarios {
+    private val EASINGS = listOf(null, "standard", "accelerate", "decelerate", "linear", "cubic(0.4, 0.0, 0.2, 1)")
+
+    /** UNSET plus every mode `ArcCurveFit` understands. */
+    private val ARCS = listOf(-1, 0, 1, 2, 3, 4, 5)
+
+    private const val SAMPLES = 12
+
+    fun generate(seed: Long): MotionScenario {
+        val random = Random(seed)
+        val parentWidth = random.nextInt(200, 1200)
+        val parentHeight = random.nextInt(200, 1200)
+        return MotionScenario(
+            seed = seed,
+            start = bounds(random, parentWidth, parentHeight),
+            end = bounds(random, parentWidth, parentHeight),
+            startAttributes = attributes(random),
+            endAttributes = attributes(random),
+            keys = keys(random),
+            // Indexed by seed rather than drawn at random, so every mode is guaranteed to appear
+            // across a run instead of merely being likely to.
+            pathMotionArc = ARCS[(seed % ARCS.size).toInt()],
+            easing = EASINGS[random.nextInt(EASINGS.size)],
+            parentWidth = parentWidth,
+            parentHeight = parentHeight,
+            duration = random.nextInt(100, 2000).toFloat(),
+            samples = SAMPLES,
+        )
+    }
+
+    private fun bounds(random: Random, parentWidth: Int, parentHeight: Int): Bounds {
+        val left = random.nextInt(0, parentWidth - 40)
+        val top = random.nextInt(0, parentHeight - 40)
+        return Bounds(left, top, left + random.nextInt(10, 200), top + random.nextInt(10, 200))
+    }
+
+    private fun attributes(random: Random): Attributes =
+        Attributes(
+            rotationZ = maybe(random) { random.nextInt(-180, 180).toFloat() },
+            scaleX = maybe(random) { random.nextInt(1, 30) / 10f },
+            scaleY = maybe(random) { random.nextInt(1, 30) / 10f },
+            alpha = maybe(random) { random.nextInt(0, 10) / 10f },
+            translationX = maybe(random) { random.nextInt(-100, 100).toFloat() },
+            translationY = maybe(random) { random.nextInt(-100, 100).toFloat() },
+        )
+
+    /** `NaN` is how the originals spell "not set", so an unset attribute is one that stays `NaN`. */
+    private fun maybe(random: Random, value: () -> Float): Float =
+        if (random.nextInt(3) == 0) Float.NaN else value()
+
+    private fun keys(random: Random): List<KeySpec> {
+        val positions = (1..random.nextInt(0, 4)).map { random.nextInt(1, 100) }.distinct().sorted()
+        return positions.map { framePosition ->
+            if (random.nextBoolean()) {
+                KeySpec.PositionKey(
+                    framePosition = framePosition,
+                    percentX = maybe(random) { random.nextInt(0, 100) / 100f },
+                    percentY = maybe(random) { random.nextInt(0, 100) / 100f },
+                    percentWidth = maybe(random) { random.nextInt(0, 100) / 100f },
+                    percentHeight = maybe(random) { random.nextInt(0, 100) / 100f },
+                    curveFit = random.nextInt(-1, 2),
+                    transitionEasing = EASINGS[random.nextInt(EASINGS.size)],
+                    pathMotionArc = ARCS[random.nextInt(ARCS.size)],
+                )
+            } else {
+                KeySpec.AttributesKey(
+                    framePosition = framePosition,
+                    rotationZ = maybe(random) { random.nextInt(-180, 180).toFloat() },
+                    scaleX = maybe(random) { random.nextInt(1, 30) / 10f },
+                    scaleY = maybe(random) { random.nextInt(1, 30) / 10f },
+                    alpha = maybe(random) { random.nextInt(0, 10) / 10f },
+                    curveFit = random.nextInt(-1, 2),
+                    transitionEasing = EASINGS[random.nextInt(EASINGS.size)],
+                )
+            }
+        }
+    }
+}

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/Scenarios.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/Scenarios.kt
@@ -82,7 +82,6 @@ internal object Scenarios {
                     scaleY = maybe(random) { random.nextInt(1, 30) / 10f },
                     alpha = maybe(random) { random.nextInt(0, 10) / 10f },
                     curveFit = random.nextInt(-1, 2),
-                    transitionEasing = EASINGS[random.nextInt(EASINGS.size)],
                 )
             }
         }

--- a/parity/src/test/kotlin/tech/annexflow/parity/motion/ScenariosTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/motion/ScenariosTest.kt
@@ -1,0 +1,41 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.motion
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ScenariosTest {
+    @Test
+    fun theSameSeedProducesTheSameScenario() {
+        assertEquals(Scenarios.generate(17L), Scenarios.generate(17L))
+    }
+
+    @Test
+    fun differentSeedsProduceDifferentScenarios() {
+        val distinct = (0L until 50L).map { Scenarios.generate(it) }.distinct()
+        assertTrue(distinct.size > 40, "generator produced ${distinct.size} distinct scenarios in 50")
+    }
+
+    @Test
+    fun bothKeyKindsAppear() {
+        val keys = (0L until 200L).flatMap { Scenarios.generate(it).keys }
+        assertTrue(keys.any { it is KeySpec.PositionKey }, "no position keys generated")
+        assertTrue(keys.any { it is KeySpec.AttributesKey }, "no attributes keys generated")
+    }
+
+    @Test
+    fun everyArcModeAppears() {
+        val arcs = (0L until 200L).map { Scenarios.generate(it).pathMotionArc }.toSet()
+        assertEquals(setOf(-1, 0, 1, 2, 3, 4, 5), arcs)
+    }
+
+    @Test
+    fun framePositionsAreInsideTheTransition() {
+        (0L until 200L).flatMap { Scenarios.generate(it).keys }.forEach {
+            assertTrue(it.framePosition in 1..99, "frame position ${it.framePosition} outside 1..99")
+        }
+    }
+}


### PR DESCRIPTION
`core/motion` had no differential coverage, and it is where defects have actually been found — two of
this port's three real translation bugs lived there ([#342](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/342), [#343](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/343)), both caught by reading rather than by a test.

This extends the `:parity` harness to drive `Motion` the way `MotionLayout` drives it — `setStart`/
`setEnd`, keys, `setPathMotionArc`, `setup` — then samples geometry and attributes through
`interpolate`, the curve through `buildPath`/`buildKeyFrames`, and velocity through `getCenter`,
across a sweep of positions. Oracle and port run the identical sequence; the snapshots are compared
verbatim.

No new vendoring was needed: the oracle already held all 39 `core/motion` files from the solver work.

## Verification

1000 generated seeds, no divergence.

Then the mutation probe, as in [#338](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/338) and [#339](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/339): `pos[0] += 1f` inside the **port's**
`Motion.getCenter` turned **1000 of 1000** scenarios red, every one showing `center=` off by exactly
1.0 with everything else identical. The probe sat in `Motion.kt` itself rather than in a utility —
a probe in `ArcCurveFit` would only have proved the harness reaches `ArcCurveFit`. Reverted;
`git diff -- compose/` is empty and no commit here touches `compose/`.

## What the whole-branch review caught that the per-task reviews did not

Five generator dimensions varied in the scenario and **never reached the code**. The harness looked
like it covered arcs and easing while measuring nothing. Each was proven by mutating the field and
observing an unchanged snapshot. Four are fixed in `d844f21`:

| | why it was inert | measured |
|---|---|---|
| scenario `easing` | applied to the **end** widget; `getAdjustedPosition` only selects frames with `mTime < position`, and the end sits at 1.0 | 0/300 |
| per-key `pathMotionArc` | `MotionKeyPosition.setValue(509, Int)` is unhandled and silently returns `false` | 0/145 |
| `AttributesKey.transitionEasing` | passed a `PositionType` id to a `MotionKeyAttributes`; upstream never reads that field either | 0/169 |
| nothing asserted scenarios ran | two `Leaked` outcomes with equal categories compare equal, so a shared harness failure read as agreement | — |

The last one is the reason the others matter: without it this harness could rot to green-while-
measuring-nothing, exactly as the first three had already half done. It now counts `Sampled`
outcomes and asserts the count equals the seed total.

Fixes verified the same way they were found — the mutation that produced no change before now
produces one.

## Coverage, stated honestly

This does **not** cover 10,967 lines, and the commit history should not be read as claiming it does.

Still inert and parked rather than fixed, because making them live means generating `POSITION_TYPE`
to reach `initScreen`/`initPath` — a coverage expansion, not a fix: `duration`, `parentWidth` and
`parentHeight` never reach `Motion`, and `keyFrameModes` is constant because `mMode` is always
`CARTESIAN`. The easing set omits `spline(...)` and `Schlick(...)`, so `StepCurve` and `Schlick` are
never constructed. `MotionKeyCycle` and `MotionKeyTimeCycle` were out of scope from the start —
oscillators and time cycles are the next increment.

## Design notes

`MotionScenario` names no type from either side; `TypeIds` duplicates the numeric ids from
`TypedValues` by value, so the two subjects cannot be handed different inputs by construction — the
leak [#339](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/339) had to repair.

Rendering lives in shared code rather than in each subject: if both formatted their own strings, a
formatting difference would be indistinguishable from a computational one, and the harness would
report a defect that does not exist.

Comparison is exact, with no tolerance. `:parity` is JVM-only, so both sides' `Float` is a true
32-bit float through the same `java.lang.Float.toString`. An epsilon would mask precisely the defect
class this exists to catch — a lost `Double`→`Float` narrowing shows up in the low bits.
`NaN == NaN` and `-0.0 != 0.0` are both intended and asserted.

`OracleMotion` and `PortMotion` are deliberate side-by-side copies, as `OracleSolver`/`PortSolver`
already are. They name types sharing no supertype, and the duplication is what makes an accidental
asymmetry visible in a diff — an asymmetry there would fabricate divergence reports, which is worse
than missing coverage. Every review on this branch checked them against each other.

CI needs no change: the `Parity tests` step already runs `./gradlew :parity:test`.
