### PR TITLE
test: keep the js target, and put every target under CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,10 @@ jobs:
           :sample:webApp:assemble
       - name: Build shaded flavours
         run: ./gradlew :compose-shaded:assemble :compose-shaded-compose:assemble
+      # Every target, not just the JVM. Five of the six had never been exercised here at all, and
+      # the js target's float-precision exclusions only mean something if something runs them.
       - name: Test
-        run: ./gradlew :compose:jvmTest
+        run: ./gradlew :compose:allTests
       - name: Test shaded flavours
         run: ./gradlew :compose-shaded:jvmTest :compose-shaded-compose:jvmTest
       # Compares the ported parser against a vendored copy of the upstream one. The suite above

--- a/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/tech/annexflow/buildlogic/ConstraintLayoutLibraryPlugin.kt
@@ -59,6 +59,7 @@ class ConstraintLayoutLibraryPlugin : Plugin<Project> {
                 val generateKarmaConfig = registerKarmaConfig()
                 js { browser { testTask { useKarmaConfig(generateKarmaConfig) } } }
                 wasmJs { browser { testTask { useKarmaConfig(generateKarmaConfig) } } }
+                excludeFloatSensitiveTestsFromJs()
                 macosArm64()
 
                 listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
@@ -189,6 +190,64 @@ private val Project.karmaConfigDir: Provider<Directory>
     get() = layout.buildDirectory.dir("karma.config.d")
 
 private const val KARMA_MOCHA_TIMEOUT_MS = 120_000
+
+/**
+ * Drops [JS_FLOAT_SENSITIVE_TESTS] from the `js` test task, and from that task only.
+ *
+ * Applied here rather than inside `js { browser { testTask { … } } }` because the receiver that
+ * block exposes does not carry Gradle's `filter`. Matching on the task name is what keeps `wasmJs`
+ * out of it: the two tasks are `jsBrowserTest` and `wasmJsBrowserTest`, and only the former starts
+ * with "js".
+ */
+private fun Project.excludeFloatSensitiveTestsFromJs() {
+    tasks.withType(KotlinJsTest::class.java).configureEach {
+        if (!name.startsWith("js")) return@configureEach
+        JS_FLOAT_SENSITIVE_TESTS.forEach { pattern -> filter.excludeTestsMatching(pattern) }
+    }
+}
+
+/**
+ * Tests excluded from the `js` target only.
+ *
+ * Kotlin/JS has no 32-bit `Float` — it is a JS Number, that is, a double — and these twenty tests
+ * depend on the difference in one of two ways. Some compare rendered text: `1.0f.toString()` is
+ * "1.0" on every other target and "1" on JS, so `DslTest` reads `horizontalWeight:1` where it
+ * expects `horizontalWeight:1.0`. The rest compare computed geometry, where a double's rounding
+ * accumulates until a laid-out edge moves by a pixel, or an ASCII plot of a trajectory diverges.
+ *
+ * `wasmJs` has a true f32 and passes all twenty, so it is deliberately left unfiltered.
+ *
+ * These are upstream's own tests, kept near-verbatim. Excluding them here rather than annotating
+ * them keeps those files byte-identical to the original, which is what makes comparing them against
+ * upstream worth doing — and that comparison is how every translation defect in this port has been
+ * found so far.
+ *
+ * The patterns lead with `*` because `commonTest` is relocated into the shaded flavours, where the
+ * same classes live under `tech.annexflow.constraintlayout`.
+ */
+private val JS_FLOAT_SENSITIVE_TESTS =
+    listOf(
+        "*.DslTest.testBarrier02",
+        "*.DslTest.testConstraint02",
+        "*.DslTest.testConstraint03",
+        "*.DslTest.testHChain03",
+        "*.DslTest.testVChain03",
+        "*.LinearSystemTest.testAddEquation1",
+        "*.LinearSystemTest.testAddEquation2",
+        "*.MotionArcCurveTest.arcTest3",
+        "*.MotionTransitionTest.testTransitionJson",
+        "*.MotionTransitionTest.testTransitionJson2",
+        "*.MotionTransitionTest.testTransitionOnSwipe1",
+        "*.RatioTest.testChainRatio4",
+        "*.RatioTest.testNestedRatio2",
+        "*.StopLogicTest.accelerateCruseDecelerate",
+        "*.StopLogicTest.accelerateDecelerate",
+        "*.StopLogicTest.backwardAccelerateCruseDecelerate",
+        "*.StopLogicTest.backwardAccelerateDecelerate",
+        "*.StopLogicTest.basicSpring",
+        "*.StopLogicTest.cruseDecelerate",
+        "*.StopLogicTest.hardStop",
+    )
 
 /**
  * The `android { }` block of a Kotlin Multiplatform library. Build scripts reach it through a


### PR DESCRIPTION
Closes the last open question from the original "why don't the tests pass on every platform" task.

`./gradlew :compose:jsTest` failed with 20 failures. Every other target — jvm, wasmJs, macosArm64,
iosSimulatorArm64, android host — ran the same 455 tests across the same 54 classes and passed.
Those twenty were the only red tests anywhere in the project.

## One cause, two symptoms

**Kotlin/JS has no 32-bit `Float`.** It is a JS Number, i.e. a double. `wasmJs` has a true f32,
which is why it passes.

| symptom | evidence |
|---|---|
| rendered text | `DslTest.testConstraint02` expects `horizontalWeight:1.0` and gets `horizontalWeight:1`, because `1.0f.toString()` is `"1"` on JS |
| the same, via a goal string | `LinearSystemTest.testAddEquation1` asserts `result == "0 = 0.0" \|\| result == " goal -> (0.0) : "`; JS renders `"0"` |
| accumulated arithmetic | `RatioTest.testNestedRatio2` — `Expected <176>, actual <175>` |
| trajectory plots | `StopLogicTest`'s seven ASCII plots diverge in the low bits |

## Excluded through the task, not annotated in the tests

The twenty are dropped from the js test task in the convention plugin. **No test file is touched.**

These tests came from upstream nearly verbatim, and comparing them line by line against the original
is how every translation defect in this port has been found — including two this month
([#342](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/342), [#343](https://github.com/Lavmee/constraintlayout-compose-multiplatform/pull/343)). Twenty `@IgnoreOnJs` annotations would be twenty permanent diffs against
upstream in exactly the files where that comparison is worth the most. An `expect`/`actual` ignore
annotation was designed first and dropped for that reason.

Patterns lead with `*` so they also match the shaded flavours, where `commonTest` is relocated under
`tech.annexflow.constraintlayout`. The filter sits on the task rather than inside
`js { browser { testTask { … } } }` because the receiver that block exposes does not carry Gradle's
`filter`.

## CI now runs every target

The `Test` step becomes `:compose:allTests` instead of `:compose:jvmTest`. Five of the six targets
had never been exercised in CI — which is how twenty failures sat unnoticed long enough to become an
open question rather than a bug. About two and a half minutes locally with a warm cache; the job
already runs on a macOS runner, so the native and browser tests are all runnable there.

## What this costs

Those twenty tests do not run on `js`. There is no coverage there for what they check. The
alternative — relaxing the assertions to accept both precisions — would have removed that coverage
on the five targets where they currently pass at full strength.

The safe direction is preserved: if a test is renamed its pattern stops matching, the test runs, and
it fails loudly. The list holds explicit names only, so it cannot hide a *new* failure.

## Verification

Per-target counts after the change — this is what proves the filter hit exactly twenty and nothing
else, since a pattern that was too broad would show as a count falling on a target that should not
have changed:

```
iosSimulatorArm64Test    455  0 failures
jsBrowserTest            435  0 failures     <- 455 - 20
jvmTest                  455  0 failures
macosArm64Test           455  0 failures
testAndroidHostTest      455  0 failures
wasmJsBrowserTest        455  0 failures
```

All three modules (`:compose`, `:compose-shaded`, `:compose-shaded-compose`) report 435 on js, which
is what proves the leading `*` reaches the relocated package.

And a mutation probe, the discipline used throughout this project: dropping
`"*.RatioTest.testNestedRatio2"` from the list turns `jsTest` red on precisely that test with
`Expected <176>, actual <175>`, and restoring it turns it green. The list is what is holding the
target green, not something else having changed.
