### PR TITLE
perf: stop building what CI throws away, and build it in parallel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Actions were watched by nobody until now, which is how build.yml and static-validations.yml
+  # came to sit on `gradle-build-action@v2.4.2` and `setup-java@v3` long after release.yml had
+  # moved on. Weekly rather than daily: there are six actions in three files, and a daily cadence
+  # would open more pull requests than the churn justifies.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2.4.2
-        with:
-          gradle-home-cache-cleanup: true
+      # `gradle/actions/*` replaces `gradle-build-action`, which Gradle retired, and
+      # `wrapper-validation-action`, which moved into the same repository. release.yml has run
+      # on these three for a while — this file and static-validations.yml were the two left
+      # behind, still on actions whose Node 16 runtime GitHub no longer supports.
+      #
+      # `gradle-home-cache-cleanup: true` is gone rather than renamed: setup-gradle cleans the
+      # Gradle home before saving the cache on its own, so the input no longer exists.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       # `:sample` is only a container directory since the per-platform split, so it owns no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,17 @@ jobs:
         run: chmod +x ./gradlew
       # `:sample` is only a container directory since the per-platform split, so it owns no
       # `assemble` task — the sample modules have to be named individually.
+      #
+      # `assemble` also links the *release* Kotlin/Native binaries, and nothing here consumes
+      # them: release.yml never calls assemble, and the Maven publication is klibs and metadata,
+      # so no framework reaches the Portal. They are not cheap either — one release link measured
+      # 133s against 29s for the matching debug link, and together they were 54% of the task time
+      # of the first step and 60% of the second.
+      #
+      # Excluded rather than removed from the build: sample/iosApp is a real Xcode project, and a
+      # Release build of it needs the release framework. Excluding by bare task name covers every
+      # module at once, and Gradle fails the build if a named task does not exist — so a rename
+      # cannot quietly turn these into no-ops.
       - name: Build
         run: >-
           ./gradlew
@@ -38,8 +49,18 @@ jobs:
           :sample:androidApp:assemble
           :sample:desktopApp:assemble
           :sample:webApp:assemble
+          -x linkReleaseFrameworkIosArm64
+          -x linkReleaseFrameworkIosSimulatorArm64
+          -x linkReleaseExecutableMacosArm64
+      # Two exclusions, not three: the library flavours declare frameworks but no macOS
+      # executable, and naming a task that does not exist is an error.
       - name: Build shaded flavours
-        run: ./gradlew :compose-shaded:assemble :compose-shaded-compose:assemble
+        run: >-
+          ./gradlew
+          :compose-shaded:assemble
+          :compose-shaded-compose:assemble
+          -x linkReleaseFrameworkIosArm64
+          -x linkReleaseFrameworkIosSimulatorArm64
       # Every target, not just the JVM. Five of the six had never been exercised here at all, and
       # the js target's float-precision exclusions only mean something if something runs them.
       - name: Test

--- a/.github/workflows/static-validations.yml
+++ b/.github/workflows/static-validations.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
             distribution: 'zulu'
             java-version: 17

--- a/compose/src/commonTest/kotlin/androidx/constraintlayout/core/NestedLayout.kt
+++ b/compose/src/commonTest/kotlin/androidx/constraintlayout/core/NestedLayout.kt
@@ -26,6 +26,14 @@ import kotlin.test.assertEquals
  * Test nested layout
  */
 class NestedLayout {
+    // Disabled upstream too, which comments out the `@Test` rather than annotating it. Neither
+    // upstream nor this port recorded why, so it read like an unexplained port failure.
+    //
+    // It is not one. Nesting a container inside another and wrapping it to its children does
+    // nothing: the container keeps its original width and the children land outside it. The
+    // oracle and the port produce identical numbers, so the expectations below describe a
+    // feature `constraintlayout-core` never implemented, not behaviour this port lost.
+    // `tech.annexflow.parity.solver.NestedContainerTest` runs both sides and holds them equal.
     @Ignore
     @Test
     fun testNestedLayout() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,21 @@
 #Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 
+# Both of these are off by default, so until now CI built this project serially and threw the
+# result away afterwards. Contributors mostly do not notice, because a personal
+# ~/.gradle/gradle.properties usually turns them on and it silently covers for the project not
+# doing so — the runner has no such file.
+#
+# Seven targets across three published flavours and four sample modules is a wide, shallow graph,
+# which is the shape parallel execution suits. `org.gradle.workers.max` is left at its default of
+# one worker per processor.
+org.gradle.parallel=true
+
+# The build cache pays off only if it outlives the job, and it does: gradle/actions/setup-gradle
+# saves the Gradle home, the local cache included, and by default writes it from the default
+# branch and reads it everywhere else — so a pull request starts from main's outputs.
+org.gradle.caching=true
+
 #Kotlin
 kotlin.code.style=official
 

--- a/parity/src/test/kotlin/tech/annexflow/parity/solver/NestedContainerTest.kt
+++ b/parity/src/test/kotlin/tech/annexflow/parity/solver/NestedContainerTest.kt
@@ -1,0 +1,110 @@
+// Copyright 2023, Sergei Gagarin and the project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tech.annexflow.parity.solver
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import androidx.constraintlayout.core.widgets.ConstraintAnchor as OracleAnchor
+import androidx.constraintlayout.core.widgets.ConstraintWidget as OracleWidget
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer as OracleContainer
+import tech.annexflow.constraintlayout.core.widgets.ConstraintAnchor as PortAnchor
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidget as PortWidget
+import tech.annexflow.constraintlayout.core.widgets.ConstraintWidgetContainer as PortContainer
+
+/**
+ * The one scenario [Scenarios] cannot generate: a `ConstraintWidgetContainer` nested inside another.
+ *
+ * [Scenario] describes a single root and a flat list of widgets. Nesting would need a parent per
+ * widget and a scope per barrier, guideline and chain — a change to the model rather than an axis
+ * added to it. This test covers the case by hand in the meantime, because it is the case behind the
+ * only `@Ignore` left in the ported suite: `androidx.constraintlayout.core.NestedLayout`.
+ *
+ * That test is disabled upstream too, by commenting out its `@Test`, and neither upstream nor the
+ * port says why. The reason is that the feature does not work — and does not work identically on
+ * both sides. Wrapping the inner container to its two children leaves it at its original width and
+ * throws the children well outside it:
+ *
+ * ```
+ * container.width  100, not the 150 the disabled test wants
+ * container.left   450, not 425
+ * a.left           -24, not 425
+ * b.left            50, not 525
+ * ```
+ *
+ * The wrap is not merely wrong but inert: switching the inner container between `WRAP_CONTENT`
+ * and `FIXED` moves nothing at all, on either side.
+ *
+ * So the `@Ignore` is faithful rather than a port defect, which is what this test pins. Comparing
+ * the two implementations rather than asserting those numbers is deliberate: the numbers are
+ * upstream's behaviour, not a specification, and if a future oracle refresh fixes nested wrapping
+ * this should report that the port now lags — not quietly keep asserting the old breakage.
+ */
+class NestedContainerTest {
+    @Test
+    fun thePortAgreesWithTheOracle() {
+        assertEquals(oracle(), port())
+    }
+
+    private fun oracle(): String {
+        val root = OracleContainer(20, 20, 1000, 1000)
+        val container = OracleContainer(0, 0, 100, 100)
+        root.debugName = "root"
+        container.debugName = "container"
+        container.connect(OracleAnchor.Type.LEFT, root, OracleAnchor.Type.LEFT)
+        container.connect(OracleAnchor.Type.RIGHT, root, OracleAnchor.Type.RIGHT)
+        root.add(container)
+        root.layout()
+        val afterFirstPass = render("container" to container)
+
+        val a = OracleWidget(0, 0, 100, 20)
+        val b = OracleWidget(0, 0, 50, 20)
+        container.add(a)
+        container.add(b)
+        container.setHorizontalDimensionBehaviour(OracleWidget.DimensionBehaviour.WRAP_CONTENT)
+        a.connect(OracleAnchor.Type.LEFT, container, OracleAnchor.Type.LEFT)
+        a.connect(OracleAnchor.Type.RIGHT, b, OracleAnchor.Type.LEFT)
+        b.connect(OracleAnchor.Type.RIGHT, container, OracleAnchor.Type.RIGHT)
+        root.layout()
+        return afterFirstPass + render("container" to container, "a" to a, "b" to b)
+    }
+
+    private fun port(): String {
+        val root = PortContainer(20, 20, 1000, 1000)
+        val container = PortContainer(0, 0, 100, 100)
+        root.debugName = "root"
+        container.debugName = "container"
+        container.connect(PortAnchor.Type.LEFT, root, PortAnchor.Type.LEFT)
+        container.connect(PortAnchor.Type.RIGHT, root, PortAnchor.Type.RIGHT)
+        root.add(container)
+        root.layout()
+        val afterFirstPass = render("container" to container)
+
+        val a = PortWidget(0, 0, 100, 20)
+        val b = PortWidget(0, 0, 50, 20)
+        container.add(a)
+        container.add(b)
+        container.setHorizontalDimensionBehaviour(PortWidget.DimensionBehaviour.WRAP_CONTENT)
+        a.connect(PortAnchor.Type.LEFT, container, PortAnchor.Type.LEFT)
+        a.connect(PortAnchor.Type.RIGHT, b, PortAnchor.Type.LEFT)
+        b.connect(PortAnchor.Type.RIGHT, container, PortAnchor.Type.RIGHT)
+        root.layout()
+        return afterFirstPass + render("container" to container, "a" to a, "b" to b)
+    }
+
+    /**
+     * Both overloads take the widget as `Any` because the two implementations have no common
+     * supertype — that is the whole reason this harness exists — and the four accessors resolve on
+     * each concrete class.
+     */
+    private fun render(vararg widgets: Pair<String, Any>): String =
+        widgets.joinToString(separator = "", postfix = "--\n") { (name, widget) ->
+            val (left, top, width, height) =
+                when (widget) {
+                    is OracleWidget -> listOf(widget.left, widget.top, widget.width, widget.height)
+                    is PortWidget -> listOf(widget.left, widget.top, widget.width, widget.height)
+                    else -> error("unexpected widget type ${widget::class}")
+                }
+            "$name l=$left t=$top w=$width h=$height\n"
+        }
+}


### PR DESCRIPTION
Stacked on #352 so that its run stays a clean before-measurement of the same job.

Profiled a clean run of both build steps. Two things came out of it.

## `assemble` links release Kotlin/Native binaries that nothing consumes

| step | task time | of which release linking |
|---|---|---|
| samples | 15.9 min | 8.5 min — **54%** |
| shaded flavours | 14.2 min | 8.5 min — **60%** |

One release link measured 133s against 29s for the matching debug link. And nothing reads the output: `release.yml` never calls `assemble`, and the Maven publication is klibs, metadata and sources, so no framework reaches the Portal. They were built and deleted.

Excluding them, locally:

| step | before | after | |
|---|---|---|---|
| samples | 3m35s | **52s** | 4.1× |
| shaded flavours | 2m40s | **34s** | 4.7× |

**Excluded from the CI invocation, not removed from the build.** `sample/iosApp` is a real Xcode project, and its build phase runs `:sample:shared:embedAndSignAppleFrameworkForXcode`, which picks Debug or Release from Xcode's own configuration — a Release build there still needs the release framework, and still gets it. Xcode never goes through `assemble`.

Excluding by bare task name covers every module in one flag, and Gradle fails the build when a named task matches nothing — checked directly, a bogus name aborts with "Task 'x' not found". So these cannot rot into silent no-ops the way a mis-typed compiler-diagnostic name did in #347.

Verified against the task graph rather than inferred from timings — the exclusions remove exactly the named tasks:

```
step 1: :sample:shared:linkRelease{FrameworkIosArm64,FrameworkIosSimulatorArm64,ExecutableMacosArm64}
step 2: :compose-shaded{,-compose}:linkReleaseFramework{IosArm64,IosSimulatorArm64}
added:  nothing
```

## CI was building serially, and throwing the result away

`gradle.properties` set neither `org.gradle.parallel` nor `org.gradle.caching`. Both are off by default, so every CI run compiled the whole graph one task at a time and kept nothing.

This is easy to miss from a developer machine: a personal `~/.gradle/gradle.properties` usually turns both on, and then it quietly covers for the project not doing so. Mine does — eight workers and an 8 GB heap — which is also why the wall-clock figures above are not transferable to a three-core runner. The task weights are; they do not depend on how many run at once.

The build cache survives a clean, checked rather than assumed: the shaded step goes from 1m1s cold to **15s**, with 32 tasks served from the cache. `gradle/actions/setup-gradle` persists the Gradle home between jobs and by default writes it from the default branch and reads it everywhere else, so pull requests start from main's outputs.

**Memory is deliberately untouched.** Raising `-Xmx` in the same change as enabling parallelism would make any regression unattributable, and 2 GB across the default worker count either holds or fails loudly — no silent mode.

## Verification

Full local rehearsal of the CI job, from `clean`, with every change applied:

```
Build              53s   BUILD SUCCESSFUL
Build shaded       17s   BUILD SUCCESSFUL
Test              1m57s  BUILD SUCCESSFUL
Test shaded        10s   BUILD SUCCESSFUL
Parity tests        4s   BUILD SUCCESSFUL
```

Test counts unchanged, which is the check that matters once parallelism is on — a faster suite that quietly runs less would look identical otherwise:

| target | tests |
|---|---|
| js | 435 |
| jvm, wasmJs, macosArm64, iosSimulatorArm64, android host | 455 |

## What this does not address

The remaining cost is real compilation: three published flavours across seven targets, plus four sample modules. That is inherent to what the project ships. The larger remaining lever is the runner itself — the job is on `macos-latest`, billed at ten times the minute rate, while only the three Apple targets need macOS. Splitting the matrix is its own change and is not attempted here.