### PR TITLE
ci: move off the retired Gradle actions, and close the last @Ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Actions were watched by nobody until now, which is how build.yml and static-validations.yml
+  # came to sit on `gradle-build-action@v2.4.2` and `setup-java@v3` long after release.yml had
+  # moved on. Weekly rather than daily: there are six actions in three files, and a daily cadence
+  # would open more pull requests than the churn justifies.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2.4.2
-        with:
-          gradle-home-cache-cleanup: true
+      # `gradle/actions/*` replaces `gradle-build-action`, which Gradle retired, and
+      # `wrapper-validation-action`, which moved into the same repository. release.yml has run
+      # on these three for a while — this file and static-validations.yml were the two left
+      # behind, still on actions whose Node 16 runtime GitHub no longer supports.
+      #
+      # `gradle-home-cache-cleanup: true` is gone rather than renamed: setup-gradle cleans the
+      # Gradle home before saving the cache on its own, so the input no longer exists.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       # `:sample` is only a container directory since the per-platform split, so it owns no

--- a/.github/workflows/static-validations.yml
+++ b/.github/workflows/static-validations.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
             distribution: 'zulu'
             java-version: 17

--- a/compose/src/commonTest/kotlin/androidx/constraintlayout/core/NestedLayout.kt
+++ b/compose/src/commonTest/kotlin/androidx/constraintlayout/core/NestedLayout.kt
@@ -26,6 +26,14 @@ import kotlin.test.assertEquals
  * Test nested layout
  */
 class NestedLayout {
+    // Disabled upstream too, which comments out the `@Test` rather than annotating it. Neither
+    // upstream nor this port recorded why, so it read like an unexplained port failure.
+    //
+    // It is not one. Nesting a container inside another and wrapping it to its children does
+    // nothing: the container keeps its original width and the children land outside it. The
+    // oracle and the port produce identical numbers, so the expectations below describe a
+    // feature `constraintlayout-core` never implemented, not behaviour this port lost.
+    // `tech.annexflow.parity.solver.NestedContainerTest` runs both sides and holds them equal.
     @Ignore
     @Test
     fun testNestedLayout() {

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/NestedContainerTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/NestedContainerTest.kt
@@ -1,0 +1,110 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import androidx.constraintlayout.core.widgets.ConstraintAnchor as OracleAnchor
+import androidx.constraintlayout.core.widgets.ConstraintWidget as OracleWidget
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer as OracleContainer
+import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor as PortAnchor
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget as PortWidget
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer as PortContainer
+
+/**
+ * The one scenario [Scenarios] cannot generate: a `ConstraintWidgetContainer` nested inside another.
+ *
+ * [Scenario] describes a single root and a flat list of widgets. Nesting would need a parent per
+ * widget and a scope per barrier, guideline and chain — a change to the model rather than an axis
+ * added to it. This test covers the case by hand in the meantime, because it is the case behind the
+ * only `@Ignore` left in the ported suite: `androidx.constraintlayout.core.NestedLayout`.
+ *
+ * That test is disabled upstream too, by commenting out its `@Test`, and neither upstream nor the
+ * port says why. The reason is that the feature does not work — and does not work identically on
+ * both sides. Wrapping the inner container to its two children leaves it at its original width and
+ * throws the children well outside it:
+ *
+ * ```
+ * container.width  100, not the 150 the disabled test wants
+ * container.left   450, not 425
+ * a.left           -24, not 425
+ * b.left            50, not 525
+ * ```
+ *
+ * The wrap is not merely wrong but inert: switching the inner container between `WRAP_CONTENT`
+ * and `FIXED` moves nothing at all, on either side.
+ *
+ * So the `@Ignore` is faithful rather than a port defect, which is what this test pins. Comparing
+ * the two implementations rather than asserting those numbers is deliberate: the numbers are
+ * upstream's behaviour, not a specification, and if a future oracle refresh fixes nested wrapping
+ * this should report that the port now lags — not quietly keep asserting the old breakage.
+ */
+class NestedContainerTest {
+    @Test
+    fun thePortAgreesWithTheOracle() {
+        assertEquals(oracle(), port())
+    }
+
+    private fun oracle(): String {
+        val root = OracleContainer(20, 20, 1000, 1000)
+        val container = OracleContainer(0, 0, 100, 100)
+        root.debugName = "root"
+        container.debugName = "container"
+        container.connect(OracleAnchor.Type.LEFT, root, OracleAnchor.Type.LEFT)
+        container.connect(OracleAnchor.Type.RIGHT, root, OracleAnchor.Type.RIGHT)
+        root.add(container)
+        root.layout()
+        val afterFirstPass = render("container" to container)
+
+        val a = OracleWidget(0, 0, 100, 20)
+        val b = OracleWidget(0, 0, 50, 20)
+        container.add(a)
+        container.add(b)
+        container.setHorizontalDimensionBehaviour(OracleWidget.DimensionBehaviour.WRAP_CONTENT)
+        a.connect(OracleAnchor.Type.LEFT, container, OracleAnchor.Type.LEFT)
+        a.connect(OracleAnchor.Type.RIGHT, b, OracleAnchor.Type.LEFT)
+        b.connect(OracleAnchor.Type.RIGHT, container, OracleAnchor.Type.RIGHT)
+        root.layout()
+        return afterFirstPass + render("container" to container, "a" to a, "b" to b)
+    }
+
+    private fun port(): String {
+        val root = PortContainer(20, 20, 1000, 1000)
+        val container = PortContainer(0, 0, 100, 100)
+        root.debugName = "root"
+        container.debugName = "container"
+        container.connect(PortAnchor.Type.LEFT, root, PortAnchor.Type.LEFT)
+        container.connect(PortAnchor.Type.RIGHT, root, PortAnchor.Type.RIGHT)
+        root.add(container)
+        root.layout()
+        val afterFirstPass = render("container" to container)
+
+        val a = PortWidget(0, 0, 100, 20)
+        val b = PortWidget(0, 0, 50, 20)
+        container.add(a)
+        container.add(b)
+        container.setHorizontalDimensionBehaviour(PortWidget.DimensionBehaviour.WRAP_CONTENT)
+        a.connect(PortAnchor.Type.LEFT, container, PortAnchor.Type.LEFT)
+        a.connect(PortAnchor.Type.RIGHT, b, PortAnchor.Type.LEFT)
+        b.connect(PortAnchor.Type.RIGHT, container, PortAnchor.Type.RIGHT)
+        root.layout()
+        return afterFirstPass + render("container" to container, "a" to a, "b" to b)
+    }
+
+    /**
+     * Both overloads take the widget as `Any` because the two implementations have no common
+     * supertype — that is the whole reason this harness exists — and the four accessors resolve on
+     * each concrete class.
+     */
+    private fun render(vararg widgets: Pair<String, Any>): String =
+        widgets.joinToString(separator = "", postfix = "--\n") { (name, widget) ->
+            val (left, top, width, height) =
+                when (widget) {
+                    is OracleWidget -> listOf(widget.left, widget.top, widget.width, widget.height)
+                    is PortWidget -> listOf(widget.left, widget.top, widget.width, widget.height)
+                    else -> error("unexpected widget type ${widget::class}")
+                }
+            "$name l=$left t=$top w=$width h=$height\n"
+        }
+}


### PR DESCRIPTION
Two independent pieces of housekeeping, both of which came out of measuring rather than assuming.

## Retired actions

`build.yml` and `static-validations.yml` were still on `gradle-build-action@v2.4.2`, `wrapper-validation-action@v1` and `setup-java@v3` — all three on a Node 16 runtime GitHub no longer supports. `release.yml`, in the same directory, had already moved to `gradle/actions/*` and `setup-java@v4` and has been publishing releases on them, so this is convergence on a configuration already proven in this repository rather than a version guess.

`gradle-home-cache-cleanup: true` is dropped rather than renamed: `setup-gradle` cleans the Gradle home before saving the cache on its own, and the input no longer exists.

Nothing watched the actions, which is exactly how two files drifted three years behind a third one beside them. Dependabot now covers the `github-actions` ecosystem, weekly, so the next bump arrives as a pull request with CI attached instead of by hand.

### A note on where CI time actually goes

Widening the `Test` step to `:compose:allTests` in #350 came with a warning from me that the build job would get noticeably longer. Measured against the runs either side of it, that was pointed at the wrong step:

| step | before (31528610731) | after (32080275006) |
|---|---|---|
| Build (`:sample:*`) | 2420s | 2547s |
| Build shaded flavours | 1156s | 1294s |
| **Test** | **19s** | **411s** |

The job was already about an hour, and 93% of it is assembling four sample apps and two shaded flavours. Six extra minutes of tests is not what makes it slow. Worth keeping in view given the job runs on `macos-latest`, which GitHub bills at ten times the minute rate — but the target is the build steps, not the test step, and that is its own piece of work.

## The last `@Ignore`

`androidx.constraintlayout.core.NestedLayout` was the only remaining ignored test in the suite, with no explanation, so it read like an unresolved port failure.

It is not one. Replaying the scenario against the vendored upstream core and against the port gives identical output from both:

| | oracle | port | the disabled test wants |
|---|---|---|---|
| phase 1 `container.left` | 450 | 450 | 450 |
| phase 2 `container.width` | 100 | 100 | 150 |
| phase 2 `container.left` | 450 | 450 | 425 |
| phase 2 `a.left` | −24 | −24 | 425 |
| phase 2 `b.left` | 50 | 50 | 525 |

The wrap is not merely wrong but inert — switching the inner container between `WRAP_CONTENT` and `FIXED` moves nothing on either side. Nesting a container inside another is a feature `constraintlayout-core` never implemented, not behaviour this port lost. Upstream disables the same test too, by commenting out its `@Test`, and records no reason either.

`NestedContainerTest` holds the two implementations equal rather than asserting the observed numbers: those numbers are upstream's behaviour, not a specification, and if a future oracle refresh implements nested wrapping this should report that the port now lags rather than quietly keep asserting the old breakage.

`Scenario` describes one root and a flat list of widgets, so the generator cannot reach this case — nesting needs a parent per widget and a scope per barrier, guideline and chain, which is a change to the model rather than an axis added to it. Left as follow-up; this test covers the case by hand meanwhile.

## Verification

`:parity:test` — 65 tests across 13 classes, green. `:compose:jvmTest`, `:compose-shaded:jvmTest` and `lint` green.

Mutation probe on the new test: narrowing widget `a` on the port side alone from 100 to 90 turns it red. A first probe — flipping the port's container to `FIXED` — did *not*, which is how the inertness above was found rather than assumed.